### PR TITLE
chore(deps): upgrade Vitest from v3 to v4

### DIFF
--- a/packages/arte-odyssey/package.json
+++ b/packages/arte-odyssey/package.json
@@ -86,8 +86,8 @@
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react-swc": "catalog:",
-    "@vitest/browser": "3.2.4",
-    "@vitest/ui": "3.2.4",
+    "@vitest/browser-playwright": "4.0.3",
+    "@vitest/ui": "4.0.3",
     "postcss": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
@@ -95,8 +95,8 @@
     "storybook-addon-mock-date": "1.0.2",
     "tailwindcss": "catalog:",
     "vite": "catalog:",
-    "vitest": "3.2.4",
-    "vitest-browser-react": "1.0.1"
+    "vitest": "4.0.3",
+    "vitest-browser-react": "2.0.0"
   },
   "peerDependencies": {
     "@types/react": ">=19.0.0",

--- a/packages/arte-odyssey/src/hooks/click-away/index.test.tsx
+++ b/packages/arte-odyssey/src/hooks/click-away/index.test.tsx
@@ -1,5 +1,5 @@
-import { userEvent } from '@vitest/browser/context';
 import type { FC } from 'react';
+import { userEvent } from 'vitest/browser';
 import { render } from 'vitest-browser-react';
 import { useClickAway } from '.';
 
@@ -19,7 +19,7 @@ describe('useClickAway', () => {
   it('領域外を触るとcallbackが呼び出される', async () => {
     const fn = vi.fn();
 
-    const { getByText } = render(<OutsideClicker callback={fn} />);
+    const { getByText } = await render(<OutsideClicker callback={fn} />);
     const element = getByText('Element');
     const outsideElement = getByText('Outside');
 

--- a/packages/arte-odyssey/src/hooks/clipboard/index.test.ts
+++ b/packages/arte-odyssey/src/hooks/clipboard/index.test.ts
@@ -15,7 +15,7 @@ describe('useClipboard', () => {
       },
     });
 
-    const { result } = renderHook(() => useClipboard());
+    const { result } = await renderHook(() => useClipboard());
     await result.current.writeClipboard(writeText);
 
     expect(writeTextMockFn).toBeCalledWith(writeText);
@@ -30,7 +30,7 @@ describe('useClipboard', () => {
       },
     });
 
-    const { result } = renderHook(() => useClipboard());
+    const { result } = await renderHook(() => useClipboard());
     await result.current.readClipboard();
 
     expect(readTextMockFn).toHaveBeenCalledOnce();

--- a/packages/arte-odyssey/src/hooks/hash/index.test.ts
+++ b/packages/arte-odyssey/src/hooks/hash/index.test.ts
@@ -16,14 +16,14 @@ describe('useHash', () => {
     window.location.hash = realHash;
   });
 
-  it('現在のhash値を取得できる', () => {
-    const { result } = renderHook(() => useHash());
+  it('現在のhash値を取得できる', async () => {
+    const { result } = await renderHook(() => useHash());
 
     expect(result.current).toBe('test');
   });
 
-  it('hash値が変更されたときに更新される', () => {
-    const { result, act } = renderHook(() => useHash());
+  it('hash値が変更されたときに更新される', async () => {
+    const { result, act } = await renderHook(() => useHash());
 
     act(() => {
       window.location.hash = '#changed';
@@ -34,7 +34,7 @@ describe('useHash', () => {
   });
 
   it('pushStateでhash値が変更されたときに更新される', async () => {
-    const { result, act } = renderHook(() => useHash());
+    const { result, act } = await renderHook(() => useHash());
 
     act(() => {
       window.history.pushState({}, '', '/#pushed');
@@ -46,7 +46,7 @@ describe('useHash', () => {
   });
 
   it('replaceStateでhash値が変更されたときに更新される', async () => {
-    const { result, act } = renderHook(() => useHash());
+    const { result, act } = await renderHook(() => useHash());
 
     act(() => {
       window.history.replaceState({}, '', '/#replaced');

--- a/packages/arte-odyssey/src/hooks/interval/index.test.ts
+++ b/packages/arte-odyssey/src/hooks/interval/index.test.ts
@@ -2,11 +2,11 @@ import { renderHook } from 'vitest-browser-react';
 import { useInterval } from '.';
 
 describe('useInterval', () => {
-  it('指定時間ごとに実行される', () => {
+  it('指定時間ごとに実行される', async () => {
     const fn = vi.fn();
     vi.useFakeTimers();
 
-    renderHook(() => {
+    await renderHook(() => {
       useInterval(fn, 1000);
     });
     vi.advanceTimersByTime(2000);
@@ -14,11 +14,11 @@ describe('useInterval', () => {
     expect(fn).toHaveBeenCalledTimes(2);
   });
 
-  it('指定時間を過ぎないと実行されない', () => {
+  it('指定時間を過ぎないと実行されない', async () => {
     const fn = vi.fn();
     vi.useFakeTimers();
 
-    renderHook(() => {
+    await renderHook(() => {
       useInterval(fn, 1000);
     });
     vi.advanceTimersByTime(10);
@@ -26,11 +26,11 @@ describe('useInterval', () => {
     expect(fn).not.toHaveBeenCalled();
   });
 
-  it('アンマウント後は実行されない', () => {
+  it('アンマウント後は実行されない', async () => {
     const fn = vi.fn();
     vi.useFakeTimers();
 
-    const { unmount } = renderHook(() => {
+    const { unmount } = await renderHook(() => {
       useInterval(fn, 1000);
     });
     unmount();

--- a/packages/arte-odyssey/src/hooks/local-storage/index.test.ts
+++ b/packages/arte-odyssey/src/hooks/local-storage/index.test.ts
@@ -16,21 +16,25 @@ describe('useLocalStorage', () => {
     consoleErrorMock.mockReset();
   });
 
-  it('localStorageに値がなければ初期値を返す', () => {
-    const { result } = renderHook(() => useLocalStorage(key, 'defaultValue'));
+  it('localStorageに値がなければ初期値を返す', async () => {
+    const { result } = await renderHook(() =>
+      useLocalStorage(key, 'defaultValue'),
+    );
 
     expect(result.current[0]).toBe('defaultValue');
   });
 
-  it('localStorageに値が存在あればその値を返す', () => {
+  it('localStorageに値が存在あればその値を返す', async () => {
     localStorage.setItem(key, JSON.stringify('storedValue'));
-    const { result } = renderHook(() => useLocalStorage(key, 'defaultValue'));
+    const { result } = await renderHook(() =>
+      useLocalStorage(key, 'defaultValue'),
+    );
 
     expect(result.current[0]).toBe('storedValue');
   });
 
-  it('更新処理ではlocalStorageとstateの両方を更新する', () => {
-    const { result, act } = renderHook(() =>
+  it('更新処理ではlocalStorageとstateの両方を更新する', async () => {
+    const { result, act } = await renderHook(() =>
       useLocalStorage(key, 'defaultValue'),
     );
 
@@ -42,9 +46,9 @@ describe('useLocalStorage', () => {
     expect(result.current[0]).toBe('newValue');
   });
 
-  it('削除処理ではlocalStorageは値を削除され、stateは初期値になる', () => {
+  it('削除処理ではlocalStorageは値を削除され、stateは初期値になる', async () => {
     localStorage.setItem(key, JSON.stringify('storedValue'));
-    const { result, act } = renderHook(() =>
+    const { result, act } = await renderHook(() =>
       useLocalStorage(key, 'defaultValue'),
     );
 
@@ -56,8 +60,8 @@ describe('useLocalStorage', () => {
     expect(result.current[0]).toBe('defaultValue');
   });
 
-  it('nullで更新した場合はremoveと同じ結果になる', () => {
-    const { result, act } = renderHook(() =>
+  it('nullで更新した場合はremoveと同じ結果になる', async () => {
+    const { result, act } = await renderHook(() =>
       useLocalStorage<{ lang: string[] } | null>(key, {
         lang: ['ja', 'en'],
       }),
@@ -71,8 +75,8 @@ describe('useLocalStorage', () => {
     expect(result.current[0]).toEqual({ lang: ['ja', 'en'] });
   });
 
-  it('storageイベントの発火に応じて状stateが更新される', () => {
-    const { result, act } = renderHook(() =>
+  it('storageイベントの発火に応じて状stateが更新される', async () => {
+    const { result, act } = await renderHook(() =>
       useLocalStorage(key, 'defaultValue'),
     );
 
@@ -89,8 +93,8 @@ describe('useLocalStorage', () => {
     expect(result.current[0]).toBe('updatedValue');
   });
 
-  it('異なるキーのstorageイベントはstateを更新しない', () => {
-    const { result, act } = renderHook(() =>
+  it('異なるキーのstorageイベントはstateを更新しない', async () => {
+    const { result, act } = await renderHook(() =>
       useLocalStorage(key, 'defaultValue'),
     );
 
@@ -107,9 +111,11 @@ describe('useLocalStorage', () => {
     expect(result.current[0]).toBe('defaultValue');
   });
 
-  it('JSONをパースできない時はエラーを吐いて初期値を返す', () => {
+  it('JSONをパースできない時はエラーを吐いて初期値を返す', async () => {
     localStorage.setItem(key, '{invalidJSON');
-    const { result } = renderHook(() => useLocalStorage(key, 'defaultValue'));
+    const { result } = await renderHook(() =>
+      useLocalStorage(key, 'defaultValue'),
+    );
 
     expect(result.current[0]).toBe('defaultValue');
     expect(consoleErrorMock).toHaveBeenCalledOnce();

--- a/packages/arte-odyssey/src/hooks/scroll-direction/index.test.ts
+++ b/packages/arte-odyssey/src/hooks/scroll-direction/index.test.ts
@@ -13,15 +13,15 @@ describe('useScrollDirection', () => {
     });
   });
 
-  it('初期状態ではx: right, y: upを返す', () => {
-    const { result } = renderHook(() => useScrollDirection());
+  it('初期状態ではx: right, y: upを返す', async () => {
+    const { result } = await renderHook(() => useScrollDirection());
 
     expect(result.current).toEqual({ x: 'right', y: 'up' });
   });
 
   describe('Vertical scroll', () => {
-    it('100px以上下にスクロールするとy: downを返す', () => {
-      const { result, act } = renderHook(() => useScrollDirection());
+    it('100px以上下にスクロールするとy: downを返す', async () => {
+      const { result, act } = await renderHook(() => useScrollDirection());
 
       act(() => {
         Object.defineProperty(window, 'scrollY', { value: 150 });
@@ -31,8 +31,8 @@ describe('useScrollDirection', () => {
       expect(result.current.y).toBe('down');
     });
 
-    it('100px未満のスクロールではy: upのまま', () => {
-      const { result, act } = renderHook(() => useScrollDirection());
+    it('100px未満のスクロールではy: upのまま', async () => {
+      const { result, act } = await renderHook(() => useScrollDirection());
 
       act(() => {
         Object.defineProperty(window, 'scrollY', { value: 50 });
@@ -42,8 +42,8 @@ describe('useScrollDirection', () => {
       expect(result.current.y).toBe('up');
     });
 
-    it('上にスクロールするとy: upを返す', () => {
-      const { result, act } = renderHook(() => useScrollDirection());
+    it('上にスクロールするとy: upを返す', async () => {
+      const { result, act } = await renderHook(() => useScrollDirection());
 
       // 最初に下にスクロール
       act(() => {
@@ -64,8 +64,8 @@ describe('useScrollDirection', () => {
   });
 
   describe('Horizontal scroll', () => {
-    it('100px以上右にスクロールするとx: rightを返す', () => {
-      const { result, act } = renderHook(() => useScrollDirection());
+    it('100px以上右にスクロールするとx: rightを返す', async () => {
+      const { result, act } = await renderHook(() => useScrollDirection());
 
       act(() => {
         Object.defineProperty(window, 'scrollX', { value: 150 });
@@ -75,8 +75,8 @@ describe('useScrollDirection', () => {
       expect(result.current.x).toBe('right');
     });
 
-    it('100px未満のスクロールではx: rightのまま', () => {
-      const { result, act } = renderHook(() => useScrollDirection());
+    it('100px未満のスクロールではx: rightのまま', async () => {
+      const { result, act } = await renderHook(() => useScrollDirection());
 
       act(() => {
         Object.defineProperty(window, 'scrollX', { value: 50 });
@@ -86,8 +86,8 @@ describe('useScrollDirection', () => {
       expect(result.current.x).toBe('right');
     });
 
-    it('左にスクロールするとx: leftを返す', () => {
-      const { result, act } = renderHook(() => useScrollDirection());
+    it('左にスクロールするとx: leftを返す', async () => {
+      const { result, act } = await renderHook(() => useScrollDirection());
 
       // 最初に右にスクロール
       act(() => {
@@ -108,8 +108,8 @@ describe('useScrollDirection', () => {
   });
 
   describe('Combined scroll', () => {
-    it('縦横同時にスクロールした場合、両方向を正しく検知する', () => {
-      const { result, act } = renderHook(() => useScrollDirection());
+    it('縦横同時にスクロールした場合、両方向を正しく検知する', async () => {
+      const { result, act } = await renderHook(() => useScrollDirection());
 
       act(() => {
         Object.defineProperty(window, 'scrollY', { value: 150 });
@@ -121,10 +121,10 @@ describe('useScrollDirection', () => {
     });
   });
 
-  it('アンマウント後はイベントリスナーが削除される', () => {
+  it('アンマウント後はイベントリスナーが削除される', async () => {
     const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
 
-    const { unmount } = renderHook(() => useScrollDirection());
+    const { unmount } = await renderHook(() => useScrollDirection());
 
     unmount();
 
@@ -134,10 +134,10 @@ describe('useScrollDirection', () => {
     );
   });
 
-  it('スクロールイベントがpassive: trueで登録される', () => {
+  it('スクロールイベントがpassive: trueで登録される', async () => {
     const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
 
-    renderHook(() => useScrollDirection());
+    await renderHook(() => useScrollDirection());
 
     expect(addEventListenerSpy).toHaveBeenCalledWith(
       'scroll',
@@ -147,8 +147,8 @@ describe('useScrollDirection', () => {
   });
 
   describe('Threshold parameter', () => {
-    it('thresholdが100の場合、100px以下のスクロールでは方向が変わらない', () => {
-      const { result, act } = renderHook(() => useScrollDirection(100));
+    it('thresholdが100の場合、100px以下のスクロールでは方向が変わらない', async () => {
+      const { result, act } = await renderHook(() => useScrollDirection(100));
 
       act(() => {
         Object.defineProperty(window, 'scrollY', { value: 100 });
@@ -165,8 +165,8 @@ describe('useScrollDirection', () => {
       expect(result.current.x).toBe('right');
     });
 
-    it('thresholdが100の場合、101px以上のスクロールで方向が変わる', () => {
-      const { result, act } = renderHook(() => useScrollDirection(100));
+    it('thresholdが100の場合、101px以上のスクロールで方向が変わる', async () => {
+      const { result, act } = await renderHook(() => useScrollDirection(100));
 
       act(() => {
         Object.defineProperty(window, 'scrollY', { value: 101 });
@@ -183,8 +183,8 @@ describe('useScrollDirection', () => {
       expect(result.current.x).toBe('right');
     });
 
-    it('thresholdが10の場合、10px以下のスクロールでは方向が変わらない', () => {
-      const { result, act } = renderHook(() => useScrollDirection(10));
+    it('thresholdが10の場合、10px以下のスクロールでは方向が変わらない', async () => {
+      const { result, act } = await renderHook(() => useScrollDirection(10));
 
       act(() => {
         Object.defineProperty(window, 'scrollY', { value: 10 });
@@ -194,8 +194,8 @@ describe('useScrollDirection', () => {
       expect(result.current.y).toBe('up');
     });
 
-    it('thresholdが10の場合、11px以上のスクロールで方向が変わる', () => {
-      const { result, act } = renderHook(() => useScrollDirection(10));
+    it('thresholdが10の場合、11px以上のスクロールで方向が変わる', async () => {
+      const { result, act } = await renderHook(() => useScrollDirection(10));
 
       act(() => {
         Object.defineProperty(window, 'scrollY', { value: 11 });
@@ -205,8 +205,8 @@ describe('useScrollDirection', () => {
       expect(result.current.y).toBe('down');
     });
 
-    it('thresholdが0の場合、1px以上のスクロールで方向が変わる', () => {
-      const { result, act } = renderHook(() => useScrollDirection(0));
+    it('thresholdが0の場合、1px以上のスクロールで方向が変わる', async () => {
+      const { result, act } = await renderHook(() => useScrollDirection(0));
 
       act(() => {
         Object.defineProperty(window, 'scrollY', { value: 1 });
@@ -216,8 +216,8 @@ describe('useScrollDirection', () => {
       expect(result.current.y).toBe('down');
     });
 
-    it('デフォルト値（threshold未指定）では50pxの閾値が適用される', () => {
-      const { result, act } = renderHook(() => useScrollDirection());
+    it('デフォルト値（threshold未指定）では50pxの閾値が適用される', async () => {
+      const { result, act } = await renderHook(() => useScrollDirection());
 
       act(() => {
         Object.defineProperty(window, 'scrollY', { value: 50 });

--- a/packages/arte-odyssey/src/hooks/step/index.test.ts
+++ b/packages/arte-odyssey/src/hooks/step/index.test.ts
@@ -1,23 +1,25 @@
-import { userEvent } from '@vitest/browser/context';
+import { userEvent } from 'vitest/browser';
 import { renderHook } from 'vitest-browser-react';
 import { useStep } from '.';
 
 describe('useStep', () => {
-  it('初期状態', () => {
+  it('初期状態', async () => {
     const initialCount = 1;
     const maxCount = 10;
 
-    const { result } = renderHook(() => useStep({ initialCount, maxCount }));
+    const { result } = await renderHook(() =>
+      useStep({ initialCount, maxCount }),
+    );
 
     expect(result.current.count).toBe(initialCount);
     expect(result.current.isDisabledBack).toBeTruthy();
     expect(result.current.isDisabledNext).toBeFalsy();
   });
-  it('nextでinitialCountから1進む', () => {
+  it('nextでinitialCountから1進む', async () => {
     const initialCount = 1;
     const maxCount = 10;
 
-    const { result, act } = renderHook(() =>
+    const { result, act } = await renderHook(() =>
       useStep({ initialCount, maxCount }),
     );
     act(() => {
@@ -28,11 +30,11 @@ describe('useStep', () => {
     expect(result.current.isDisabledBack).toBeFalsy();
     expect(result.current.isDisabledNext).toBeFalsy();
   });
-  it('initialCountからはbackできない', () => {
+  it('initialCountからはbackできない', async () => {
     const initialCount = 1;
     const maxCount = 10;
 
-    const { result, act } = renderHook(() =>
+    const { result, act } = await renderHook(() =>
       useStep({ initialCount, maxCount }),
     );
     act(() => {
@@ -43,11 +45,11 @@ describe('useStep', () => {
     expect(result.current.isDisabledBack).toBeTruthy();
     expect(result.current.isDisabledNext).toBeFalsy();
   });
-  it('maxCountまで進む', () => {
+  it('maxCountまで進む', async () => {
     const initialCount = 1;
     const maxCount = 3;
 
-    const { result, act } = renderHook(() =>
+    const { result, act } = await renderHook(() =>
       useStep({ initialCount, maxCount }),
     );
     act(() => {
@@ -59,11 +61,11 @@ describe('useStep', () => {
     expect(result.current.isDisabledBack).toBeFalsy();
     expect(result.current.isDisabledNext).toBeTruthy();
   });
-  it('maxCount以上は進めない', () => {
+  it('maxCount以上は進めない', async () => {
     const initialCount = 1;
     const maxCount = 3;
 
-    const { result, act } = renderHook(() =>
+    const { result, act } = await renderHook(() =>
       useStep({ initialCount, maxCount }),
     );
     act(() => {
@@ -76,11 +78,11 @@ describe('useStep', () => {
     expect(result.current.isDisabledBack).toBeFalsy();
     expect(result.current.isDisabledNext).toBeTruthy();
   });
-  it('nextとbackを組み合わせて利用できる', () => {
+  it('nextとbackを組み合わせて利用できる', async () => {
     const initialCount = 1;
     const maxCount = 3;
 
-    const { result, act } = renderHook(() =>
+    const { result, act } = await renderHook(() =>
       useStep({ initialCount, maxCount }),
     );
     act(() => {
@@ -96,7 +98,9 @@ describe('useStep', () => {
     const initialCount = 1;
     const maxCount = 3;
 
-    const { result } = renderHook(() => useStep({ initialCount, maxCount }));
+    const { result } = await renderHook(() =>
+      useStep({ initialCount, maxCount }),
+    );
 
     await userEvent.keyboard('{arrowright}');
     expect(result.current.count).toBe(initialCount + 1);

--- a/packages/arte-odyssey/src/hooks/timeout/index.test.ts
+++ b/packages/arte-odyssey/src/hooks/timeout/index.test.ts
@@ -2,11 +2,11 @@ import { renderHook } from 'vitest-browser-react';
 import { useTimeout } from '.';
 
 describe('useTimeout', () => {
-  it('指定時間後に実行される', () => {
+  it('指定時間後に実行される', async () => {
     const fn = vi.fn();
     vi.useFakeTimers();
 
-    renderHook(() => {
+    await renderHook(() => {
       useTimeout(fn, 1000);
     });
     vi.advanceTimersByTime(1000);
@@ -14,11 +14,11 @@ describe('useTimeout', () => {
     expect(fn).toHaveBeenCalledOnce();
   });
 
-  it('指定時間前に実行されない', () => {
+  it('指定時間前に実行されない', async () => {
     const fn = vi.fn();
     vi.useFakeTimers();
 
-    renderHook(() => {
+    await renderHook(() => {
       useTimeout(fn, 1000);
     });
     vi.advanceTimersByTime(10);
@@ -26,11 +26,11 @@ describe('useTimeout', () => {
     expect(fn).not.toHaveBeenCalled();
   });
 
-  it('指定時間前にアンマウントされない場合は実行されない', () => {
+  it('指定時間前にアンマウントされない場合は実行されない', async () => {
     const fn = vi.fn();
     vi.useFakeTimers();
 
-    const { unmount } = renderHook(() => {
+    const { unmount } = await renderHook(() => {
       useTimeout(fn, 1000);
     });
     unmount();

--- a/packages/arte-odyssey/src/hooks/window-size/index.test.ts
+++ b/packages/arte-odyssey/src/hooks/window-size/index.test.ts
@@ -2,14 +2,14 @@ import { renderHook } from 'vitest-browser-react';
 import { useWindowSize } from '.';
 
 describe('useWindowSize', () => {
-  it('windowサイズの変更に合わせて現在のwindowサイズを取得する', () => {
+  it('windowサイズの変更に合わせて現在のwindowサイズを取得する', async () => {
     const initWindowSize = { width: 0, height: 0 };
     const resizedWindowSize = { width: 1000, height: 1000 };
 
     window.innerWidth = initWindowSize.width;
     window.innerHeight = initWindowSize.height;
 
-    const { result, act } = renderHook(() => useWindowSize());
+    const { result, act } = await renderHook(() => useWindowSize());
 
     expect(result.current).toEqual(initWindowSize);
 

--- a/packages/arte-odyssey/vitest.config.ts
+++ b/packages/arte-odyssey/vitest.config.ts
@@ -1,5 +1,6 @@
 import { fileURLToPath } from 'node:url';
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
+import { playwright } from '@vitest/browser-playwright';
 import { defineConfig, mergeConfig } from 'vitest/config';
 import viteConfig from './vite.config';
 
@@ -30,7 +31,7 @@ export default mergeConfig(
             name: { label: 'components', color: 'magenta' },
             browser: {
               enabled: true,
-              provider: 'playwright',
+              provider: playwright(),
               headless: true,
               screenshotFailures: false,
               instances: [
@@ -58,7 +59,7 @@ export default mergeConfig(
                   browser: 'chromium',
                 },
               ],
-              provider: 'playwright',
+              provider: playwright(),
               headless: true,
               screenshotFailures: false,
             },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ catalogs:
       specifier: 4.1.16
       version: 4.1.16
     vite:
-      specifier: 7.1.9
-      version: 7.1.9
+      specifier: 7.1.12
+      version: 7.1.12
 
 importers:
 
@@ -113,7 +113,7 @@ importers:
         version: link:../../packages/arte-odyssey
       '@tailwindcss/vite':
         specifier: 'catalog:'
-        version: 4.1.16(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
+        version: 4.1.16(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
       tailwindcss:
         specifier: 'catalog:'
         version: 4.1.16
@@ -126,7 +126,7 @@ importers:
         version: 19.2.2(@types/react@19.2.2)
       '@vitejs/plugin-react-swc':
         specifier: 'catalog:'
-        version: 4.2.0(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
+        version: 4.2.0(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
       react:
         specifier: 'catalog:'
         version: 19.2.0
@@ -135,7 +135,7 @@ importers:
         version: 19.2.0(react@19.2.0)
       vite:
         specifier: 'catalog:'
-        version: 7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)
+        version: 7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)
 
   packages/arte-odyssey:
     dependencies:
@@ -165,23 +165,23 @@ importers:
         version: 3.3.1
       typescript:
         specifier: '>=5.9.0'
-        version: 5.9.2
+        version: 5.9.3
     devDependencies:
       '@chromatic-com/storybook':
         specifier: 4.1.1
-        version: 4.1.1(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))
+        version: 4.1.1(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))
       '@storybook/addon-a11y':
         specifier: 9.1.15
-        version: 9.1.15(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))
+        version: 9.1.15(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))
       '@storybook/addon-docs':
         specifier: 9.1.15
-        version: 9.1.15(@types/react@19.2.2)(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))
+        version: 9.1.15(@types/react@19.2.2)(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))
       '@storybook/addon-vitest':
         specifier: 9.1.15
-        version: 9.1.15(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))(vitest@3.2.4)
+        version: 9.1.15(@vitest/browser-playwright@4.0.3)(@vitest/browser@4.0.3(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))(vitest@4.0.3))(@vitest/runner@4.0.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))(vitest@4.0.3)
       '@storybook/react-vite':
         specifier: 9.1.15
-        version: 9.1.15(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.48.1)(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))(typescript@5.9.2)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
+        version: 9.1.15(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.48.1)(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))(typescript@5.9.3)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
       '@tailwindcss/postcss':
         specifier: 'catalog:'
         version: 4.1.16
@@ -193,13 +193,13 @@ importers:
         version: 19.2.2(@types/react@19.2.2)
       '@vitejs/plugin-react-swc':
         specifier: 'catalog:'
-        version: 4.2.0(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
-      '@vitest/browser':
-        specifier: 3.2.4
-        version: 3.2.4(playwright@1.56.1)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))(vitest@3.2.4)
+        version: 4.2.0(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
+      '@vitest/browser-playwright':
+        specifier: 4.0.3
+        version: 4.0.3(playwright@1.56.1)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))(vitest@4.0.3)
       '@vitest/ui':
-        specifier: 3.2.4
-        version: 3.2.4(vitest@3.2.4)
+        specifier: 4.0.3
+        version: 4.0.3(vitest@4.0.3)
       postcss:
         specifier: 'catalog:'
         version: 8.5.6
@@ -211,22 +211,22 @@ importers:
         version: 19.2.0(react@19.2.0)
       storybook:
         specifier: 9.1.15
-        version: 9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
+        version: 9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
       storybook-addon-mock-date:
         specifier: 1.0.2
-        version: 1.0.2(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))
+        version: 1.0.2(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))
       tailwindcss:
         specifier: 'catalog:'
         version: 4.1.16
       vite:
         specifier: 'catalog:'
-        version: 7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)
+        version: 7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)
       vitest:
-        specifier: 3.2.4
-        version: 3.2.4(@types/node@24.9.1)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.6.1)(lightningcss@1.30.2)
+        specifier: 4.0.3
+        version: 4.0.3(@types/node@24.9.1)(@vitest/browser-playwright@4.0.3)(@vitest/ui@4.0.3)(jiti@2.6.1)(lightningcss@1.30.2)
       vitest-browser-react:
-        specifier: 1.0.1
-        version: 1.0.1(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(@vitest/browser@3.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vitest@3.2.4)
+        specifier: 2.0.0
+        version: 2.0.0(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vitest@4.0.3)
 
 packages:
 
@@ -1236,6 +1236,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
   '@storybook/addon-a11y@9.1.15':
     resolution: {integrity: sha512-UIr9F/XCECoE9nxZ4v7SmBl50soy+7N7RtcruMNeiDjv0nlBsSO5xUc9Lr4ZwcTkN8FOrAvddHpoF4UtGrAmsQ==}
     peerDependencies:
@@ -1565,23 +1568,22 @@ packages:
     peerDependencies:
       vite: ^4 || ^5 || ^6 || ^7
 
-  '@vitest/browser@3.2.4':
-    resolution: {integrity: sha512-tJxiPrWmzH8a+w9nLKlQMzAKX/7VjFs50MWgcAj7p9XQ7AQ9/35fByFYptgPELyLw+0aixTnC4pUWV+APcZ/kw==}
+  '@vitest/browser-playwright@4.0.3':
+    resolution: {integrity: sha512-dWbOAtgWRsa4ErGqBqb1noX8BzoHy3Ti1wgm+rA7qJ9bB1JaTDUK1yZk+WAhD/zKw9s6Eyi+etPumId1U8W7dA==}
     peerDependencies:
       playwright: '*'
-      safaridriver: '*'
-      vitest: 3.2.4
-      webdriverio: ^7.0.0 || ^8.0.0 || ^9.0.0
-    peerDependenciesMeta:
-      playwright:
-        optional: true
-      safaridriver:
-        optional: true
-      webdriverio:
-        optional: true
+      vitest: 4.0.3
+
+  '@vitest/browser@4.0.3':
+    resolution: {integrity: sha512-XmGOU2m0x86yFIrAFiIQ5yV7dpk8hW1HCohUR7QOGfywGS8z2WshdEZc5A+G67mS69L8Ub3NEttjWtXVhw/Sew==}
+    peerDependencies:
+      vitest: 4.0.3
 
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/expect@4.0.3':
+    resolution: {integrity: sha512-v3eSDx/bF25pzar6aEJrrdTXJduEBU3uSGXHslIdGIpJVP8tQQHV6x1ZfzbFQ/bLIomLSbR/2ZCfnaEGkWkiVQ==}
 
   '@vitest/mocker@3.2.4':
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
@@ -1594,25 +1596,45 @@ packages:
       vite:
         optional: true
 
+  '@vitest/mocker@4.0.3':
+    resolution: {integrity: sha512-evZcRspIPbbiJEe748zI2BRu94ThCBE+RkjCpVF8yoVYuTV7hMe+4wLF/7K86r8GwJHSmAPnPbZhpXWWrg1qbA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
-  '@vitest/runner@3.2.4':
-    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+  '@vitest/pretty-format@4.0.3':
+    resolution: {integrity: sha512-N7gly/DRXzxa9w9sbDXwD9QNFYP2hw90LLLGDobPNwiWgyW95GMxsCt29/COIKKh3P7XJICR38PSDePenMBtsw==}
 
-  '@vitest/snapshot@3.2.4':
-    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+  '@vitest/runner@4.0.3':
+    resolution: {integrity: sha512-1/aK6fPM0lYXWyGKwop2Gbvz1plyTps/HDbIIJXYtJtspHjpXIeB3If07eWpVH4HW7Rmd3Rl+IS/+zEAXrRtXA==}
+
+  '@vitest/snapshot@4.0.3':
+    resolution: {integrity: sha512-amnYmvZ5MTjNCP1HZmdeczAPLRD6iOm9+2nMRUGxbe/6sQ0Ymur0NnR9LIrWS8JA3wKE71X25D6ya/3LN9YytA==}
 
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
-  '@vitest/ui@3.2.4':
-    resolution: {integrity: sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==}
+  '@vitest/spy@4.0.3':
+    resolution: {integrity: sha512-82vVL8Cqz7rbXaNUl35V2G7xeNMAjBdNOVaHbrzznT9BmiCiPOzhf0FhU3eP41nP1bLDm/5wWKZqkG4nyU95DQ==}
+
+  '@vitest/ui@4.0.3':
+    resolution: {integrity: sha512-HURRrgGVzz2GQ2Imurp55FA+majHXgCXMzcwtojUZeRsAXyHNgEvxGRJf4QQY4kJeVakiugusGYeUqBgZ/xylg==}
     peerDependencies:
-      vitest: 3.2.4
+      vitest: 4.0.3
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  '@vitest/utils@4.0.3':
+    resolution: {integrity: sha512-qV6KJkq8W3piW6MDIbGOmn1xhvcW4DuA07alqaQ+vdx7YA49J85pnwnxigZVQFQw3tWnQNRKWwhz5wbP6iv/GQ==}
 
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
@@ -1708,10 +1730,6 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
-  cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
-
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -1721,6 +1739,10 @@ packages:
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  chai@6.2.0:
+    resolution: {integrity: sha512-aUTnJc/JipRzJrNADXVvpVqi6CO0dn3nx4EVPxijri+fj3LUUDyZQOgVeW54Ob3Y1Xh9Iz8f+CgaCl8v0mn9bA==}
     engines: {node: '>=18'}
 
   chalk@5.6.0:
@@ -1830,6 +1852,15 @@ packages:
 
   debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -2164,9 +2195,6 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-tokens@9.0.1:
-    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
-
   js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
     hasBin: true
@@ -2397,9 +2425,6 @@ packages:
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
-
-  magic-string@0.30.18:
-    resolution: {integrity: sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==}
 
   magic-string@0.30.19:
     resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
@@ -2703,6 +2728,10 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
+  pixelmatch@7.1.0:
+    resolution: {integrity: sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==}
+    hasBin: true
+
   playwright-core@1.56.1:
     resolution: {integrity: sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==}
     engines: {node: '>=18'}
@@ -2712,6 +2741,10 @@ packages:
     resolution: {integrity: sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -2848,8 +2881,8 @@ packages:
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
 
-  sirv@3.0.1:
-    resolution: {integrity: sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==}
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
 
   sisteransi@1.0.5:
@@ -2926,9 +2959,6 @@ packages:
     resolution: {integrity: sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==}
     engines: {node: '>=12'}
 
-  strip-literal@3.0.0:
-    resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
-
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -2982,20 +3012,16 @@ packages:
   tinyexec@1.0.1:
     resolution: {integrity: sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==}
 
-  tinyglobby@0.2.14:
-    resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
-    engines: {node: '>=12.0.0'}
-
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@1.1.1:
-    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@4.0.3:
@@ -3058,11 +3084,6 @@ packages:
     resolution: {integrity: sha512-5c9Fdsr9qfpT3hA0EyYSFRZj1dVVsb6KIWubA9JBYZ/9ZEAijgUEae0BBR/Xl/wekt4w65/lYLTFaP3JmwSO8w==}
     hasBin: true
 
-  typescript@5.9.2:
-    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -3093,13 +3114,8 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
-  vite-node@3.2.4:
-    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-
-  vite@7.1.9:
-    resolution: {integrity: sha512-4nVGliEpxmhCL8DslSAUdxlB6+SMrhB0a1v5ijlh1xB1nEPuy1mxaHxysVucLHuWryAxLWg6a5ei+U4TLn/rFg==}
+  vite@7.1.12:
+    resolution: {integrity: sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -3138,32 +3154,32 @@ packages:
       yaml:
         optional: true
 
-  vitest-browser-react@1.0.1:
-    resolution: {integrity: sha512-LqiGFCdknrbMoSDWXTCTrPsED3SvdIXIgYOOZyYUNj2dkJusW2eF6NENOlBlxwq+FBQqzNK1X59b+b03pXFpAQ==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+  vitest-browser-react@2.0.0:
+    resolution: {integrity: sha512-h6JbNDnEwE/zuqvChEeIf+fSXMJ5jyqSHmxPKWMFFGkeHOTLTwTskdoFAeW5UZMH+udiJH2VoGnNxOU2gWEdnQ==}
     peerDependencies:
       '@types/react': ^18.0.0 || ^19.0.0
       '@types/react-dom': ^18.0.0 || ^19.0.0
-      '@vitest/browser': ^2.1.0 || ^3.0.0 || ^4.0.0-0
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
-      vitest: ^2.1.0 || ^3.0.0 || ^4.0.0-0
+      vitest: ^4.0.0-0
     peerDependenciesMeta:
       '@types/react':
         optional: true
       '@types/react-dom':
         optional: true
 
-  vitest@3.2.4:
-    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+  vitest@4.0.3:
+    resolution: {integrity: sha512-IUSop8jgaT7w0g1yOM/35qVtKjr/8Va4PrjzH1OUb0YH4c3OXB2lCZDkMAB6glA8T5w8S164oJGsbcmAecr4sA==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/debug': ^4.1.12
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.2.4
-      '@vitest/ui': 3.2.4
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.3
+      '@vitest/browser-preview': 4.0.3
+      '@vitest/browser-webdriverio': 4.0.3
+      '@vitest/ui': 4.0.3
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -3173,7 +3189,11 @@ packages:
         optional: true
       '@types/node':
         optional: true
-      '@vitest/browser':
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
         optional: true
       '@vitest/ui':
         optional: true
@@ -3547,13 +3567,13 @@ snapshots:
       human-id: 4.1.1
       prettier: 2.8.8
 
-  '@chromatic-com/storybook@4.1.1(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))':
+  '@chromatic-com/storybook@4.1.1(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))':
     dependencies:
       '@neoconfetti/react': 1.0.0
       chromatic: 12.2.0
       filesize: 10.1.6
       jsonfile: 6.2.0
-      storybook: 9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
+      storybook: 9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
       strip-ansi: 7.1.0
     transitivePeerDependencies:
       - '@chromatic-com/cypress'
@@ -3957,14 +3977,14 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@5.9.2)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@5.9.3)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))':
     dependencies:
       glob: 10.4.5
       magic-string: 0.30.19
-      react-docgen-typescript: 2.4.0(typescript@5.9.2)
-      vite: 7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)
+      react-docgen-typescript: 2.4.0(typescript@5.9.3)
+      vite: 7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)
     optionalDependencies:
-      typescript: 5.9.2
+      typescript: 5.9.3
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -4132,50 +4152,53 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.48.1':
     optional: true
 
-  '@storybook/addon-a11y@9.1.15(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))':
+  '@standard-schema/spec@1.0.0': {}
+
+  '@storybook/addon-a11y@9.1.15(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.10.3
-      storybook: 9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
+      storybook: 9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
 
-  '@storybook/addon-docs@9.1.15(@types/react@19.2.2)(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))':
+  '@storybook/addon-docs@9.1.15(@types/react@19.2.2)(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))':
     dependencies:
       '@mdx-js/react': 3.1.0(@types/react@19.2.2)(react@19.2.0)
-      '@storybook/csf-plugin': 9.1.15(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))
+      '@storybook/csf-plugin': 9.1.15(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))
       '@storybook/icons': 1.4.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@storybook/react-dom-shim': 9.1.15(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))
+      '@storybook/react-dom-shim': 9.1.15(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      storybook: 9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
+      storybook: 9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-vitest@9.1.15(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))(vitest@3.2.4)':
+  '@storybook/addon-vitest@9.1.15(@vitest/browser-playwright@4.0.3)(@vitest/browser@4.0.3(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))(vitest@4.0.3))(@vitest/runner@4.0.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))(vitest@4.0.3)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 1.4.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       prompts: 2.4.2
-      storybook: 9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
+      storybook: 9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
       ts-dedent: 2.2.0
     optionalDependencies:
-      '@vitest/browser': 3.2.4(playwright@1.56.1)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))(vitest@3.2.4)
-      '@vitest/runner': 3.2.4
-      vitest: 3.2.4(@types/node@24.9.1)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.6.1)(lightningcss@1.30.2)
+      '@vitest/browser': 4.0.3(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))(vitest@4.0.3)
+      '@vitest/browser-playwright': 4.0.3(playwright@1.56.1)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))(vitest@4.0.3)
+      '@vitest/runner': 4.0.3
+      vitest: 4.0.3(@types/node@24.9.1)(@vitest/browser-playwright@4.0.3)(@vitest/ui@4.0.3)(jiti@2.6.1)(lightningcss@1.30.2)
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@storybook/builder-vite@9.1.15(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))':
+  '@storybook/builder-vite@9.1.15(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))':
     dependencies:
-      '@storybook/csf-plugin': 9.1.15(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))
-      storybook: 9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
+      '@storybook/csf-plugin': 9.1.15(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))
+      storybook: 9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
       ts-dedent: 2.2.0
-      vite: 7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)
+      vite: 7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)
 
-  '@storybook/csf-plugin@9.1.15(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))':
+  '@storybook/csf-plugin@9.1.15(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))':
     dependencies:
-      storybook: 9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
+      storybook: 9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
       unplugin: 1.16.1
 
   '@storybook/global@5.0.0': {}
@@ -4185,41 +4208,41 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@storybook/react-dom-shim@9.1.15(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))':
+  '@storybook/react-dom-shim@9.1.15(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))':
     dependencies:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      storybook: 9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
+      storybook: 9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
 
-  '@storybook/react-vite@9.1.15(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.48.1)(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))(typescript@5.9.2)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))':
+  '@storybook/react-vite@9.1.15(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.48.1)(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))(typescript@5.9.3)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.9.2)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.9.3)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
       '@rollup/pluginutils': 5.2.0(rollup@4.48.1)
-      '@storybook/builder-vite': 9.1.15(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
-      '@storybook/react': 9.1.15(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))(typescript@5.9.2)
+      '@storybook/builder-vite': 9.1.15(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
+      '@storybook/react': 9.1.15(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))(typescript@5.9.3)
       find-up: 7.0.0
       magic-string: 0.30.19
       react: 19.2.0
       react-docgen: 8.0.1
       react-dom: 19.2.0(react@19.2.0)
       resolve: 1.22.10
-      storybook: 9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
+      storybook: 9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
       tsconfig-paths: 4.2.0
-      vite: 7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)
+      vite: 7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  '@storybook/react@9.1.15(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))(typescript@5.9.2)':
+  '@storybook/react@9.1.15(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 9.1.15(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))
+      '@storybook/react-dom-shim': 9.1.15(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)))
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      storybook: 9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
+      storybook: 9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
     optionalDependencies:
-      typescript: 5.9.2
+      typescript: 5.9.3
 
   '@swc/core-darwin-arm64@1.13.5':
     optional: true
@@ -4346,12 +4369,12 @@ snapshots:
       postcss: 8.5.6
       tailwindcss: 4.1.16
 
-  '@tailwindcss/vite@4.1.16(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))':
+  '@tailwindcss/vite@4.1.16(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))':
     dependencies:
       '@tailwindcss/node': 4.1.16
       '@tailwindcss/oxide': 4.1.16
       tailwindcss: 4.1.16
-      vite: 7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)
+      vite: 7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -4434,27 +4457,38 @@ snapshots:
 
   '@types/trusted-types@2.0.7': {}
 
-  '@vitejs/plugin-react-swc@4.2.0(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))':
+  '@vitejs/plugin-react-swc@4.2.0(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.43
       '@swc/core': 1.13.5
-      vite: 7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)
+      vite: 7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitest/browser@3.2.4(playwright@1.56.1)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))(vitest@3.2.4)':
+  '@vitest/browser-playwright@4.0.3(playwright@1.56.1)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))(vitest@4.0.3)':
     dependencies:
-      '@testing-library/dom': 10.4.1
-      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/mocker': 3.2.4(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
-      '@vitest/utils': 3.2.4
-      magic-string: 0.30.18
-      sirv: 3.0.1
-      tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@24.9.1)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.6.1)(lightningcss@1.30.2)
-      ws: 8.18.3
-    optionalDependencies:
+      '@vitest/browser': 4.0.3(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))(vitest@4.0.3)
+      '@vitest/mocker': 4.0.3(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
       playwright: 1.56.1
+      tinyrainbow: 3.0.3
+      vitest: 4.0.3(@types/node@24.9.1)(@vitest/browser-playwright@4.0.3)(@vitest/ui@4.0.3)(jiti@2.6.1)(lightningcss@1.30.2)
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser@4.0.3(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))(vitest@4.0.3)':
+    dependencies:
+      '@vitest/mocker': 4.0.3(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
+      '@vitest/utils': 4.0.3
+      magic-string: 0.30.19
+      pixelmatch: 7.1.0
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.0.3
+      vitest: 4.0.3(@types/node@24.9.1)(@vitest/browser-playwright@4.0.3)(@vitest/ui@4.0.3)(jiti@2.6.1)(lightningcss@1.30.2)
+      ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -4469,50 +4503,77 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))':
+  '@vitest/expect@4.0.3':
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      '@types/chai': 5.2.2
+      '@vitest/spy': 4.0.3
+      '@vitest/utils': 4.0.3
+      chai: 6.2.0
+      tinyrainbow: 3.0.3
+
+  '@vitest/mocker@3.2.4(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
-      magic-string: 0.30.18
+      magic-string: 0.30.19
     optionalDependencies:
-      vite: 7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)
+      vite: 7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)
+
+  '@vitest/mocker@4.0.3(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))':
+    dependencies:
+      '@vitest/spy': 4.0.3
+      estree-walker: 3.0.3
+      magic-string: 0.30.19
+    optionalDependencies:
+      vite: 7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/runner@3.2.4':
+  '@vitest/pretty-format@4.0.3':
     dependencies:
-      '@vitest/utils': 3.2.4
-      pathe: 2.0.3
-      strip-literal: 3.0.0
+      tinyrainbow: 3.0.3
 
-  '@vitest/snapshot@3.2.4':
+  '@vitest/runner@4.0.3':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
-      magic-string: 0.30.18
+      '@vitest/utils': 4.0.3
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.0.3':
+    dependencies:
+      '@vitest/pretty-format': 4.0.3
+      magic-string: 0.30.19
       pathe: 2.0.3
 
   '@vitest/spy@3.2.4':
     dependencies:
       tinyspy: 4.0.3
 
-  '@vitest/ui@3.2.4(vitest@3.2.4)':
+  '@vitest/spy@4.0.3': {}
+
+  '@vitest/ui@4.0.3(vitest@4.0.3)':
     dependencies:
-      '@vitest/utils': 3.2.4
+      '@vitest/utils': 4.0.3
       fflate: 0.8.2
       flatted: 3.3.3
       pathe: 2.0.3
-      sirv: 3.0.1
-      tinyglobby: 0.2.14
-      tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@24.9.1)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.6.1)(lightningcss@1.30.2)
+      sirv: 3.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vitest: 4.0.3(@types/node@24.9.1)(@vitest/browser-playwright@4.0.3)(@vitest/ui@4.0.3)(jiti@2.6.1)(lightningcss@1.30.2)
 
   '@vitest/utils@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
       loupe: 3.2.1
       tinyrainbow: 2.0.0
+
+  '@vitest/utils@4.0.3':
+    dependencies:
+      '@vitest/pretty-format': 4.0.3
+      tinyrainbow: 3.0.3
 
   JSONStream@1.3.5:
     dependencies:
@@ -4596,8 +4657,6 @@ snapshots:
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.3)
 
-  cac@6.7.14: {}
-
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001737: {}
@@ -4609,6 +4668,8 @@ snapshots:
       deep-eql: 5.0.2
       loupe: 3.2.1
       pathval: 2.0.1
+
+  chai@6.2.0: {}
 
   chalk@5.6.0: {}
 
@@ -4701,6 +4762,10 @@ snapshots:
   dataloader@1.4.0: {}
 
   debug@4.4.1:
+    dependencies:
+      ms: 2.1.3
+
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
@@ -5026,8 +5091,6 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-tokens@9.0.1: {}
-
   js-yaml@3.14.1:
     dependencies:
       argparse: 1.0.10
@@ -5209,10 +5272,6 @@ snapshots:
 
   lz-string@1.5.0: {}
 
-  magic-string@0.30.18:
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
-
   magic-string@0.30.19:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -5365,6 +5424,10 @@ snapshots:
 
   pify@4.0.1: {}
 
+  pixelmatch@7.1.0:
+    dependencies:
+      pngjs: 7.0.0
+
   playwright-core@1.56.1: {}
 
   playwright@1.56.1:
@@ -5372,6 +5435,8 @@ snapshots:
       playwright-core: 1.56.1
     optionalDependencies:
       fsevents: 2.3.2
+
+  pngjs@7.0.0: {}
 
   postcss@8.4.31:
     dependencies:
@@ -5402,9 +5467,9 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  react-docgen-typescript@2.4.0(typescript@5.9.2):
+  react-docgen-typescript@2.4.0(typescript@5.9.3):
     dependencies:
-      typescript: 5.9.2
+      typescript: 5.9.3
 
   react-docgen@8.0.1:
     dependencies:
@@ -5554,7 +5619,7 @@ snapshots:
       is-arrayish: 0.3.2
     optional: true
 
-  sirv@3.0.1:
+  sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.29
       mrmime: 2.0.1
@@ -5581,17 +5646,17 @@ snapshots:
 
   std-env@3.9.0: {}
 
-  storybook-addon-mock-date@1.0.2(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))):
+  storybook-addon-mock-date@1.0.2(storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))):
     dependencies:
-      storybook: 9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
+      storybook: 9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
 
-  storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)):
+  storybook@9.1.15(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)):
     dependencies:
       '@storybook/global': 5.0.0
       '@testing-library/jest-dom': 6.8.0
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
+      '@vitest/mocker': 3.2.4(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
       '@vitest/spy': 3.2.4
       better-opn: 3.0.2
       esbuild: 0.25.11
@@ -5639,10 +5704,6 @@ snapshots:
     dependencies:
       min-indent: 1.0.1
 
-  strip-literal@3.0.0:
-    dependencies:
-      js-tokens: 9.0.1
-
   styled-jsx@5.1.6(react@19.2.0):
     dependencies:
       client-only: 0.0.1
@@ -5672,19 +5733,14 @@ snapshots:
 
   tinyexec@1.0.1: {}
 
-  tinyglobby@0.2.14:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
-  tinypool@1.1.1: {}
-
   tinyrainbow@2.0.0: {}
+
+  tinyrainbow@3.0.3: {}
 
   tinyspy@4.0.3: {}
 
@@ -5733,8 +5789,6 @@ snapshots:
       turbo-windows-64: 2.5.8
       turbo-windows-arm64: 2.5.8
 
-  typescript@5.9.2: {}
-
   typescript@5.9.3: {}
 
   undici-types@7.16.0: {}
@@ -5756,28 +5810,7 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  vite-node@3.2.4(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.1
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2):
+  vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2):
     dependencies:
       esbuild: 0.25.10
       fdir: 6.5.0(picomatch@4.0.3)
@@ -5791,45 +5824,41 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.2
 
-  vitest-browser-react@1.0.1(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(@vitest/browser@3.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vitest@3.2.4):
+  vitest-browser-react@2.0.0(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vitest@4.0.3):
     dependencies:
-      '@vitest/browser': 3.2.4(playwright@1.56.1)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))(vitest@3.2.4)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      vitest: 3.2.4(@types/node@24.9.1)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.6.1)(lightningcss@1.30.2)
+      vitest: 4.0.3(@types/node@24.9.1)(@vitest/browser-playwright@4.0.3)(@vitest/ui@4.0.3)(jiti@2.6.1)(lightningcss@1.30.2)
     optionalDependencies:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.2(@types/react@19.2.2)
 
-  vitest@3.2.4(@types/node@24.9.1)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.6.1)(lightningcss@1.30.2):
+  vitest@4.0.3(@types/node@24.9.1)(@vitest/browser-playwright@4.0.3)(@vitest/ui@4.0.3)(jiti@2.6.1)(lightningcss@1.30.2):
     dependencies:
-      '@types/chai': 5.2.2
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.1
+      '@vitest/expect': 4.0.3
+      '@vitest/mocker': 4.0.3(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
+      '@vitest/pretty-format': 4.0.3
+      '@vitest/runner': 4.0.3
+      '@vitest/snapshot': 4.0.3
+      '@vitest/spy': 4.0.3
+      '@vitest/utils': 4.0.3
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
       expect-type: 1.2.2
-      magic-string: 0.30.18
+      magic-string: 0.30.19
       pathe: 2.0.3
       picomatch: 4.0.3
       std-env: 3.9.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.14
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)
-      vite-node: 3.2.4(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.9.1
-      '@vitest/browser': 3.2.4(playwright@1.56.1)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))(vitest@3.2.4)
-      '@vitest/ui': 3.2.4(vitest@3.2.4)
+      '@vitest/browser-playwright': 4.0.3(playwright@1.56.1)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))(vitest@4.0.3)
+      '@vitest/ui': 4.0.3(vitest@4.0.3)
     transitivePeerDependencies:
       - jiti
       - less

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,7 @@ catalog:
   react: 19.2.0
   react-dom: 19.2.0
   tailwindcss: 4.1.16
-  vite: 7.1.9
+  vite: 7.1.12
 
 ignoredBuiltDependencies:
   - sharp

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,11 +24,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noUncheckedIndexedAccess": true,
-    "types": [
-      "node",
-      "vitest/globals",
-      "@vitest/browser/matchers",
-      "vitest/importMeta"
-    ]
+    "types": ["node", "vitest/globals", "vitest/importMeta"]
   }
 }


### PR DESCRIPTION
## Summary
- Upgrade Vitest and related packages from v3 to v4
- Update all test files to use the new Vitest v4 API (async render/renderHook, updated imports)
- Update vitest.config.ts to use new provider configuration

## Changes
### Dependencies
- `@vitest/browser` → `@vitest/browser-playwright@4.0.3`
- `@vitest/ui@3.2.4` → `@vitest/ui@4.0.3`
- `vitest@3.2.4` → `vitest@4.0.3`
- `vitest-browser-react@1.0.1` → `vitest-browser-react@2.0.0`

### Test Files
- Changed imports from `@vitest/browser/context` to `vitest/browser`
- Added `await` to all `render()` and `renderHook()` calls (now async in v4)
- Updated test functions to `async` where needed

### Configuration
- Updated `vitest.config.ts` provider from string `'playwright'` to function call `playwright()`

## Test plan
- [x] All test files updated to match Vitest v4 API
- [ ] Run `pnpm test` to verify all tests pass
- [ ] Verify Storybook tests still work with addon-vitest

🤖 Generated with [Claude Code](https://claude.com/claude-code)