### PR TITLE
feat(form): add defaultValue support to form components

### DIFF
--- a/packages/arte-odyssey/src/components/form/checkbox/checkbox.tsx
+++ b/packages/arte-odyssey/src/components/form/checkbox/checkbox.tsx
@@ -5,16 +5,23 @@ import { CheckIcon } from '../../icons';
 type Props = {
   label: string;
   value: boolean;
+  defaultChecked?: boolean;
   onChange: ChangeEventHandler<HTMLInputElement>;
 };
 
-export const Checkbox: FC<Props> = ({ label, value, onChange }) => {
+export const Checkbox: FC<Props> = ({
+  label,
+  value,
+  defaultChecked,
+  onChange,
+}) => {
   const [isFocus, setIsFocus] = useState(false);
   return (
     <label className="inline-flex cursor-pointer items-center gap-2">
       <input
         checked={value}
         className="sr-only"
+        defaultChecked={defaultChecked}
         onBlur={() => {
           setIsFocus(false);
         }}

--- a/packages/arte-odyssey/src/components/form/number-field/number-field.tsx
+++ b/packages/arte-odyssey/src/components/form/number-field/number-field.tsx
@@ -10,6 +10,7 @@ type Props = {
   isDisabled: boolean;
   isRequired: boolean;
   value: number;
+  defaultValue?: number;
   onChange: (value: number) => void;
   step?: number;
   precision?: number;
@@ -25,6 +26,7 @@ export const NumberField: FC<Props> = ({
   isDisabled,
   isRequired,
   value,
+  defaultValue,
   onChange,
   step = 1,
   precision = 0,
@@ -32,9 +34,15 @@ export const NumberField: FC<Props> = ({
   min = -9007199254740991,
   placeholder,
 }) => {
-  const [displayValue, setDisplayValue] = useState(value.toFixed(precision));
+  const [displayValue, setDisplayValue] = useState(
+    defaultValue !== undefined
+      ? defaultValue.toFixed(precision)
+      : value.toFixed(precision),
+  );
 
-  const [prevValue, setPrevValue] = useState(value);
+  const [prevValue, setPrevValue] = useState(
+    defaultValue !== undefined ? defaultValue : value,
+  );
 
   if (value !== prevValue) {
     setDisplayValue(value.toFixed(precision));

--- a/packages/arte-odyssey/src/components/form/radio/radio.tsx
+++ b/packages/arte-odyssey/src/components/form/radio/radio.tsx
@@ -6,6 +6,7 @@ type Props = {
   labelId: string;
   isDisabled: boolean;
   value: string;
+  defaultValue?: string;
   onChange: ChangeEventHandler<HTMLInputElement>;
   options: readonly Option[];
 };
@@ -14,6 +15,7 @@ export const Radio: FC<Props> = ({
   labelId,
   isDisabled,
   value,
+  defaultValue,
   onChange,
   options,
 }) => {
@@ -40,6 +42,7 @@ export const Radio: FC<Props> = ({
               'cursor-pointer',
               'disabled:cursor-not-allowed disabled:bg-bg-mute',
             )}
+            defaultChecked={defaultValue === option.value}
             disabled={isDisabled}
             onChange={onChange}
             type="radio"

--- a/packages/arte-odyssey/src/components/form/range-field/range-field.tsx
+++ b/packages/arte-odyssey/src/components/form/range-field/range-field.tsx
@@ -8,6 +8,7 @@ type Props = {
   isDisabled: boolean;
   isRequired: boolean;
   value: number;
+  defaultValue?: number;
   onChange: (value: number) => void;
   step?: number;
   max?: number;
@@ -23,6 +24,7 @@ export const RangeField: FC<Props> = ({
   isDisabled,
   isRequired,
   value,
+  defaultValue,
   onChange,
   step = 1,
   max = 100,
@@ -45,6 +47,7 @@ export const RangeField: FC<Props> = ({
           'disabled:cursor-not-allowed disabled:opacity-50',
           isInvalid && 'ring-2 ring-border-error',
         )}
+        defaultValue={defaultValue}
         disabled={isDisabled}
         id={id}
         max={max}

--- a/packages/arte-odyssey/src/components/form/select/select.tsx
+++ b/packages/arte-odyssey/src/components/form/select/select.tsx
@@ -11,6 +11,7 @@ type Props = {
   isRequired: boolean;
   options: readonly Option[];
   value: string;
+  defaultValue?: string;
   onChange: ChangeEventHandler<HTMLSelectElement>;
 };
 
@@ -22,6 +23,7 @@ export const Select: FC<Props> = ({
   isRequired,
   options,
   value,
+  defaultValue,
   onChange,
 }) => {
   return (
@@ -36,6 +38,7 @@ export const Select: FC<Props> = ({
           'disabled:cursor-not-allowed disabled:border-border-mute disabled:bg-bg-mute disabled:hover:bg-bg-mute',
           'focus-visible:border-transparent focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-border-info',
         )}
+        defaultValue={defaultValue}
         disabled={isDisabled}
         id={id}
         onChange={onChange}


### PR DESCRIPTION
## Summary
- Add `defaultValue` prop to form components to enable uncontrolled usage
- Checkbox: add `defaultChecked` prop
- NumberField: add `defaultValue` prop with proper state initialization  
- RangeField: add `defaultValue` prop
- Select: add `defaultValue` prop
- Radio: add `defaultValue` prop (defaultChecked for individual options)
- Autocomplete: add `defaultValue` prop with controlled/uncontrolled state management

## Test plan
- [ ] Test all form components with `defaultValue` prop
- [ ] Verify controlled mode still works with `value` prop
- [ ] Test Autocomplete in both controlled and uncontrolled modes
- [ ] Ensure backward compatibility with existing usage

🤖 Generated with [Claude Code](https://claude.ai/code)