### PR TITLE
fix: primary/secondary トークンの階調整理

### DIFF
--- a/.changeset/refine-primary-secondary-tokens.md
+++ b/.changeset/refine-primary-secondary-tokens.md
@@ -1,0 +1,9 @@
+---
+'@k8o/arte-odyssey': patch
+---
+
+primary / secondary トークンの被りを解消し階調を整理
+
+- dark の `primary-fg` / `secondary-fg` を 100 → 300 に変更（明るすぎを抑制）
+- light の `bg-emphasize` を 200 → 300 に変更（bg との被りを解消）
+- dark の `bg-subtle` を 900 → 950、`bg-mute` を 800 → 900 に変更（bg との被りを解消）

--- a/apps/docs/src/pages/theming.tsx
+++ b/apps/docs/src/pages/theming.tsx
@@ -327,7 +327,7 @@ const PRIMARY_TOKENS: TokenDef[] = [
   {
     name: 'primary-fg',
     light: { source: 'teal-800' },
-    dark: { source: 'teal-100' },
+    dark: { source: 'teal-300' },
   },
   {
     name: 'primary-bg',
@@ -337,16 +337,16 @@ const PRIMARY_TOKENS: TokenDef[] = [
   {
     name: 'primary-bg-subtle',
     light: { source: 'teal-50' },
-    dark: { source: 'teal-900' },
+    dark: { source: 'teal-950' },
   },
   {
     name: 'primary-bg-mute',
     light: { source: 'teal-100' },
-    dark: { source: 'teal-800' },
+    dark: { source: 'teal-900' },
   },
   {
     name: 'primary-bg-emphasize',
-    light: { source: 'teal-200' },
+    light: { source: 'teal-300' },
     dark: { source: 'teal-700' },
   },
   {
@@ -360,7 +360,7 @@ const SECONDARY_TOKENS: TokenDef[] = [
   {
     name: 'secondary-fg',
     light: { source: 'cyan-800' },
-    dark: { source: 'cyan-100' },
+    dark: { source: 'cyan-300' },
   },
   {
     name: 'secondary-bg',
@@ -370,16 +370,16 @@ const SECONDARY_TOKENS: TokenDef[] = [
   {
     name: 'secondary-bg-subtle',
     light: { source: 'cyan-50' },
-    dark: { source: 'cyan-900' },
+    dark: { source: 'cyan-950' },
   },
   {
     name: 'secondary-bg-mute',
     light: { source: 'cyan-100' },
-    dark: { source: 'cyan-800' },
+    dark: { source: 'cyan-900' },
   },
   {
     name: 'secondary-bg-emphasize',
-    light: { source: 'cyan-200' },
+    light: { source: 'cyan-300' },
     dark: { source: 'cyan-700' },
   },
   {

--- a/packages/arte-odyssey/src/styles/index.css
+++ b/packages/arte-odyssey/src/styles/index.css
@@ -246,14 +246,14 @@
   --primary-bg: var(--teal-200);
   --primary-bg-subtle: var(--teal-50);
   --primary-bg-mute: var(--teal-100);
-  --primary-bg-emphasize: var(--teal-200);
+  --primary-bg-emphasize: var(--teal-300);
   --primary-border: var(--teal-500);
 
   --secondary-fg: var(--cyan-800);
   --secondary-bg: var(--cyan-200);
   --secondary-bg-subtle: var(--cyan-50);
   --secondary-bg-mute: var(--cyan-100);
-  --secondary-bg-emphasize: var(--cyan-200);
+  --secondary-bg-emphasize: var(--cyan-300);
   --secondary-border: var(--cyan-500);
 
   --back-drop: rgb(0, 0, 0, 0.5);
@@ -295,17 +295,17 @@
   --border-warning: var(--yellow-400);
   --border-error: var(--red-400);
 
-  --primary-fg: var(--teal-100);
+  --primary-fg: var(--teal-300);
   --primary-bg: var(--teal-800);
-  --primary-bg-subtle: var(--teal-900);
-  --primary-bg-mute: var(--teal-800);
+  --primary-bg-subtle: var(--teal-950);
+  --primary-bg-mute: var(--teal-900);
   --primary-bg-emphasize: var(--teal-700);
   --primary-border: var(--teal-500);
 
-  --secondary-fg: var(--cyan-100);
+  --secondary-fg: var(--cyan-300);
   --secondary-bg: var(--cyan-800);
-  --secondary-bg-subtle: var(--cyan-900);
-  --secondary-bg-mute: var(--cyan-800);
+  --secondary-bg-subtle: var(--cyan-950);
+  --secondary-bg-mute: var(--cyan-900);
   --secondary-bg-emphasize: var(--cyan-700);
   --secondary-border: var(--cyan-500);
 


### PR DESCRIPTION
## Summary
- dark の `primary-fg` / `secondary-fg` を 100 → 300 に変更（明るすぎを抑制）
- light の `bg-emphasize` を 200 → 300 に変更（`bg` との被りを解消）
- dark の `bg-subtle` を 900 → 950、`bg-mute` を 800 → 900 に変更（`bg` との被りを解消）
- docs の theming ページも同期

## Test plan
- [ ] ダークモードで primary/secondary の fg が明るすぎないこと
- [ ] 各 bg トークンが視覚的に区別できること