### PR TITLE
bg-raisedトークンを追加し浮くUIに適用

### DIFF
--- a/.changeset/bg-raised-token.md
+++ b/.changeset/bg-raised-token.md
@@ -1,0 +1,10 @@
+---
+'@k8o/arte-odyssey': minor
+---
+
+bg-raised トークンを追加し浮くUIに適用
+
+- `bg-raised` トークン追加（light: white, dark: gray-800）
+- Card/InteractiveCard: `bg-raised` を適用、secondary variant を削除
+- Modal, Dialog, Tooltip, DropdownMenu, ListBox, AutoComplete: `bg-raised` を適用し border を削除
+- Tooltip: 背景を inverse に変更

--- a/apps/docs/src/i18n/messages/en.ts
+++ b/apps/docs/src/i18n/messages/en.ts
@@ -155,7 +155,6 @@ export const en = {
   'components.badge.variantsTitle': 'Variants',
   'components.badge.interactiveTitle': 'Interactive',
   'components.card.description': 'A card for grouping content.',
-  'components.card.variantsTitle': 'Variants',
   'components.card.widthTitle': 'Width',
   'components.code.description': 'An inline code display component.',
   'components.code.colorDetectionTitle': 'Color Detection',

--- a/apps/docs/src/i18n/messages/ja.ts
+++ b/apps/docs/src/i18n/messages/ja.ts
@@ -160,7 +160,6 @@ export const ja = {
   'components.badge.variantsTitle': 'バリアント',
   'components.badge.interactiveTitle': 'インタラクティブ',
   'components.card.description': 'コンテンツをグループ化するカードです。',
-  'components.card.variantsTitle': 'バリアント',
   'components.card.widthTitle': 'Width',
   'components.code.description': 'インラインコード表示コンポーネントです。',
   'components.code.colorDetectionTitle': 'カラー検出',

--- a/apps/docs/src/i18n/types.ts
+++ b/apps/docs/src/i18n/types.ts
@@ -150,7 +150,6 @@ export const MESSAGE_KEYS = [
   'components.badge.variantsTitle',
   'components.badge.interactiveTitle',
   'components.card.description',
-  'components.card.variantsTitle',
   'components.card.widthTitle',
   'components.code.description',
   'components.code.colorDetectionTitle',

--- a/apps/docs/src/pages/components/_previews/popover-previews.tsx
+++ b/apps/docs/src/pages/components/_previews/popover-previews.tsx
@@ -14,7 +14,7 @@ export function PopoverBasicPreview() {
       />
       <Popover.Content
         renderItem={(props) => (
-          <div className="rounded-lg bg-bg-mute p-4 shadow-md" {...props}>
+          <div className="rounded-lg bg-bg-raised p-4 shadow-md" {...props}>
             <div role="menuitem">Popover content goes here.</div>
           </div>
         )}
@@ -36,7 +36,7 @@ export function PopoverPlacementPreview() {
         />
         <Popover.Content
           renderItem={(props) => (
-            <div className="rounded-lg bg-bg-mute p-4 shadow-md" {...props}>
+            <div className="rounded-lg bg-bg-raised p-4 shadow-md" {...props}>
               <div role="menuitem">Top placement</div>
             </div>
           )}
@@ -52,7 +52,7 @@ export function PopoverPlacementPreview() {
         />
         <Popover.Content
           renderItem={(props) => (
-            <div className="rounded-lg bg-bg-mute p-4 shadow-md" {...props}>
+            <div className="rounded-lg bg-bg-raised p-4 shadow-md" {...props}>
               <div role="menuitem">Right placement</div>
             </div>
           )}
@@ -68,7 +68,7 @@ export function PopoverPlacementPreview() {
         />
         <Popover.Content
           renderItem={(props) => (
-            <div className="rounded-lg bg-bg-mute p-4 shadow-md" {...props}>
+            <div className="rounded-lg bg-bg-raised p-4 shadow-md" {...props}>
               <div role="menuitem">Bottom placement</div>
             </div>
           )}
@@ -84,7 +84,7 @@ export function PopoverPlacementPreview() {
         />
         <Popover.Content
           renderItem={(props) => (
-            <div className="rounded-lg bg-bg-mute p-4 shadow-md" {...props}>
+            <div className="rounded-lg bg-bg-raised p-4 shadow-md" {...props}>
               <div role="menuitem">Left placement</div>
             </div>
           )}

--- a/apps/docs/src/pages/components/card-page.tsx
+++ b/apps/docs/src/pages/components/card-page.tsx
@@ -8,11 +8,6 @@ import { STORYBOOK_URL } from '../../constants';
 
 const cardProps: PropItem[] = [
   {
-    name: 'variant',
-    types: ["'primary'", "'secondary'"],
-    defaultValue: "'primary'",
-  },
-  {
     name: 'width',
     types: ["'full'", "'fit'"],
     defaultValue: "'full'",
@@ -59,28 +54,6 @@ export function CardPage() {
           >
             <Card>
               <div className="p-6">Card content</div>
-            </Card>
-          </ComponentPreview>
-        </div>
-
-        {/* Variants */}
-        <div className="flex flex-col gap-4">
-          <Heading type="h3">
-            <T k="components.card.variantsTitle" />
-          </Heading>
-          <ComponentPreview
-            code={`<Card variant="primary">
-  <div className="p-6">Primary</div>
-</Card>
-<Card variant="secondary">
-  <div className="p-6">Secondary</div>
-</Card>`}
-          >
-            <Card variant="primary">
-              <div className="p-6">Primary</div>
-            </Card>
-            <Card variant="secondary">
-              <div className="p-6">Secondary</div>
             </Card>
           </ComponentPreview>
         </div>

--- a/apps/docs/src/pages/components/popover-page.tsx
+++ b/apps/docs/src/pages/components/popover-page.tsx
@@ -83,7 +83,7 @@ export function PopoverPage() {
   <Popover.Content
     renderItem={(props) => (
       <div
-        className="rounded-lg bg-bg-mute p-4 shadow-md"
+        className="rounded-lg bg-bg-raised p-4 shadow-md"
         {...props}
       >
         <p>Popover content goes here.</p>
@@ -110,7 +110,7 @@ export function PopoverPage() {
   />
   <Popover.Content
     renderItem={(props) => (
-      <div className="rounded-lg bg-bg-mute p-4 shadow-md" {...props}>
+      <div className="rounded-lg bg-bg-raised p-4 shadow-md" {...props}>
         <p>Top placement</p>
       </div>
     )}
@@ -125,7 +125,7 @@ export function PopoverPage() {
   />
   <Popover.Content
     renderItem={(props) => (
-      <div className="rounded-lg bg-bg-mute p-4 shadow-md" {...props}>
+      <div className="rounded-lg bg-bg-raised p-4 shadow-md" {...props}>
         <p>Right placement</p>
       </div>
     )}
@@ -140,7 +140,7 @@ export function PopoverPage() {
   />
   <Popover.Content
     renderItem={(props) => (
-      <div className="rounded-lg bg-bg-mute p-4 shadow-md" {...props}>
+      <div className="rounded-lg bg-bg-raised p-4 shadow-md" {...props}>
         <p>Bottom placement</p>
       </div>
     )}
@@ -155,7 +155,7 @@ export function PopoverPage() {
   />
   <Popover.Content
     renderItem={(props) => (
-      <div className="rounded-lg bg-bg-mute p-4 shadow-md" {...props}>
+      <div className="rounded-lg bg-bg-raised p-4 shadow-md" {...props}>
         <p>Left placement</p>
       </div>
     )}

--- a/apps/docs/src/pages/theming.tsx
+++ b/apps/docs/src/pages/theming.tsx
@@ -229,6 +229,11 @@ const BG_TOKENS: TokenDef[] = [
     dark: { source: 'gray-900' },
   },
   {
+    name: 'bg-raised',
+    light: { source: 'white' },
+    dark: { source: 'gray-800' },
+  },
+  {
     name: 'bg-surface',
     light: { source: 'gray-50' },
     dark: { source: 'gray-950' },

--- a/packages/arte-odyssey/CLAUDE.md
+++ b/packages/arte-odyssey/CLAUDE.md
@@ -76,15 +76,15 @@ No raw color values — always use semantic tokens in Tailwind classes. The toke
 
 ### Token Categories
 
-| Category   | Tokens                                                            | Usage              |
-| ---------- | ----------------------------------------------------------------- | ------------------ |
-| Foreground | `fg-base`, `fg-mute`, `fg-subtle`, `fg-inverse`                   | Text colors        |
-| Background | `bg-base`, `bg-raised`, `bg-subtle`, `bg-mute`, `bg-emphasize`, `bg-inverse` | Surfaces   |
-| Border     | `border-base`, `border-subtle`, `border-mute`, `border-emphasize` | Borders            |
-| Status     | `{fg,bg,border}-{info,success,warning,error}`                     | Semantic status    |
-| Primary    | `primary-{fg,bg,bg-subtle,bg-mute,bg-emphasize,border}`           | Teal accent        |
-| Secondary  | `secondary-{fg,bg,bg-subtle,bg-mute,bg-emphasize,border}`         | Cyan accent        |
-| Group      | `group-{primary,secondary,tertiary,quaternary}`                   | Data visualization |
+| Category   | Tokens                                                                       | Usage              |
+| ---------- | ---------------------------------------------------------------------------- | ------------------ |
+| Foreground | `fg-base`, `fg-mute`, `fg-subtle`, `fg-inverse`                              | Text colors        |
+| Background | `bg-base`, `bg-raised`, `bg-subtle`, `bg-mute`, `bg-emphasize`, `bg-inverse` | Surfaces           |
+| Border     | `border-base`, `border-subtle`, `border-mute`, `border-emphasize`            | Borders            |
+| Status     | `{fg,bg,border}-{info,success,warning,error}`                                | Semantic status    |
+| Primary    | `primary-{fg,bg,bg-subtle,bg-mute,bg-emphasize,border}`                      | Teal accent        |
+| Secondary  | `secondary-{fg,bg,bg-subtle,bg-mute,bg-emphasize,border}`                    | Cyan accent        |
+| Group      | `group-{primary,secondary,tertiary,quaternary}`                              | Data visualization |
 
 ### Dark Mode
 

--- a/packages/arte-odyssey/CLAUDE.md
+++ b/packages/arte-odyssey/CLAUDE.md
@@ -79,7 +79,7 @@ No raw color values — always use semantic tokens in Tailwind classes. The toke
 | Category   | Tokens                                                            | Usage              |
 | ---------- | ----------------------------------------------------------------- | ------------------ |
 | Foreground | `fg-base`, `fg-mute`, `fg-subtle`, `fg-inverse`                   | Text colors        |
-| Background | `bg-base`, `bg-subtle`, `bg-mute`, `bg-emphasize`, `bg-inverse`   | Surfaces           |
+| Background | `bg-base`, `bg-raised`, `bg-subtle`, `bg-mute`, `bg-emphasize`, `bg-inverse` | Surfaces   |
 | Border     | `border-base`, `border-subtle`, `border-mute`, `border-emphasize` | Borders            |
 | Status     | `{fg,bg,border}-{info,success,warning,error}`                     | Semantic status    |
 | Primary    | `primary-{fg,bg,bg-subtle,bg-mute,bg-emphasize,border}`           | Teal accent        |

--- a/packages/arte-odyssey/src/components/data-display/card/card.stories.tsx
+++ b/packages/arte-odyssey/src/components/data-display/card/card.stories.tsx
@@ -25,16 +25,6 @@ export const Primary: Story = {
   ),
 };
 
-export const Secondary: Story = {
-  render: () => (
-    <Card variant="secondary">
-      <div className="p-4">
-        <p className="text-fg-mute">セカンダリバリエーションは背景色が少し暗くなります。</p>
-      </div>
-    </Card>
-  ),
-};
-
 export const Interactive: Story = {
   render: () => (
     <div className="flex flex-col gap-4">

--- a/packages/arte-odyssey/src/components/data-display/card/card.tsx
+++ b/packages/arte-odyssey/src/components/data-display/card/card.tsx
@@ -2,21 +2,15 @@ import type { FC } from 'react';
 import { cn } from './../../../helpers/cn';
 import type { CardProps } from './type';
 
-export const Card: FC<CardProps> = ({
-  children,
-  variant = 'primary',
-  width = 'full',
-  appearance = 'shadow',
-}) => (
+export const Card: FC<CardProps> = ({ children, width = 'full', appearance = 'shadow' }) => (
   <div
     className={cn(
       'rounded-xl',
-      appearance === 'shadow' && 'shadow-sm',
+      appearance === 'shadow' && 'shadow-sm dark:border dark:border-border-mute',
       appearance === 'bordered' && 'border border-border-mute',
       width === 'full' && 'w-full',
       width === 'fit' && 'w-fit',
-      variant === 'primary' && 'bg-bg-base',
-      variant === 'secondary' && 'bg-bg-mute',
+      'bg-bg-raised',
     )}
   >
     {children}

--- a/packages/arte-odyssey/src/components/data-display/card/interactive-card.tsx
+++ b/packages/arte-odyssey/src/components/data-display/card/interactive-card.tsx
@@ -4,19 +4,17 @@ import type { CardProps } from './type';
 
 export const InteractiveCard: FC<CardProps> = ({
   children,
-  variant = 'primary',
   width = 'full',
   appearance = 'shadow',
 }) => (
   <div
     className={cn(
       'rounded-xl transition-transform hover:scale-[1.02] active:scale-[0.98]',
-      appearance === 'shadow' && 'shadow-sm',
+      appearance === 'shadow' && 'shadow-sm dark:border dark:border-border-mute',
       appearance === 'bordered' && 'border border-border-mute',
       width === 'full' && 'w-full',
       width === 'fit' && 'w-fit',
-      variant === 'primary' && 'bg-bg-base',
-      variant === 'secondary' && 'bg-bg-mute',
+      'bg-bg-raised',
     )}
   >
     {children}

--- a/packages/arte-odyssey/src/components/data-display/card/type.ts
+++ b/packages/arte-odyssey/src/components/data-display/card/type.ts
@@ -1,7 +1,6 @@
 import type { PropsWithChildren } from 'react';
 
 export type CardProps = PropsWithChildren<{
-  variant?: 'primary' | 'secondary';
   width?: 'full' | 'fit';
   appearance?: 'shadow' | 'bordered';
 }>;

--- a/packages/arte-odyssey/src/components/form/autocomplete/autocomplete.tsx
+++ b/packages/arte-odyssey/src/components/form/autocomplete/autocomplete.tsx
@@ -209,7 +209,7 @@ export const Autocomplete: FC<Props> = ({
       <div className="relative w-full">
         {open && (
           <div
-            className="absolute top-1 z-10 w-full rounded-xl border border-border-mute bg-bg-base shadow-md"
+            className="absolute top-1 z-10 w-full rounded-xl bg-bg-raised shadow-md"
             role="presentation"
           >
             <ul className="max-h-96 py-2" id={`${id}_listbox`}>

--- a/packages/arte-odyssey/src/components/overlays/dialog/dialog.tsx
+++ b/packages/arte-odyssey/src/components/overlays/dialog/dialog.tsx
@@ -32,7 +32,7 @@ const Root: FC<
     <section
       aria-describedby={`${rootId}-content`}
       aria-labelledby={`${rootId}-header`}
-      className="relative w-full rounded-lg border border-border-mute bg-bg-base shadow-md"
+      className="relative w-full rounded-lg bg-bg-raised shadow-md"
       id={id}
       ref={ref}
       role={role}

--- a/packages/arte-odyssey/src/components/overlays/dropdown-menu/dropdown-menu.tsx
+++ b/packages/arte-odyssey/src/components/overlays/dropdown-menu/dropdown-menu.tsx
@@ -73,7 +73,7 @@ const Content: FC<PropsWithChildren> = ({ children }) => {
           <div
             {...props}
             {...contentProps}
-            className="flex min-w-40 flex-col rounded-lg border border-border-mute bg-bg-base py-2 shadow-md"
+            className="flex min-w-40 flex-col rounded-lg bg-bg-raised py-2 shadow-md"
           >
             {children}
           </div>

--- a/packages/arte-odyssey/src/components/overlays/list-box/list-box.tsx
+++ b/packages/arte-odyssey/src/components/overlays/list-box/list-box.tsx
@@ -105,7 +105,7 @@ const Content: FC<{
           <div
             {...props}
             {...contentProps}
-            className="flex max-h-48 min-w-40 flex-col overflow-y-auto rounded-lg border border-border-mute bg-bg-base py-2 shadow-md"
+            className="flex max-h-48 min-w-40 flex-col overflow-y-auto rounded-lg bg-bg-raised py-2 shadow-md"
           >
             {helpContent}
             {options.map(({ key, label }, idx) => (

--- a/packages/arte-odyssey/src/components/overlays/modal/modal.tsx
+++ b/packages/arte-odyssey/src/components/overlays/modal/modal.tsx
@@ -133,11 +133,11 @@ export const Modal: FC<
     <motion.dialog
       animate={realDialogOpen ? 'open' : 'closed'}
       className={cn(
-        'border-border-mute bg-bg-base text-fg-base shadow-md backdrop:bg-back-drop',
-        type === 'center' && 'm-auto max-h-lg w-5/6 max-w-2xl rounded-lg dark:border',
-        type === 'bottom' && 'mt-auto w-screen max-w-screen rounded-t-lg dark:border-t',
-        type === 'right' && 'ml-auto h-svh max-h-none w-screen max-w-sm rounded-l-lg dark:border-l',
-        type === 'left' && 'mr-auto h-svh max-h-none w-screen max-w-sm rounded-r-lg dark:border-r',
+        'bg-bg-raised text-fg-base shadow-md backdrop:bg-back-drop',
+        type === 'center' && 'm-auto max-h-lg w-5/6 max-w-2xl rounded-lg',
+        type === 'bottom' && 'mt-auto w-screen max-w-screen rounded-t-lg',
+        type === 'right' && 'ml-auto h-svh max-h-none w-screen max-w-sm rounded-l-lg',
+        type === 'left' && 'mr-auto h-svh max-h-none w-screen max-w-sm rounded-r-lg',
       )}
       exit="closed"
       initial="closed"

--- a/packages/arte-odyssey/src/components/overlays/popover/popover.stories.tsx
+++ b/packages/arte-odyssey/src/components/overlays/popover/popover.stories.tsx
@@ -32,7 +32,7 @@ export const Default: Story = {
       />
       <Popover.Content
         renderItem={(props) => (
-          <div className="rounded-lg bg-bg-mute p-4 shadow-md" {...props}>
+          <div className="rounded-lg bg-bg-raised p-4 shadow-md" {...props}>
             <div role="menuitem">ポップオーバーのコンテンツ</div>
           </div>
         )}

--- a/packages/arte-odyssey/src/components/overlays/tooltip/tooltip.tsx
+++ b/packages/arte-odyssey/src/components/overlays/tooltip/tooltip.tsx
@@ -51,7 +51,7 @@ const Content: FC<PropsWithChildren> = ({ children }) => {
         },
       }}
       renderItem={(props) => (
-        <div {...props} className="rounded-lg bg-bg-raised px-4 py-2 shadow-md">
+        <div {...props} className="rounded-lg bg-bg-inverse px-4 py-2 text-fg-inverse shadow-md">
           {children}
         </div>
       )}

--- a/packages/arte-odyssey/src/components/overlays/tooltip/tooltip.tsx
+++ b/packages/arte-odyssey/src/components/overlays/tooltip/tooltip.tsx
@@ -51,10 +51,7 @@ const Content: FC<PropsWithChildren> = ({ children }) => {
         },
       }}
       renderItem={(props) => (
-        <div
-          {...props}
-          className="rounded-lg border border-border-mute bg-bg-base px-4 py-2 shadow-md"
-        >
+        <div {...props} className="rounded-lg bg-bg-raised px-4 py-2 shadow-md">
           {children}
         </div>
       )}

--- a/packages/arte-odyssey/src/styles/index.css
+++ b/packages/arte-odyssey/src/styles/index.css
@@ -222,6 +222,7 @@
   --fg-error: var(--red-800);
 
   --bg-base: var(--white);
+  --bg-raised: var(--white);
   --bg-surface: var(--gray-50);
   --bg-subtle: var(--gray-100);
   --bg-mute: var(--gray-200);
@@ -275,6 +276,7 @@
   --fg-error: var(--red-200);
 
   --bg-base: var(--gray-900);
+  --bg-raised: var(--gray-800);
   --bg-surface: var(--gray-950);
   --bg-subtle: var(--gray-800);
   --bg-mute: var(--gray-700);
@@ -328,6 +330,7 @@
   --color-fg-error: var(--fg-error);
 
   --color-bg-base: var(--bg-base);
+  --color-bg-raised: var(--bg-raised);
   --color-bg-surface: var(--bg-surface);
   --color-bg-subtle: var(--bg-subtle);
   --color-bg-mute: var(--bg-mute);


### PR DESCRIPTION
## Summary
- `bg-raised` トークンを追加（light: white, dark: gray-800）。dark modeで浮くUIがページ背景と分離するための階層トークン
- Card/InteractiveCard: `bg-raised` を適用、shadow時は `dark:border` で補助。未使用の secondary variant を削除
- Modal, Dialog, Tooltip, DropdownMenu, ListBox, AutoComplete dropdown: `bg-raised` を適用し border を削除
- Tooltip: 背景を `bg-inverse` に変更
- Popover の examples/docs で Content 背景を `bg-raised` に統一

## Test plan
- [ ] Storybookで Card, Modal, Dialog, Tooltip, DropdownMenu, ListBox, AutoComplete, Popover を確認
- [ ] dark modeで浮くUIがページ背景から分離されていることを確認
- [ ] light modeで見た目に変化がないことを確認