### PR TITLE
ci: use k8o bot token for changesets action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,17 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.K35O_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.K35O_BOT_PRIVATE_KEY }}
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          persist-credentials: false
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Install
         uses: ./.github/composite-actions/install
@@ -33,4 +40,4 @@ jobs:
         with:
           publish: pnpm release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
## Summary

- Swap `secrets.GITHUB_TOKEN` for a token minted from the `k8o` GitHub App so changesets commits/PRs come from the bot instead of `github-actions[bot]` and ship as verified, signed commits
- Mirror the `actions/create-github-app-token` pattern already used in `k35o/k8o`'s Renovate workflow
- Drop `persist-credentials: false` on checkout: `changesets/action` calls `git push` directly, so the persisted credential is required

## Test plan

- [ ] Merge and confirm the next `Version Packages` PR is opened by `k8o[bot]` with a verified signature