### PR TITLE
feat(pagination): Paginationコンポーネントを追加

### DIFF
--- a/.changeset/pagination.md
+++ b/.changeset/pagination.md
@@ -1,0 +1,15 @@
+---
+'@k8o/arte-odyssey': minor
+---
+
+Pagination コンポーネントを追加
+
+前後ページ移動と現在位置 (`4 / 10`) を示すミニマルなページネーション。Button (`variant="skeleton" color="gray"`) ベースで実装し、他のナビゲーションコンポーネントと視覚的に統一。
+
+```tsx
+<Pagination
+  totalPages={10}
+  currentPage={page}
+  onPageChange={setPage}
+/>
+```

--- a/apps/docs/src/app.tsx
+++ b/apps/docs/src/app.tsx
@@ -10,6 +10,7 @@ import { AvatarPage } from './pages/components/avatar-page';
 import { BadgePage } from './pages/components/badge-page';
 import { BaselineStatusPage } from './pages/components/baseline-status-page';
 import { BreadcrumbPage } from './pages/components/breadcrumb-page';
+import { PaginationPage } from './pages/components/pagination-page';
 import { ButtonPage } from './pages/components/button-page';
 import { CardPage } from './pages/components/card-page';
 import { CheckboxCardPage } from './pages/components/checkbox-card-page';
@@ -274,6 +275,10 @@ const routes: RouteDefinition[] = [
       route({
         path: '/components/breadcrumb',
         component: <BreadcrumbPage />,
+      }),
+      route({
+        path: '/components/pagination',
+        component: <PaginationPage />,
       }),
       route({
         path: '/components/scroll-linked',

--- a/apps/docs/src/data/components-nav.ts
+++ b/apps/docs/src/data/components-nav.ts
@@ -16,6 +16,7 @@ export const componentCategories: NavCategory[] = [
       { name: 'Anchor', path: '/components/anchor' },
       { name: 'Tabs', path: '/components/tabs' },
       { name: 'Breadcrumb', path: '/components/breadcrumb' },
+      { name: 'Pagination', path: '/components/pagination' },
     ],
   },
   {

--- a/apps/docs/src/i18n/messages/en.ts
+++ b/apps/docs/src/i18n/messages/en.ts
@@ -193,6 +193,9 @@ export const en = {
   'components.tabs.defaultSelectedTitle': 'Default Selected',
   'components.breadcrumb.description': 'A breadcrumb navigation component.',
   'components.breadcrumb.sizesTitle': 'Sizes',
+  'components.pagination.description':
+    'A minimal pagination component with prev/next controls and current position indicator.',
+  'components.pagination.disabledTitle': 'Disabled',
   'components.scrollLinked.description': 'A progress bar linked to scroll position.',
   'components.icons.description': 'A catalog of icon components provided by ArteOdyssey.',
   'components.icons.sizesTitle': 'Sizes',

--- a/apps/docs/src/i18n/messages/ja.ts
+++ b/apps/docs/src/i18n/messages/ja.ts
@@ -200,6 +200,9 @@ export const ja = {
   'components.tabs.defaultSelectedTitle': 'デフォルト選択',
   'components.breadcrumb.description': 'ナビゲーションのパンくずリストです。',
   'components.breadcrumb.sizesTitle': 'サイズ',
+  'components.pagination.description':
+    '前後のページ移動と現在位置を示すシンプルなページネーションです。',
+  'components.pagination.disabledTitle': '無効',
   'components.scrollLinked.description': 'スクロール位置に連動するプログレスバーです。',
   'components.icons.description': 'ArteOdysseyが提供するアイコンコンポーネントの一覧です。',
   'components.icons.sizesTitle': 'サイズ',

--- a/apps/docs/src/i18n/types.ts
+++ b/apps/docs/src/i18n/types.ts
@@ -188,6 +188,8 @@ export const MESSAGE_KEYS = [
   'components.tabs.defaultSelectedTitle',
   'components.breadcrumb.description',
   'components.breadcrumb.sizesTitle',
+  'components.pagination.description',
+  'components.pagination.disabledTitle',
   'components.scrollLinked.description',
   'components.icons.description',
   'components.icons.sizesTitle',

--- a/apps/docs/src/pages/components/_previews/pagination-previews.tsx
+++ b/apps/docs/src/pages/components/_previews/pagination-previews.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { Pagination } from '@k8o/arte-odyssey';
+import { useState } from 'react';
+
+export function PaginationPreview() {
+  const [page, setPage] = useState(1);
+  return <Pagination currentPage={page} onPageChange={setPage} totalPages={10} />;
+}
+
+export function PaginationDisabledPreview() {
+  return <Pagination currentPage={3} isDisabled onPageChange={() => {}} totalPages={10} />;
+}

--- a/apps/docs/src/pages/components/pagination-page.tsx
+++ b/apps/docs/src/pages/components/pagination-page.tsx
@@ -1,0 +1,91 @@
+import { Anchor, Heading, Separator } from '@k8o/arte-odyssey';
+import { CodeBlock } from '../../components/code-block';
+import { ComponentPreview } from '../../components/component-preview';
+import type { PropItem } from '../../components/props-table';
+import { PropsTable } from '../../components/props-table';
+import { T } from '../../components/t';
+import { STORYBOOK_URL } from '../../constants';
+import { PaginationDisabledPreview, PaginationPreview } from './_previews/pagination-previews';
+
+const paginationProps: PropItem[] = [
+  { name: 'totalPages', types: ['number'], defaultValue: null },
+  { name: 'currentPage', types: ['number'], defaultValue: null },
+  { name: 'onPageChange', types: ['(page: number) => void'], defaultValue: null },
+  { name: 'isDisabled', types: ['boolean'], defaultValue: 'false' },
+  { name: 'prevLabel', types: ['string'], defaultValue: "'前へ'" },
+  { name: 'nextLabel', types: ['string'], defaultValue: "'次へ'" },
+  { name: 'aria-label', types: ['string'], defaultValue: "'ページネーション'" },
+];
+
+export function PaginationPage() {
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
+      <div className="flex flex-col gap-4">
+        <Heading type="h1">Pagination</Heading>
+        <p className="text-fg-mute text-lg">
+          <T k="components.pagination.description" />
+        </p>
+        <div>
+          <Anchor
+            href={`${STORYBOOK_URL}/?path=/docs/components-navigation-pagination--docs`}
+            openInNewTab
+          >
+            <T k="components.common.storybookLink" />
+          </Anchor>
+        </div>
+      </div>
+      <Separator color="mute" />
+
+      <section className="flex flex-col gap-4">
+        <Heading type="h2">
+          <T k="components.common.importTitle" />
+        </Heading>
+        <CodeBlock code="import { Pagination } from '@k8o/arte-odyssey';" lang="ts" />
+      </section>
+      <Separator color="mute" />
+
+      <section className="flex flex-col gap-8">
+        <div className="flex flex-col gap-4">
+          <Heading type="h2">
+            <T k="components.common.usageTitle" />
+          </Heading>
+          <ComponentPreview
+            code={`const [page, setPage] = useState(1);
+
+<Pagination
+  currentPage={page}
+  onPageChange={setPage}
+  totalPages={10}
+/>`}
+          >
+            <PaginationPreview />
+          </ComponentPreview>
+        </div>
+
+        <div className="flex flex-col gap-4">
+          <Heading type="h3">
+            <T k="components.pagination.disabledTitle" />
+          </Heading>
+          <ComponentPreview
+            code={`<Pagination
+  currentPage={3}
+  isDisabled
+  onPageChange={() => {}}
+  totalPages={10}
+/>`}
+          >
+            <PaginationDisabledPreview />
+          </ComponentPreview>
+        </div>
+      </section>
+      <Separator color="mute" />
+
+      <section className="flex flex-col gap-4">
+        <Heading type="h2">
+          <T k="components.common.propsTitle" />
+        </Heading>
+        <PropsTable items={paginationProps} />
+      </section>
+    </div>
+  );
+}

--- a/packages/arte-odyssey/src/components/index.ts
+++ b/packages/arte-odyssey/src/components/index.ts
@@ -35,6 +35,7 @@ export { ScrollLinked } from './layout/scroll-linked';
 export { Separator } from './layout/separator';
 export { Anchor } from './navigation/anchor';
 export { Breadcrumb } from './navigation/breadcrumb';
+export { Pagination } from './navigation/pagination';
 export { Tabs } from './navigation/tabs';
 export { Dialog } from './overlays/dialog';
 export { Drawer } from './overlays/drawer';

--- a/packages/arte-odyssey/src/components/navigation/pagination/index.ts
+++ b/packages/arte-odyssey/src/components/navigation/pagination/index.ts
@@ -1,0 +1,1 @@
+export { Pagination } from './pagination';

--- a/packages/arte-odyssey/src/components/navigation/pagination/pagination.stories.tsx
+++ b/packages/arte-odyssey/src/components/navigation/pagination/pagination.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { Pagination } from './pagination';
+
+const meta: Meta<typeof Pagination> = {
+  title: 'components/navigation/pagination',
+  component: Pagination,
+};
+
+export default meta;
+type Story = StoryObj<typeof Pagination>;
+
+export const Default: Story = {
+  render: () => {
+    const [page, setPage] = useState(1);
+    return <Pagination currentPage={page} onPageChange={setPage} totalPages={10} />;
+  },
+};
+
+export const Middle: Story = {
+  render: () => {
+    const [page, setPage] = useState(5);
+    return <Pagination currentPage={page} onPageChange={setPage} totalPages={10} />;
+  },
+};
+
+export const Last: Story = {
+  render: () => {
+    const [page, setPage] = useState(10);
+    return <Pagination currentPage={page} onPageChange={setPage} totalPages={10} />;
+  },
+};
+
+export const Disabled: Story = {
+  render: () => <Pagination currentPage={3} isDisabled onPageChange={() => {}} totalPages={10} />,
+};

--- a/packages/arte-odyssey/src/components/navigation/pagination/pagination.tsx
+++ b/packages/arte-odyssey/src/components/navigation/pagination/pagination.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import type { FC } from 'react';
+import { Button } from '../../buttons/button';
+import { ChevronIcon } from '../../icons';
+
+type Props = {
+  totalPages: number;
+  currentPage: number;
+  onPageChange: (page: number) => void;
+  isDisabled?: boolean;
+  prevLabel?: string;
+  nextLabel?: string;
+  'aria-label'?: string;
+};
+
+export const Pagination: FC<Props> = ({
+  totalPages,
+  currentPage,
+  onPageChange,
+  isDisabled = false,
+  prevLabel = '前へ',
+  nextLabel = '次へ',
+  'aria-label': ariaLabel = 'ページネーション',
+}) => {
+  const safeTotal = Math.max(1, totalPages);
+  const safeCurrent = Math.min(Math.max(1, currentPage), safeTotal);
+  const isFirst = safeCurrent <= 1;
+  const isLast = safeCurrent >= safeTotal;
+
+  return (
+    <nav aria-label={ariaLabel}>
+      <div className="flex items-center justify-center gap-2">
+        <Button
+          color="gray"
+          disabled={isDisabled || isFirst}
+          onClick={() => {
+            onPageChange(safeCurrent - 1);
+          }}
+          size="sm"
+          startIcon={<ChevronIcon direction="left" size="sm" />}
+          variant="skeleton"
+        >
+          {prevLabel}
+        </Button>
+        <p
+          aria-current="page"
+          aria-live="polite"
+          className="px-3 text-fg-mute text-sm tabular-nums"
+        >
+          <span className="text-fg-base">{safeCurrent}</span>
+          <span className="mx-1">/</span>
+          <span>{safeTotal}</span>
+        </p>
+        <Button
+          color="gray"
+          disabled={isDisabled || isLast}
+          endIcon={<ChevronIcon direction="right" size="sm" />}
+          onClick={() => {
+            onPageChange(safeCurrent + 1);
+          }}
+          size="sm"
+          variant="skeleton"
+        >
+          {nextLabel}
+        </Button>
+      </div>
+    </nav>
+  );
+};


### PR DESCRIPTION
前後ページ移動と現在位置 (\`4 / 10\`) を示すミニマルなページネーションコンポーネントを追加。Button (\`variant=\"skeleton\" color=\"gray\"\`) ベースで実装し、他のナビゲーションコンポーネントと視覚的に統一。

## API

\`\`\`tsx
<Pagination
  totalPages={10}
  currentPage={page}
  onPageChange={setPage}
/>
\`\`\`

| Prop | Type | Default |
|---|---|---|
| \`totalPages\` | \`number\` | — |
| \`currentPage\` | \`number\` | — |
| \`onPageChange\` | \`(page: number) => void\` | — |
| \`isDisabled\` | \`boolean\` | \`false\` |
| \`prevLabel\` | \`string\` | \`'前へ'\` |
| \`nextLabel\` | \`string\` | \`'次へ'\` |
| \`aria-label\` | \`string\` | \`'ページネーション'\` |

数字ページネーション (\`< 1 ... 4 5 6 ... 10 >\`) は「余白で語る」「詰め込まない」というデザイン哲学に合わないため、まずはシンプル形式のみで MVP。必要になったら \`variant=\"numbered\"\` を後から追加する方針。

## Test plan
- [x] \`pnpm typecheck\`
- [x] Storybook (Default / Middle / Last / Disabled)