### PR TITLE
fix(docs): サイドバー開閉バーの背景色をHeaderと統一

### DIFF
--- a/apps/docs/src/layouts/locale-layout.tsx
+++ b/apps/docs/src/layouts/locale-layout.tsx
@@ -84,7 +84,7 @@ function LayoutContent() {
             <Navigation />
             <Separator color="mute" />
             <div className="lg:hidden">
-              <div className="flex items-center px-4 py-2">
+              <div className="flex items-center bg-bg-surface px-4 py-2">
                 <IconButton
                   label={t('sideNav.openNavigation')}
                   onClick={() => setIsDrawerOpen(true)}


### PR DESCRIPTION
## Summary
- small画面でサイドナビゲーションを開くボタンのバーに`bg-bg-surface`を追加し、Headerと同じ背景色に統一

## Test plan
- [ ] small画面でコンポーネントページを開き、サイドバー開閉バーがHeaderと同じ色になっていることを確認