### PR TITLE
fix: add allowed_bots for renovate in auto-merge workflow

### DIFF
--- a/.github/workflows/renovate-auto-merge.yml
+++ b/.github/workflows/renovate-auto-merge.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true
+          allowed_bots: 'renovate[bot]'
           claude_args: '--system-prompt "日本語で応答してください。" --allowedTools "Bash(gh:*)"'
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
The anthropics/claude-code-action blocks bot-initiated workflows by
default. Adding allowed_bots: 'renovate[bot]' to permit Renovate
to trigger the Claude code review for dependency updates.