### PR TITLE
chore: add .plan to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ next-env.d.ts
 
 # Local settings
 settings.local.json
+
+.plan


### PR DESCRIPTION
## Summary
- `.plan` ディレクトリを `.gitignore` に追加
- コンポーネント実装計画などのローカル作業用ファイルがリポジトリに含まれないようにする

🤖 Generated with [Claude Code](https://claude.com/claude-code)