### PR TITLE
セキュリティ向上: GitHub Actionsのバージョンを固定

### DIFF
--- a/.github/composite-actions/install/action.yml
+++ b/.github/composite-actions/install/action.yml
@@ -5,10 +5,10 @@ runs:
   using: composite
   steps:
     - name: Install dependencies
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
 
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
       with:
         node-version-file: 'package.json'
         cache: 'pnpm'

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -8,13 +8,13 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           fetch-depth: 0
       - name: Install
         uses: ./.github/composite-actions/install
       - name: Publish to Chromatic
-        uses: chromaui/action@v13
+        uses: chromaui/action@d0795df816d05c4a89c80295303970fddd247cce
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           onlyChanged: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
       - name: Install
         uses: ./.github/composite-actions/install
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
       - name: Install
         uses: ./.github/composite-actions/install
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
       - name: Install
         uses: ./.github/composite-actions/install

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           fetch-depth: 1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           fetch-depth: 0
 
@@ -28,7 +28,7 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Create release Pull Request or publish to NPM
-        uses: changesets/action@v1
+        uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba
         with:
           publish: pnpm release
         env:

--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
   "prConcurrentLimit": 10,
   "schedule": ["every weekend"],
   "rangeStrategy": "pin",
+  "minimumReleaseAge": "7 days",
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
## Summary
- GitHub ActionsのSHAハッシュによるバージョン固定
- Renovateの最小リリース間隔を7日に設定

## 変更内容
- `actions/checkout@v5` → SHA固定版に更新
- `actions/setup-node@v5` → SHA固定版に更新
- `pnpm/action-setup@v4` → SHA固定版に更新
- `chromaui/action@v13` → SHA固定版に更新
- `changesets/action@v1` → SHA固定版に更新
- `renovate.json`に`minimumReleaseAge`設定を追加

## 目的
GitHub Actionsのバージョンをタグではなくコミットハッシュで固定することで、セキュリティリスクを軽減し、より安全なCI/CDパイプラインを実現する。

🤖 Generated with [Claude Code](https://claude.ai/code)