### PR TITLE
fix(card): ダークモードでカードが浮きすぎる問題を修正

### DIFF
--- a/.changeset/card-bg-base.md
+++ b/.changeset/card-bg-base.md
@@ -1,0 +1,9 @@
+---
+'@k8o/arte-odyssey': patch
+---
+
+### Card / InteractiveCard
+
+- 背景色を `bg-raised` から `bg-base` に変更
+- ダークモードの `dark:border` を削除
+  - カードが背景に馴染み、コンテンツが主役になるように

--- a/packages/arte-odyssey/src/components/data-display/card/card.tsx
+++ b/packages/arte-odyssey/src/components/data-display/card/card.tsx
@@ -6,11 +6,11 @@ export const Card: FC<CardProps> = ({ children, width = 'full', appearance = 'sh
   <div
     className={cn(
       'rounded-xl',
-      appearance === 'shadow' && 'shadow-sm dark:border dark:border-border-mute',
+      appearance === 'shadow' && 'shadow-sm',
       appearance === 'bordered' && 'border border-border-mute',
       width === 'full' && 'w-full',
       width === 'fit' && 'w-fit',
-      'bg-bg-raised',
+      'bg-bg-base',
     )}
   >
     {children}

--- a/packages/arte-odyssey/src/components/data-display/card/interactive-card.tsx
+++ b/packages/arte-odyssey/src/components/data-display/card/interactive-card.tsx
@@ -10,11 +10,11 @@ export const InteractiveCard: FC<CardProps> = ({
   <div
     className={cn(
       'rounded-xl transition-transform hover:scale-[1.02] active:scale-[0.98]',
-      appearance === 'shadow' && 'shadow-sm dark:border dark:border-border-mute',
+      appearance === 'shadow' && 'shadow-sm',
       appearance === 'bordered' && 'border border-border-mute',
       width === 'full' && 'w-full',
       width === 'fit' && 'w-fit',
-      'bg-bg-raised',
+      'bg-bg-base',
     )}
   >
     {children}


### PR DESCRIPTION
## Summary
- Card / InteractiveCard の背景色を `bg-raised` から `bg-base` に変更
- shadow appearanceの `dark:border` を削除
- ダークモードでカードが背景に馴染み、コンテンツが主役になるように

## Test plan
- [ ] ダークモードでカードが背景と同化し、borderなしで表示されること
- [ ] ライトモードでは見た目が変わらないこと（bg-raised/bg-baseともに白）
- [ ] InteractiveCardのhover/activeアニメーションが正常に動作すること