### PR TITLE
fix(ci): use simpler gh command pattern for allowedTools

### DIFF
--- a/.github/workflows/renovate-auto-merge.yml
+++ b/.github/workflows/renovate-auto-merge.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true
-          claude_args: '--system-prompt "日本語で応答してください。" --allowedTools "Bash(gh pr view*),Bash(gh pr review*)"'
+          claude_args: '--system-prompt "日本語で応答してください。" --allowedTools "Bash(gh:*)"'
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ steps.pr.outputs.number }}


### PR DESCRIPTION
## Summary
- Change allowedTools pattern from `Bash(gh pr view*),Bash(gh pr review*)` to `Bash(gh:*)`
- The previous pattern was not properly matching gh commands with special characters in arguments (emojis, newlines, etc.)

## Problem
The Renovate auto-merge workflow was failing to approve PRs because the `gh pr review` command was being denied by the allowedTools restriction. The pattern `Bash(gh pr review*)` was not matching commands like:
```
gh pr review 198 --approve --body "✅ **承認理由:**\n\n..."
```

## Solution
Use a simpler pattern `Bash(gh:*)` that matches all gh commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)