### PR TITLE
Exclude CHANGELOG.md from lint and format checks

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,8 +3,10 @@ import { defineConfig } from 'vite-plus';
 export default defineConfig({
   fmt: {
     singleQuote: true,
+    ignorePatterns: ['CHANGELOG.md'],
   },
   lint: {
+    ignorePatterns: ['CHANGELOG.md'],
     options: {
       typeAware: true,
     },


### PR DESCRIPTION
CHANGELOG.md files are auto-generated by changesets and should not be subject to oxlint/oxfmt checks.

https://claude.ai/code/session_01A9YePaVU1J4wA9TyqvXKg6