### PR TITLE
fix(ci): remove --allowedTools restriction for Renovate auto-merge

### DIFF
--- a/.github/workflows/renovate-auto-merge.yml
+++ b/.github/workflows/renovate-auto-merge.yml
@@ -47,9 +47,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true
-          claude_args: |
-            --allowedTools mcp__github__get_pull_request,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_files,mcp__github__create_pull_request_review
-            --system-prompt "日本語で応答してください。"
+          claude_args: '--system-prompt "日本語で応答してください。"'
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ steps.pr.outputs.number }}


### PR DESCRIPTION
The --allowedTools restriction was preventing Claude from using the necessary MCP tools. Removing this restriction allows Claude to use all available GitHub MCP tools for reviewing and approving PRs.