### PR TITLE
refactor: rename ComponentProvider to ArteOdysseyProvider

### DIFF
--- a/.changeset/late-trains-wish.md
+++ b/.changeset/late-trains-wish.md
@@ -1,0 +1,7 @@
+---
+'@k8o/arte-odyssey': major
+---
+
+Rename ComponentProvider to ArteOdysseyProvider
+
+BREAKING CHANGE: ComponentProvider has been renamed to ArteOdysseyProvider. Update your imports from `import { ComponentProvider }` to `import { ArteOdysseyProvider }`.

--- a/examples/nextjs/src/app/layout.tsx
+++ b/examples/nextjs/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import { Noto_Sans_JP } from 'next/font/google';
 import './globals.css';
-import { ComponentProvider } from '@k8o/arte-odyssey/providers';
+import { ArteOdysseyProvider } from '@k8o/arte-odyssey/providers';
 
 const notoSansJP = Noto_Sans_JP({
   subsets: ['latin'],
@@ -14,7 +14,7 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body className={notoSansJP.className}>
-        <ComponentProvider>{children}</ComponentProvider>
+        <ArteOdysseyProvider>{children}</ArteOdysseyProvider>
       </body>
     </html>
   );

--- a/examples/vite/src/main.tsx
+++ b/examples/vite/src/main.tsx
@@ -2,13 +2,13 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 import '@k8o/arte-odyssey/styles.css';
-import { ComponentProvider } from '@k8o/arte-odyssey';
+import { ArteOdysseyProvider } from '@k8o/arte-odyssey';
 
 // biome-ignore lint/style/noNonNullAssertion: ある前提なので非nullアサーションを使用
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ComponentProvider>
+    <ArteOdysseyProvider>
       <App />
-    </ComponentProvider>
+    </ArteOdysseyProvider>
   </StrictMode>,
 );

--- a/packages/arte-odyssey/.storybook/preview.tsx
+++ b/packages/arte-odyssey/.storybook/preview.tsx
@@ -1,5 +1,5 @@
 import type { Preview } from '@storybook/react-vite';
-import { ComponentProvider } from '../src/components/providers';
+import { ArteOdysseyProvider } from '../src/components/providers';
 
 import '../src/styles/index.css';
 import { type FC, memo, useEffect, useState } from 'react';
@@ -69,12 +69,12 @@ const preview: Preview = {
         );
       }, []);
       return (
-        <ComponentProvider>
+        <ArteOdysseyProvider>
           <ApplayThemeByStorybook theme={theme} />
           <div className="min-h-svh p-6">
             <Story />
           </div>
-        </ComponentProvider>
+        </ArteOdysseyProvider>
       );
     },
   ],

--- a/packages/arte-odyssey/src/components/providers/component-provider.tsx
+++ b/packages/arte-odyssey/src/components/providers/component-provider.tsx
@@ -4,7 +4,7 @@ import { MotionConfig } from 'motion/react';
 import type { FC, PropsWithChildren } from 'react';
 import { ToastProvider } from '../toast';
 
-export const ComponentProvider: FC<PropsWithChildren> = ({ children }) => {
+export const ArteOdysseyProvider: FC<PropsWithChildren> = ({ children }) => {
   return (
     <MotionConfig reducedMotion="user">
       <ToastProvider>{children}</ToastProvider>


### PR DESCRIPTION
## Summary
- Renamed ComponentProvider to ArteOdysseyProvider for better naming consistency with the library name
- Updated all import statements and usage across examples and Storybook configuration
- Added appropriate changeset marking this as a breaking change

## Test plan
- [x] Verify all imports are updated correctly
- [x] Check that examples still work with the renamed provider
- [x] Ensure Storybook configuration uses the new provider name
- [x] Confirm changeset is properly configured for major version bump

🤖 Generated with [Claude Code](https://claude.ai/code)