### PR TITLE
fix: getServerSnapshot の参照不安定による無限ループを修正

### DIFF
--- a/.changeset/fix-server-snapshot.md
+++ b/.changeset/fix-server-snapshot.md
@@ -1,0 +1,7 @@
+---
+'@k8o/arte-odyssey': patch
+---
+
+useScrollDirection・useWindowSize の getServerSnapshot を定数化し無限ループを修正
+
+`useSyncExternalStore` の `getServerSnapshot` が呼び出しごとに新しいオブジェクトリテラルを返していたため、React が参照の不一致を検出して無限ループが発生する問題を修正。

--- a/packages/arte-odyssey/src/hooks/scroll-direction/index.ts
+++ b/packages/arte-odyssey/src/hooks/scroll-direction/index.ts
@@ -7,6 +7,9 @@ type ScrollDirection = {
   y: 'up' | 'down';
 };
 
+const SERVER_SNAPSHOT: ScrollDirection = { x: 'right', y: 'up' };
+const getServerSnapshot = (): ScrollDirection => SERVER_SNAPSHOT;
+
 export const useScrollDirection = (threshold = 50): ScrollDirection => {
   const stateRef = useRef<{
     direction: ScrollDirection;
@@ -72,11 +75,6 @@ export const useScrollDirection = (threshold = 50): ScrollDirection => {
   );
 
   const getSnapshot = (): ScrollDirection => stateRef.current.direction;
-
-  const getServerSnapshot = (): ScrollDirection => ({
-    x: 'right',
-    y: 'up',
-  });
 
   return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 };

--- a/packages/arte-odyssey/src/hooks/window-size/index.ts
+++ b/packages/arte-odyssey/src/hooks/window-size/index.ts
@@ -19,10 +19,8 @@ const getSnapshot = (): Size => {
   return cachedSnapshot;
 };
 
-const getServerSnapshot = (): Size => ({
-  width: 0,
-  height: 0,
-});
+const SERVER_SNAPSHOT: Size = { width: 0, height: 0 };
+const getServerSnapshot = (): Size => SERVER_SNAPSHOT;
 
 const subscribe = (callback: () => void): (() => void) => {
   window.addEventListener('resize', callback);


### PR DESCRIPTION
## Summary
- `useScrollDirection` と `useWindowSize` の `getServerSnapshot` が毎回新しいオブジェクトリテラルを返していたため、React が参照不一致で無限再レンダリングする問題を修正
- モジュールスコープの定数に抽出して参照安定性を確保

## Test plan
- [ ] SSR 環境で `useScrollDirection` / `useWindowSize` が無限ループしないこと
- [ ] CI テスト通過