### PR TITLE
fix(ci): correct MCP tool names for Renovate auto-merge workflow

### DIFF
--- a/.github/workflows/renovate-auto-merge.yml
+++ b/.github/workflows/renovate-auto-merge.yml
@@ -48,7 +48,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true
           claude_args: |
-            --allowedTools mcp__github__create_pending_pull_request_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_files
+            --allowedTools mcp__github__get_pull_request,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_files,mcp__github__create_pull_request_review
             --system-prompt "日本語で応答してください。"
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
The workflow was using non-existent tool names (create_pending_pull_request_review,
submit_pending_pull_request_review). Updated to use the correct tool names:
- get_pull_request (added for fetching PR info)
- get_pull_request_diff
- get_pull_request_files
- create_pull_request_review (replaces the incorrect pending/submit pair)