### PR TITLE
chore(ci): use PAT for renovate auto-merge

### DIFF
--- a/.github/workflows/renovate-auto-merge.yml
+++ b/.github/workflows/renovate-auto-merge.yml
@@ -90,4 +90,4 @@ jobs:
             echo "PR is not approved (decision: $REVIEW_DECISION), skipping merge"
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
## Summary
- Renovate auto-merge ワークフローのマージステップで `GITHUB_TOKEN` を `GH_PAT` に変更
- これにより、マージが `github-actions[bot]` ではなく自分のアカウントで実行されるようになる

## 必要な設定
- リポジトリの Settings > Secrets and variables > Actions に `GH_PAT` を追加してください
- PAT には `contents: write` と `pull_requests: write` 権限が必要です