### PR TITLE
fix(toast): Toastの同時表示数を最大5つに制限

### DIFF
--- a/.changeset/toast-max-limit.md
+++ b/.changeset/toast-max-limit.md
@@ -1,0 +1,5 @@
+---
+'@k8o/arte-odyssey': patch
+---
+
+Toastの同時表示数を最大5つに制限

--- a/packages/arte-odyssey/src/components/feedback/toast/provider.tsx
+++ b/packages/arte-odyssey/src/components/feedback/toast/provider.tsx
@@ -38,7 +38,7 @@ export const useToast = () => {
   const onOpen = useCallback(
     (status: Status, message: string) => {
       setToasts((prev) => [
-        ...prev,
+        ...prev.slice(-4),
         {
           id: uuidV4(),
           status,


### PR DESCRIPTION
## Summary
- Toastの同時表示数を最大5つに制限
- 6つ目以降のToastが追加されると、最も古いものから自動的に削除される

## Test plan
- [ ] Toastを5つまで表示できることを確認
- [ ] 6つ目のToastを追加すると最も古いものが消えることを確認