### PR TITLE
Add changeset for Dialog Content and FileFieldProvider export removal

### DIFF
--- a/.changeset/clean-dialog-filefield-exports.md
+++ b/.changeset/clean-dialog-filefield-exports.md
@@ -1,0 +1,7 @@
+---
+'@k8o/arte-odyssey': major
+---
+
+Remove standalone `Content` export from Dialog — use `Dialog.Content` instead.
+
+Remove `FileFieldProvider` from public exports — it was only used internally.


### PR DESCRIPTION
Adds the missing changeset for #328 which removed `Content` (standalone Dialog export) and `FileFieldProvider` from the public API.