### PR TITLE
fix: Textarea・BaselineStatus・Modalの修正とTODO解消

### DIFF
--- a/.changeset/fix-component-improvements.md
+++ b/.changeset/fix-component-improvements.md
@@ -1,0 +1,9 @@
+---
+"@k8o/arte-odyssey": patch
+---
+
+fix: Textarea・BaselineStatus・Modalの修正
+
+- Textarea: autoResizeのuseEffectに依存配列を追加し、onInputハンドラでuncontrolled対応
+- BaselineStatus: スケルトンの高さをレスポンシブ対応しCLS軽減
+- Modal: MutationObserverで外部ref操作時のstate同期を実装

--- a/packages/arte-odyssey/src/components/data-display/baseline-status/baseline-status.tsx
+++ b/packages/arte-odyssey/src/components/data-display/baseline-status/baseline-status.tsx
@@ -32,12 +32,8 @@ export const BaselineStatus: FC<{ featureId: string }> = ({ featureId }) => {
   );
 
   if (!isLoad) {
-    // TODO: レスポンシブな見た目に対応する
     return (
-      <div
-        className="max-w-full animate-pulse rounded-lg border border-border-base bg-bg-base p-4"
-        style={{ height: '120px' }}
-      />
+      <div className="h-58 max-w-full animate-pulse rounded-lg border border-border-base bg-bg-base p-4 sm:h-40 md:h-30" />
     );
   }
 

--- a/packages/arte-odyssey/src/components/form/textarea/textarea.tsx
+++ b/packages/arte-odyssey/src/components/form/textarea/textarea.tsx
@@ -30,6 +30,11 @@ type UncontrolledProps = {
 
 type Props = BaseProps & (ControlledProps | UncontrolledProps);
 
+const resizeToContent = (el: HTMLTextAreaElement) => {
+  el.style.height = 'auto';
+  el.style.height = `${el.scrollHeight.toString()}px`;
+};
+
 export const Textarea: FC<Props> = ({
   id,
   name,
@@ -49,8 +54,7 @@ export const Textarea: FC<Props> = ({
 
   useEffect(() => {
     if (ref.current && autoResize) {
-      ref.current.style.height = 'auto';
-      ref.current.style.height = `${ref.current.scrollHeight.toString()}px`;
+      resizeToContent(ref.current);
     }
   }, [autoResize, value]);
 
@@ -73,8 +77,7 @@ export const Textarea: FC<Props> = ({
       onChange={onChange}
       onInput={(e) => {
         if (autoResize) {
-          e.currentTarget.style.height = 'auto';
-          e.currentTarget.style.height = `${e.currentTarget.scrollHeight.toString()}px`;
+          resizeToContent(e.currentTarget);
         }
       }}
       onKeyDown={(e) => {

--- a/packages/arte-odyssey/src/components/form/textarea/textarea.tsx
+++ b/packages/arte-odyssey/src/components/form/textarea/textarea.tsx
@@ -52,7 +52,8 @@ export const Textarea: FC<Props> = ({
       ref.current.style.height = 'auto';
       ref.current.style.height = `${ref.current.scrollHeight.toString()}px`;
     }
-  });
+  }, [autoResize, value]);
+
   return (
     <textarea
       aria-describedby={describedbyId}
@@ -70,6 +71,12 @@ export const Textarea: FC<Props> = ({
       id={id}
       name={name}
       onChange={onChange}
+      onInput={(e) => {
+        if (autoResize) {
+          e.currentTarget.style.height = 'auto';
+          e.currentTarget.style.height = `${e.currentTarget.scrollHeight.toString()}px`;
+        }
+      }}
       onKeyDown={(e) => {
         e.stopPropagation();
       }}

--- a/packages/arte-odyssey/src/components/overlays/modal/modal.stories.tsx
+++ b/packages/arte-odyssey/src/components/overlays/modal/modal.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { fn } from 'storybook/test';
+import { useRef } from 'react';
+import { expect, fn, waitFor } from 'storybook/test';
+import { Button } from '../../buttons/button';
 import { Dialog } from '../dialog';
 import { Modal } from './modal';
 
@@ -22,6 +24,59 @@ export const Default: Story = {
         </Dialog.Content>
       </Dialog.Root>
     ),
+  },
+  parameters: {
+    a11y: {
+      options: {
+        rules: {
+          'color-contrast': { enabled: false },
+        },
+      },
+    },
+  },
+};
+
+export const ExternalRefControl: Story = {
+  render: () => {
+    const ref = useRef<HTMLDialogElement>(null);
+    return (
+      <>
+        <Button
+          onClick={() => {
+            ref.current?.showModal();
+          }}
+          size="md"
+          type="button"
+        >
+          開く
+        </Button>
+        <Modal ref={ref} type="center">
+          <Dialog.Root>
+            <Dialog.Header
+              onClose={() => {
+                ref.current?.close();
+              }}
+              title="外部ref制御"
+            />
+            <Dialog.Content>
+              <p>ref.current.showModal() から開かれました</p>
+            </Dialog.Content>
+          </Dialog.Root>
+        </Modal>
+      </>
+    );
+  },
+  play: async ({ canvas, userEvent }) => {
+    const trigger = canvas.getByRole('button', { name: '開く' });
+    await userEvent.click(trigger);
+    await waitFor(() => {
+      const dialog = canvas.getAllByRole('dialog')[0];
+      expect(dialog).toBeInstanceOf(HTMLDialogElement);
+      expect(dialog?.hasAttribute('open')).toBe(true);
+      if (getComputedStyle(dialog as Element).opacity !== '1') {
+        throw new Error('waiting for animation');
+      }
+    });
   },
   parameters: {
     a11y: {

--- a/packages/arte-odyssey/src/components/overlays/modal/modal.tsx
+++ b/packages/arte-odyssey/src/components/overlays/modal/modal.tsx
@@ -112,21 +112,16 @@ export const Modal: FC<
   const realRef = ref ?? dialogRef;
 
   useEffect(() => {
-    if (realDialogOpen === realRef.current?.open) {
+    const dialog = realRef.current;
+    if (!dialog || realDialogOpen === dialog.open) {
       return;
     }
     if (realDialogOpen) {
-      realRef.current?.showModal();
+      dialog.showModal();
     } else {
-      realRef.current?.close();
+      dialog.close();
     }
-  }, [
-    realDialogOpen,
-    realRef.current?.close,
-    realRef.current?.open,
-    realRef.current?.showModal,
-    realRef.current,
-  ]);
+  }, [realDialogOpen, realRef]);
 
   useEffect(() => {
     const dialog = realRef.current;

--- a/packages/arte-odyssey/src/components/overlays/modal/modal.tsx
+++ b/packages/arte-odyssey/src/components/overlays/modal/modal.tsx
@@ -91,7 +91,6 @@ const leftVariants: Variants = {
 
 export const Modal: FC<
   PropsWithChildren<{
-    // TODO: 外部のref.current.showModal()にrealDialogOpenが追従するようにする
     ref?: RefObject<HTMLDialogElement | null>;
     type?: 'center' | 'bottom' | 'right' | 'left';
     defaultOpen?: boolean;
@@ -128,6 +127,19 @@ export const Modal: FC<
     realRef.current?.showModal,
     realRef.current,
   ]);
+
+  useEffect(() => {
+    const dialog = realRef.current;
+    if (!dialog || isOpen !== undefined) return;
+
+    const observer = new MutationObserver(() => {
+      setDialogOpen(dialog.open);
+    });
+    observer.observe(dialog, { attributes: true, attributeFilter: ['open'] });
+    return () => {
+      observer.disconnect();
+    };
+  }, [isOpen, realRef]);
 
   return (
     <motion.dialog


### PR DESCRIPTION
## Summary
- **Textarea**: `autoResize`の`useEffect`に依存配列がなく毎レンダー実行されていた問題を修正。`[autoResize, value]`を指定し、uncontrolled時は`onInput`ハンドラで対応
- **BaselineStatus**: スケルトンの高さを固定120pxからレスポンシブ3段階（mobile: 232px / sm: 160px / md: 120px）に変更し、CLS軽減
- **Modal**: `MutationObserver`で`open`属性を監視し、外部から`ref.current.showModal()`が呼ばれた場合にもReact stateとアニメーションが追従するよう修正（TODOコメント解消）

## Test plan
- [x] `pnpm typecheck` パス
- [x] `pnpm check` パス（error 0）
- [x] `pnpm test` 全309テストパス
- [x] BaselineStatusのスケルトン高さを実測値と照合済み（Storybook + Chrome DevTools）