### PR TITLE
chore: update pnpm-workspace.yaml settings

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,14 +24,6 @@ ignoredBuiltDependencies:
 
 minimumReleaseAge: 10080
 
-minimumReleaseAgeExclude:
-  - react
-  - react-dom
-  - next
-  - '@next/env'
-  - '@funstack/static'
-  - '@funstack/router'
-
 onlyBuiltDependencies:
   - '@swc/core'
   - '@tailwindcss/oxide'


### PR DESCRIPTION
## Summary
- `blockExoticSubdeps` と `verifyDepsBeforeRun` の設定を追加
- `ignoredBuiltDependencies` に `edgedriver`, `geckodriver` を追加
- `onlyBuiltDependencies` に `agent-browser` を追加
- `minimumReleaseAgeExclude` を削除
- 設定の並び順を整理

## Test plan
- [ ] `pnpm install` が正常に動作すること
- [ ] `pnpm build` が正常に動作すること