### PR TITLE
fix: add missing GitHub MCP tools to Claude Code Review allowedTools

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,7 +29,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true
           claude_args: |
-            --allowedTools mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_comments
+            --allowedTools mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_comments,mcp__github__get_pull_request,mcp__github__get_pull_request_files
             --system-prompt "日本語で応答してください。"
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- `mcp__github__get_pull_request` と `mcp__github__get_pull_request_files` を `allowedTools` に追加
- これにより Claude Code Review 実行時の permission denial エラーを修正

## Test plan
- [ ] 新しいPRでClaude Code Reviewが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)