### PR TITLE
各コンポーネントのhover・選択状態の色を整理

### DIFF
--- a/.changeset/ui-polish-hover-colors.md
+++ b/.changeset/ui-polish-hover-colors.md
@@ -1,0 +1,12 @@
+---
+'@k8o/arte-odyssey': patch
+---
+
+各コンポーネントのhover・選択状態の色を整理
+
+- Tabs/Accordion: hover時にprimaryカラーを適用
+- CheckboxCard/RadioCard: 選択中カードをprimaryカラーに統一し、hover状態を追加
+- Switch: borderを削除
+- AutoComplete: ドロップダウンの選択・ハイライト状態をprimaryカラーに
+- DropdownMenu/ListBox: hover背景をbg-subtleに統一
+- FormControl: labelとhelperテキストに左余白を追加

--- a/packages/arte-odyssey/src/components/data-display/accordion/accordion-button.tsx
+++ b/packages/arte-odyssey/src/components/data-display/accordion/accordion-button.tsx
@@ -15,8 +15,8 @@ export const AccordionButton: FC<PropsWithChildren> = ({ children }) => {
       aria-controls={`${id}-panel`}
       aria-expanded={open}
       className={cn(
-        'flex w-full cursor-pointer items-center justify-between rounded-md p-4 text-fg-base',
-        'hover:text-primary-fg',
+        'flex w-full cursor-pointer items-center justify-between rounded-md p-4 text-fg-base transition-colors',
+        'hover:bg-primary-bg-subtle hover:text-primary-fg',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-info',
       )}
       id={`${id}-button`}

--- a/packages/arte-odyssey/src/components/form/autocomplete/autocomplete.tsx
+++ b/packages/arte-odyssey/src/components/form/autocomplete/autocomplete.tsx
@@ -219,10 +219,10 @@ export const Autocomplete: FC<Props> = ({
                 return (
                   <li
                     className={cn(
-                      'cursor-pointer px-3 py-2',
-                      selected && 'bg-bg-mute',
-                      selectIndex === idx && !selected && 'bg-bg-emphasize',
-                      selectIndex === idx && selected && 'bg-bg-mute',
+                      'cursor-pointer px-3 py-2 transition-colors',
+                      selected && 'bg-primary-bg-subtle text-primary-fg',
+                      selectIndex === idx && !selected && 'bg-bg-subtle',
+                      selectIndex === idx && selected && 'bg-primary-bg-mute text-primary-fg',
                     )}
                     id={`${id}_option_${option.value}`}
                     key={option.value}

--- a/packages/arte-odyssey/src/components/form/checkbox-card/checkbox-card.tsx
+++ b/packages/arte-odyssey/src/components/form/checkbox-card/checkbox-card.tsx
@@ -76,11 +76,10 @@ export const CheckboxCard: FC<Props> = ({
             className={cn(
               'flex w-full min-w-0 rounded-xl border bg-bg-base p-4 text-left transition-colors',
               'has-[input:focus-visible]:outline-hidden has-[input:focus-visible]:ring-2 has-[input:focus-visible]:ring-border-info',
+              checked && 'border-primary-border bg-primary-bg-subtle hover:bg-primary-bg-mute',
               isInvalid
                 ? 'border-border-error'
-                : checked
-                  ? 'border-border-base hover:bg-bg-mute'
-                  : 'border-border-mute hover:bg-bg-mute',
+                : !checked && 'border-border-mute hover:bg-bg-subtle',
               disabled && 'cursor-not-allowed border-border-mute bg-bg-subtle text-fg-mute',
             )}
             id={optionId}

--- a/packages/arte-odyssey/src/components/form/form-control/form-control.tsx
+++ b/packages/arte-odyssey/src/components/form/form-control/form-control.tsx
@@ -37,12 +37,16 @@ export const FormControl: FC<FormControlProps> = ({
   return (
     <fieldset className="flex w-full flex-col">
       {labelAs === 'label' ? (
-        <label className="mb-1 flex gap-2 font-bold text-fg-base text-md" htmlFor={id} id={labelId}>
+        <label
+          className="mb-1 flex gap-2 pl-0.5 font-bold text-fg-base text-md"
+          htmlFor={id}
+          id={labelId}
+        >
           {label}
           {isRequired && <span className="font-medium text-fg-error">必須</span>}
         </label>
       ) : (
-        <legend className="mb-1 flex gap-2 font-bold text-fg-base text-md">
+        <legend className="mb-1 flex gap-2 pl-0.5 font-bold text-fg-base text-md">
           {label}
           {isRequired && <span className="font-medium text-fg-error">必須</span>}
         </legend>
@@ -56,12 +60,12 @@ export const FormControl: FC<FormControlProps> = ({
         isRequired,
       })}
       {isInvalid && errorText ? (
-        <p aria-live="polite" className="mt-1 text-fg-error text-sm" id={`${id}-feedback`}>
+        <p aria-live="polite" className="mt-1 pl-0.5 text-fg-error text-sm" id={`${id}-feedback`}>
           {errorText}
         </p>
       ) : (
         helpText && (
-          <p className="mt-1 text-fg-mute text-sm" id={`${id}-helptext`}>
+          <p className="mt-1 pl-0.5 text-fg-mute text-sm" id={`${id}-helptext`}>
             {helpText}
           </p>
         )

--- a/packages/arte-odyssey/src/components/form/radio-card/radio-card.tsx
+++ b/packages/arte-odyssey/src/components/form/radio-card/radio-card.tsx
@@ -92,8 +92,10 @@ export const RadioCard: FC<Props> = ({
             className={cn(
               'flex w-full min-w-0 rounded-xl border bg-bg-base p-4 text-left transition-colors',
               'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-border-info',
-              checked && 'border-border-info bg-bg-subtle',
-              isInvalid ? 'border-border-error' : 'border-border-mute hover:bg-bg-mute',
+              checked && 'border-primary-border bg-primary-bg-subtle hover:bg-primary-bg-mute',
+              isInvalid
+                ? 'border-border-error'
+                : !checked && 'border-border-mute hover:bg-bg-subtle',
               disabled && 'cursor-not-allowed border-border-mute bg-bg-subtle text-fg-mute',
             )}
             disabled={disabled}

--- a/packages/arte-odyssey/src/components/form/switch/switch.tsx
+++ b/packages/arte-odyssey/src/components/form/switch/switch.tsx
@@ -80,10 +80,10 @@ export const Switch: FC<Props> = ({
         <span
           aria-hidden={true}
           className={cn(
-            'inline-flex h-7 w-12 items-center rounded-full border transition-colors',
-            isInvalid && 'border-border-error',
-            isSelected ? 'border-border-base bg-primary-bg' : 'border-border-mute bg-bg-mute',
-            isDisabled && 'border-border-mute bg-bg-subtle',
+            'inline-flex h-7 w-12 items-center rounded-full transition-colors',
+            isInvalid && 'ring-2 ring-border-error',
+            isSelected ? 'bg-primary-bg' : 'bg-bg-mute',
+            isDisabled && 'bg-bg-subtle',
             'peer-focus-visible:outline-hidden peer-focus-visible:ring-2 peer-focus-visible:ring-border-info peer-focus-visible:ring-offset-2',
           )}
         >

--- a/packages/arte-odyssey/src/components/navigation/tabs/tabs.tsx
+++ b/packages/arte-odyssey/src/components/navigation/tabs/tabs.tsx
@@ -116,6 +116,7 @@ const Tab: FC<PropsWithChildren<{ id: string }>> = ({ id, children }) => {
       aria-selected={selectedId === id}
       className={cn(
         'relative cursor-pointer rounded-lg p-2 transition-colors',
+        selectedId !== id && 'hover:bg-primary-bg-subtle hover:text-primary-fg',
         'focus-visible:border-transparent focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-border-info',
       )}
       id={`${rootId}-tab-${id}`}

--- a/packages/arte-odyssey/src/components/overlays/dropdown-menu/dropdown-menu.tsx
+++ b/packages/arte-odyssey/src/components/overlays/dropdown-menu/dropdown-menu.tsx
@@ -90,8 +90,8 @@ const Item: FC<{ onClick: MouseEventHandler; label: string }> = ({ label, onClic
     <button
       className={cn(
         'w-full px-2 py-1 text-left transition-colors',
-        'hover:bg-bg-mute',
-        'focus-visible:bg-bg-mute focus-visible:outline-none',
+        'hover:bg-bg-subtle',
+        'focus-visible:bg-bg-subtle focus-visible:outline-none',
       )}
       {...props}
     >

--- a/packages/arte-odyssey/src/components/overlays/list-box/list-box.tsx
+++ b/packages/arte-odyssey/src/components/overlays/list-box/list-box.tsx
@@ -128,8 +128,8 @@ const Item: FC<{
     <button
       className={cn(
         'flex w-full items-center justify-between px-3 py-2 text-left transition-colors',
-        'hover:bg-bg-mute',
-        'focus-visible:border-transparent focus-visible:bg-bg-mute focus-visible:outline-hidden',
+        'hover:bg-bg-subtle',
+        'focus-visible:border-transparent focus-visible:bg-bg-subtle focus-visible:outline-hidden',
       )}
       {...props}
     >


### PR DESCRIPTION
## Summary
- Tabs/Accordion: hover時にprimaryカラーを適用
- CheckboxCard/RadioCard: 選択中カードを `border-primary-border bg-primary-bg-subtle` に統一し、hover状態を追加
- Switch: borderを削除してミニマルな見た目に
- AutoComplete: ドロップダウンの選択・ハイライト状態をprimaryカラーに統一
- DropdownMenu/ListBox: hover背景を `bg-bg-subtle` に統一
- FormControl: labelとhelperテキストに `pl-0.5` の左余白を追加

## Test plan
- [ ] Storybookで各コンポーネントのhover・選択状態を確認
- [ ] ダークモードでの見た目を確認