### PR TITLE
fix: examplesをビルド対象から除外

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "k8o",
   "license": "MIT",
   "scripts": {
-    "build": "turbo run build",
+    "build": "turbo run build --filter='!./examples/**'",
     "test": "turbo run test",
     "test:ui": "turbo run test:ui",
     "test:coverage": "turbo run test:coverage",


### PR DESCRIPTION
## Summary
- `package.json`のbuildスクリプトを修正し、turboコマンドに`--filter='!./examples/**'`を追加
- これによりexamplesディレクトリがビルド対象から除外されるようになります

## Test plan
- [ ] `pnpm build`を実行し、examplesがビルドされないことを確認
- [ ] メインパッケージ（arte-odyssey）が正常にビルドされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)