### PR TITLE
fix: add missing GitHub MCP tools to Claude Code Review allowedTools

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,7 +29,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true
           claude_args: |
-            --allowedTools mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_comments,mcp__github__get_pull_request,mcp__github__get_pull_request_files
+            --allowedTools mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_comments,mcp__github__get_pull_request,mcp__github__get_pull_request_files,mcp__github__add_comment_to_pending_review,mcp__github__delete_pending_pull_request_review,mcp__github__create_and_submit_pull_request_review,mcp__github__add_issue_comment
             --system-prompt "日本語で応答してください。"
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
Add the following tools that were causing permission errors:
- mcp__github__add_comment_to_pending_review
- mcp__github__delete_pending_pull_request_review
- mcp__github__create_and_submit_pull_request_review
- mcp__github__add_issue_comment