### PR TITLE
Update renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,16 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
+    "github>k35o/renovate-config",
     "monorepo:storybook",
     "monorepo:react",
     "monorepo:vitest"
   ],
-  "timezone": "Asia/Tokyo",
   "prConcurrentLimit": 10,
-  "schedule": ["every weekend"],
-  "rangeStrategy": "pin",
-  "minimumReleaseAge": "7 days",
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
## Summary
- renovateの設定を更新してシェアード設定を使用するように変更

## Changes
- `config:recommended` から `github>k35o/renovate-config` を使用
- timezone、schedule、rangeStrategy、minimumReleaseAge を削除（シェアード設定に移動）

🤖 Generated with [Claude Code](https://claude.ai/code)