### PR TITLE
feat(accordion): AccordionButtonにpaddingを追加

### DIFF
--- a/.changeset/accordion-button-padding.md
+++ b/.changeset/accordion-button-padding.md
@@ -1,0 +1,5 @@
+---
+'@k8o/arte-odyssey': patch
+---
+
+AccordionButtonに水平方向のpaddingを追加

--- a/packages/arte-odyssey/src/components/data-display/accordion/accordion-button.tsx
+++ b/packages/arte-odyssey/src/components/data-display/accordion/accordion-button.tsx
@@ -15,7 +15,7 @@ export const AccordionButton: FC<PropsWithChildren> = ({ children }) => {
       aria-controls={`${id}-panel`}
       aria-expanded={open}
       className={cn(
-        'flex w-full cursor-pointer items-center justify-between rounded-md py-4 text-fg-base',
+        'flex w-full cursor-pointer items-center justify-between rounded-md p-4 text-fg-base',
         'hover:text-primary-fg',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-info',
       )}


### PR DESCRIPTION
## Summary
- AccordionButtonの`py-4`を`p-4`に変更し、水平方向のpaddingを追加

## Test plan
- [ ] localhost:5173/ja/components/accordion でボタンに左右のpaddingが反映されていることを確認