### PR TITLE
PropsTableのType表示から flex-wrap を削除

### DIFF
--- a/apps/docs/src/components/props-table.tsx
+++ b/apps/docs/src/components/props-table.tsx
@@ -9,7 +9,7 @@ export type PropItem = {
 
 const TypeCodes: FC<{ types: readonly string[] }> = ({ types }) => {
   return (
-    <span className="flex items-center gap-1">
+    <span className="inline-flex items-center gap-1">
       {types.map((type, i) => (
         <span className="flex items-center gap-1" key={type}>
           {i > 0 && <span className="text-fg-mute/60">|</span>}


### PR DESCRIPTION
小画面でTypeの内容が改行されるのを防止

https://claude.ai/code/session_019DZKb2rduutzg9DWLJd65U