### PR TITLE
feat: add Tooltip to IconButton and IconLink

### DIFF
--- a/.changeset/icon-button-link-tooltip.md
+++ b/.changeset/icon-button-link-tooltip.md
@@ -4,8 +4,29 @@
 
 `IconButton` と `IconLink` にホバー/フォーカス時の `Tooltip` を内蔵し、`label` を視覚的にも確認できるようにした。
 
-- `IconLink` の `label` を必須化（旧: optional）
-- `IconLink` の `renderAnchor` シグネチャに `aria-label` / `aria-describedby` / `ref` / `onMouseEnter` / `onMouseLeave` / `onFocus` / `onBlur` を追加。カスタム `renderAnchor` を提供している場合はこれらを `<a>` にスプレッドする必要がある
+### Breaking changes
+
+- **`IconLink` の `label` を必須化**（旧: optional）
+- **`IconLink` の `renderAnchor` シグネチャを変更**: 旧来の `{ href, className, target, rel, children }` に加えて `'aria-label': string` と `triggerProps: IconLinkTriggerProps`（Tooltip 連携用の `ref` / `aria-describedby` / mouse・focus handlers）を渡すようになった。カスタム `renderAnchor` を提供している場合は `triggerProps` を `<a>` にスプレッドする必要がある:
+
+  ```tsx
+  // Before
+  renderAnchor={(props) => <a {...props}>{props.children}</a>}
+
+  // After
+  renderAnchor={({ triggerProps, children, ...rest }) => (
+    <a {...rest} {...triggerProps}>{children}</a>
+  )}
+  ```
+
+- **`IconLink` が client component になった**（`'use client'` 追加）。Tooltip 内蔵に伴う変更で、React Server Component として render できなくなる。Tooltip 不要なら `tooltipDisabled` を指定しても client 化は避けられない点に注意。
+
+### Additions
+
 - 別の Popover のトリガーとして使う場合（`DropdownMenu.IconTrigger` / `ListBox.IconTrigger` など）に Tooltip を抑止できる `tooltipDisabled` prop を追加
-- Tooltip の表示位置を制御する `tooltipPlacement` prop を追加（デフォルト `bottom`）
-- 内部修正: `Popover` の `tooltip` タイプにおいて `aria-describedby` が存在しない ID を参照していたバグを修正
+- Tooltip の表示位置を制御する `tooltipPlacement` prop を追加（デフォルト `'bottom'`、`Tooltip.Root` のデフォルト `'bottom-start'` とは異なる）
+- ユーザーが `aria-describedby` を渡した場合、Tooltip の describedby とスペース区切りでマージされるようになった
+
+### Internal fixes
+
+- `Popover` の `tooltip` タイプにおいて `aria-describedby` が存在しない `_content` ID を参照していたバグを `_list` に修正、加えて `isOpen` 時のみ set する形に変更

--- a/.changeset/icon-button-link-tooltip.md
+++ b/.changeset/icon-button-link-tooltip.md
@@ -1,0 +1,11 @@
+---
+'@k8o/arte-odyssey': major
+---
+
+`IconButton` と `IconLink` にホバー/フォーカス時の `Tooltip` を内蔵し、`label` を視覚的にも確認できるようにした。
+
+- `IconLink` の `label` を必須化（旧: optional）
+- `IconLink` の `renderAnchor` シグネチャに `aria-label` / `aria-describedby` / `ref` / `onMouseEnter` / `onMouseLeave` / `onFocus` / `onBlur` を追加。カスタム `renderAnchor` を提供している場合はこれらを `<a>` にスプレッドする必要がある
+- 別の Popover のトリガーとして使う場合（`DropdownMenu.IconTrigger` / `ListBox.IconTrigger` など）に Tooltip を抑止できる `tooltipDisabled` prop を追加
+- Tooltip の表示位置を制御する `tooltipPlacement` prop を追加（デフォルト `bottom`）
+- 内部修正: `Popover` の `tooltip` タイプにおいて `aria-describedby` が存在しない ID を参照していたバグを修正

--- a/apps/docs/src/pages/components/icon-button-page.tsx
+++ b/apps/docs/src/pages/components/icon-button-page.tsx
@@ -26,6 +26,17 @@ const iconButtonProps: PropItem[] = [
   },
   { name: 'label', types: ['string'], defaultValue: null },
   { name: 'disabled', types: ['boolean'], defaultValue: 'false' },
+  {
+    name: 'tooltipPlacement',
+    types: ['Placement'],
+    defaultValue: "'bottom'",
+  },
+  { name: 'tooltipDisabled', types: ['boolean'], defaultValue: 'false' },
+  {
+    name: 'onAction',
+    types: ['() => void | Promise<void>'],
+    defaultValue: null,
+  },
   { name: 'children', types: ['ReactNode'], defaultValue: null },
 ];
 

--- a/apps/docs/src/pages/components/icon-link-page.tsx
+++ b/apps/docs/src/pages/components/icon-link-page.tsx
@@ -27,6 +27,12 @@ const iconLinkProps: PropItem[] = [
   { name: 'label', types: ['string'], defaultValue: null },
   { name: 'href', types: ['string'], defaultValue: null },
   { name: 'openInNewTab', types: ['boolean'], defaultValue: 'false' },
+  {
+    name: 'tooltipPlacement',
+    types: ['Placement'],
+    defaultValue: "'bottom'",
+  },
+  { name: 'tooltipDisabled', types: ['boolean'], defaultValue: 'false' },
   { name: 'renderAnchor', types: ['(props) => ReactNode'], defaultValue: null },
   { name: 'children', types: ['ReactNode'], defaultValue: null },
 ];

--- a/packages/arte-odyssey/src/components/buttons/icon-button/icon-button.tsx
+++ b/packages/arte-odyssey/src/components/buttons/icon-button/icon-button.tsx
@@ -1,26 +1,54 @@
 'use client';
 
-import type { FC, HTMLProps, MouseEvent } from 'react';
+import type { Placement } from '@floating-ui/react';
+import type {
+  FC,
+  FocusEventHandler,
+  HTMLProps,
+  MouseEvent,
+  MouseEventHandler,
+  ReactElement,
+  Ref,
+} from 'react';
 import { useTransition } from 'react';
 import { useFormStatus } from 'react-dom';
 
+import { Tooltip } from '../../overlays/tooltip';
 import { cn } from './../../../helpers/cn';
+import { mergeRefs } from './../../../helpers/merge-refs';
 
 type Props = {
   size?: 'sm' | 'md' | 'lg';
   bg?: 'transparent' | 'base' | 'primary' | 'secondary';
   label: string;
+  tooltipPlacement?: Placement;
+  tooltipDisabled?: boolean;
   onAction?: () => void | Promise<void>;
 } & Omit<HTMLProps<HTMLButtonElement>, 'size' | 'type'>;
+
+type ButtonTriggerProps = {
+  ref: Ref<HTMLButtonElement>;
+  'aria-describedby': string | undefined;
+  onMouseEnter: MouseEventHandler<HTMLButtonElement>;
+  onMouseLeave: MouseEventHandler<HTMLButtonElement>;
+  onFocus: FocusEventHandler<HTMLButtonElement>;
+  onBlur: FocusEventHandler<HTMLButtonElement>;
+};
 
 export const IconButton: FC<Props> = ({
   ref,
   size = 'md',
   bg = 'transparent',
   label,
+  tooltipPlacement = 'bottom',
+  tooltipDisabled = false,
   children,
   onAction,
   onClick,
+  onMouseEnter,
+  onMouseLeave,
+  onFocus,
+  onBlur,
   disabled,
   ...props
 }) => {
@@ -42,39 +70,68 @@ export const IconButton: FC<Props> = ({
         }
       : undefined;
 
-  return (
+  const className = cn(
+    'inline-flex cursor-pointer rounded-full transition-colors',
+    'focus-visible:border-transparent focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-border-info',
+    (bg === 'transparent' || bg === 'base') &&
+      'hover:bg-bg-subtle active:bg-bg-mute',
+    bg === 'base' && 'bg-bg-base',
+    bg === 'transparent' && 'bg-transparent',
+    bg === 'primary' &&
+      'bg-primary-bg hover:bg-primary-bg-emphasize/80 active:bg-primary-bg-emphasize',
+    bg === 'secondary' &&
+      'bg-secondary-bg hover:bg-secondary-bg-emphasize/80 active:bg-secondary-bg-emphasize',
+    size === 'sm' && 'p-1',
+    size === 'md' && 'p-2',
+    size === 'lg' && 'p-3',
+    isDisabled &&
+      'cursor-not-allowed opacity-50 hover:bg-transparent active:bg-transparent',
+  );
+
+  const renderButton = (triggerProps?: ButtonTriggerProps): ReactElement => (
     <button
-      aria-busy={isPending || undefined}
-      aria-label={
-        props.role !== undefined && props.role !== '' ? label : undefined
-      }
-      className={cn(
-        'inline-flex cursor-pointer rounded-full transition-colors',
-        'focus-visible:border-transparent focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-border-info',
-        (bg === 'transparent' || bg === 'base') &&
-          'hover:bg-bg-subtle active:bg-bg-mute',
-        bg === 'base' && 'bg-bg-base',
-        bg === 'transparent' && 'bg-transparent',
-        bg === 'primary' &&
-          'bg-primary-bg hover:bg-primary-bg-emphasize/80 active:bg-primary-bg-emphasize',
-        bg === 'secondary' &&
-          'bg-secondary-bg hover:bg-secondary-bg-emphasize/80 active:bg-secondary-bg-emphasize',
-        size === 'sm' && 'p-1',
-        size === 'md' && 'p-2',
-        size === 'lg' && 'p-3',
-        isDisabled &&
-          'cursor-not-allowed opacity-50 hover:bg-transparent active:bg-transparent',
-      )}
-      disabled={isDisabled}
-      onClick={handleClick}
-      ref={ref}
-      type="button"
       {...props}
+      aria-busy={isPending || undefined}
+      aria-describedby={triggerProps?.['aria-describedby']}
+      aria-label={label}
+      className={className}
+      disabled={isDisabled}
+      onBlur={(e) => {
+        triggerProps?.onBlur(e);
+        onBlur?.(e);
+      }}
+      onClick={handleClick}
+      onFocus={(e) => {
+        triggerProps?.onFocus(e);
+        onFocus?.(e);
+      }}
+      onMouseEnter={(e) => {
+        triggerProps?.onMouseEnter(e);
+        onMouseEnter?.(e);
+      }}
+      onMouseLeave={(e) => {
+        triggerProps?.onMouseLeave(e);
+        onMouseLeave?.(e);
+      }}
+      ref={mergeRefs(ref, triggerProps?.ref)}
+      type="button"
     >
-      {(props.role === undefined || props.role === '') && (
-        <span className="sr-only">{label}</span>
-      )}
       {children}
     </button>
+  );
+
+  if (tooltipDisabled) {
+    return renderButton();
+  }
+
+  return (
+    <Tooltip.Root placement={tooltipPlacement}>
+      <Tooltip.Trigger
+        renderItem={(rawTriggerProps) =>
+          renderButton(rawTriggerProps as unknown as ButtonTriggerProps)
+        }
+      />
+      <Tooltip.Content>{label}</Tooltip.Content>
+    </Tooltip.Root>
   );
 };

--- a/packages/arte-odyssey/src/components/buttons/icon-button/icon-button.tsx
+++ b/packages/arte-odyssey/src/components/buttons/icon-button/icon-button.tsx
@@ -7,7 +7,6 @@ import type {
   HTMLProps,
   MouseEvent,
   MouseEventHandler,
-  ReactElement,
   Ref,
 } from 'react';
 import { useTransition } from 'react';
@@ -35,6 +34,13 @@ type ButtonTriggerProps = {
   onBlur: FocusEventHandler<HTMLButtonElement>;
 };
 
+const joinIds = (
+  ...ids: ReadonlyArray<string | undefined>
+): string | undefined => {
+  const filtered = ids.filter(Boolean);
+  return filtered.length === 0 ? undefined : filtered.join(' ');
+};
+
 export const IconButton: FC<Props> = ({
   ref,
   size = 'md',
@@ -50,6 +56,7 @@ export const IconButton: FC<Props> = ({
   onFocus,
   onBlur,
   disabled,
+  'aria-describedby': describedBy,
   ...props
 }) => {
   const [transitionPending, startTransition] = useTransition();
@@ -88,48 +95,68 @@ export const IconButton: FC<Props> = ({
       'cursor-not-allowed opacity-50 hover:bg-transparent active:bg-transparent',
   );
 
-  const renderButton = (triggerProps?: ButtonTriggerProps): ReactElement => (
-    <button
-      {...props}
-      aria-busy={isPending || undefined}
-      aria-describedby={triggerProps?.['aria-describedby']}
-      aria-label={label}
-      className={className}
-      disabled={isDisabled}
-      onBlur={(e) => {
-        triggerProps?.onBlur(e);
-        onBlur?.(e);
-      }}
-      onClick={handleClick}
-      onFocus={(e) => {
-        triggerProps?.onFocus(e);
-        onFocus?.(e);
-      }}
-      onMouseEnter={(e) => {
-        triggerProps?.onMouseEnter(e);
-        onMouseEnter?.(e);
-      }}
-      onMouseLeave={(e) => {
-        triggerProps?.onMouseLeave(e);
-        onMouseLeave?.(e);
-      }}
-      ref={mergeRefs(ref, triggerProps?.ref)}
-      type="button"
-    >
-      {children}
-    </button>
-  );
-
   if (tooltipDisabled) {
-    return renderButton();
+    return (
+      <button
+        {...props}
+        aria-busy={isPending || undefined}
+        aria-describedby={describedBy}
+        aria-label={label}
+        className={className}
+        disabled={isDisabled}
+        onBlur={onBlur}
+        onClick={handleClick}
+        onFocus={onFocus}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+        ref={ref}
+        type="button"
+      >
+        {children}
+      </button>
+    );
   }
 
   return (
     <Tooltip.Root placement={tooltipPlacement}>
       <Tooltip.Trigger
-        renderItem={(rawTriggerProps) =>
-          renderButton(rawTriggerProps as unknown as ButtonTriggerProps)
-        }
+        renderItem={(rawTriggerProps) => {
+          const triggerProps = rawTriggerProps as unknown as ButtonTriggerProps;
+          return (
+            <button
+              {...props}
+              aria-busy={isPending || undefined}
+              aria-describedby={joinIds(
+                describedBy,
+                triggerProps['aria-describedby'],
+              )}
+              aria-label={label}
+              className={className}
+              disabled={isDisabled}
+              onBlur={(e) => {
+                triggerProps.onBlur(e);
+                onBlur?.(e);
+              }}
+              onClick={handleClick}
+              onFocus={(e) => {
+                triggerProps.onFocus(e);
+                onFocus?.(e);
+              }}
+              onMouseEnter={(e) => {
+                triggerProps.onMouseEnter(e);
+                onMouseEnter?.(e);
+              }}
+              onMouseLeave={(e) => {
+                triggerProps.onMouseLeave(e);
+                onMouseLeave?.(e);
+              }}
+              ref={mergeRefs(ref, triggerProps.ref)}
+              type="button"
+            >
+              {children}
+            </button>
+          );
+        }}
       />
       <Tooltip.Content>{label}</Tooltip.Content>
     </Tooltip.Root>

--- a/packages/arte-odyssey/src/components/buttons/icon-link/icon-link.tsx
+++ b/packages/arte-odyssey/src/components/buttons/icon-link/icon-link.tsx
@@ -13,7 +13,16 @@ import { Tooltip } from '../../overlays/tooltip';
 import { cn } from './../../../helpers/cn';
 import { isInternalRoute } from './../../../helpers/is-internal-route';
 
-type AnchorTriggerProps = {
+export type IconLinkTriggerProps = {
+  ref?: Ref<HTMLAnchorElement>;
+  'aria-describedby'?: string;
+  onMouseEnter?: MouseEventHandler<HTMLAnchorElement>;
+  onMouseLeave?: MouseEventHandler<HTMLAnchorElement>;
+  onFocus?: FocusEventHandler<HTMLAnchorElement>;
+  onBlur?: FocusEventHandler<HTMLAnchorElement>;
+};
+
+type RawTriggerProps = {
   ref: Ref<HTMLAnchorElement>;
   'aria-describedby': string | undefined;
   onMouseEnter: MouseEventHandler<HTMLAnchorElement>;
@@ -31,8 +40,10 @@ export const IconLink = <T extends string>({
   openInNewTab = false,
   tooltipPlacement = 'bottom',
   tooltipDisabled = false,
-  renderAnchor = ({ children: anchorChildren, ...rest }) => (
-    <a {...rest}>{anchorChildren}</a>
+  renderAnchor = ({ children: anchorChildren, triggerProps, ...rest }) => (
+    <a {...rest} {...triggerProps}>
+      {anchorChildren}
+    </a>
   ),
 }: PropsWithChildren<{
   size?: 'sm' | 'md' | 'lg';
@@ -47,14 +58,9 @@ export const IconLink = <T extends string>({
     className: string;
     target?: string;
     rel?: string;
-    children: ReactNode;
     'aria-label': string;
-    'aria-describedby': string | undefined;
-    ref: Ref<HTMLAnchorElement> | undefined;
-    onMouseEnter: MouseEventHandler<HTMLAnchorElement> | undefined;
-    onMouseLeave: MouseEventHandler<HTMLAnchorElement> | undefined;
-    onFocus: FocusEventHandler<HTMLAnchorElement> | undefined;
-    onBlur: FocusEventHandler<HTMLAnchorElement> | undefined;
+    triggerProps: IconLinkTriggerProps;
+    children: ReactNode;
   }) => ReactNode;
 }>) => {
   const type = isInternalRoute(href) && !openInNewTab ? 'internal' : 'external';
@@ -81,33 +87,39 @@ export const IconLink = <T extends string>({
     size === 'lg' && 'p-3',
   );
 
-  const renderAnchorWith = (triggerProps?: AnchorTriggerProps): ReactNode =>
-    renderAnchor({
-      href,
-      className,
-      ...externalProps,
-      'aria-label': label,
-      'aria-describedby': triggerProps?.['aria-describedby'],
-      ref: triggerProps?.ref,
-      onMouseEnter: triggerProps?.onMouseEnter,
-      onMouseLeave: triggerProps?.onMouseLeave,
-      onFocus: triggerProps?.onFocus,
-      onBlur: triggerProps?.onBlur,
-      children,
-    });
-
   if (tooltipDisabled) {
-    return <>{renderAnchorWith()}</>;
+    return (
+      <>
+        {renderAnchor({
+          href,
+          className,
+          ...externalProps,
+          'aria-label': label,
+          triggerProps: {},
+          children,
+        })}
+      </>
+    );
   }
 
   return (
     <Tooltip.Root placement={tooltipPlacement}>
       <Tooltip.Trigger
-        renderItem={(rawTriggerProps) => (
-          <>
-            {renderAnchorWith(rawTriggerProps as unknown as AnchorTriggerProps)}
-          </>
-        )}
+        renderItem={(rawTriggerProps) => {
+          const triggerProps = rawTriggerProps as unknown as RawTriggerProps;
+          return (
+            <>
+              {renderAnchor({
+                href,
+                className,
+                ...externalProps,
+                'aria-label': label,
+                triggerProps,
+                children,
+              })}
+            </>
+          );
+        }}
       />
       <Tooltip.Content>{label}</Tooltip.Content>
     </Tooltip.Root>

--- a/packages/arte-odyssey/src/components/buttons/icon-link/icon-link.tsx
+++ b/packages/arte-odyssey/src/components/buttons/icon-link/icon-link.tsx
@@ -1,7 +1,26 @@
-import type { PropsWithChildren, ReactNode } from 'react';
+'use client';
 
+import type { Placement } from '@floating-ui/react';
+import type {
+  FocusEventHandler,
+  MouseEventHandler,
+  PropsWithChildren,
+  ReactNode,
+  Ref,
+} from 'react';
+
+import { Tooltip } from '../../overlays/tooltip';
 import { cn } from './../../../helpers/cn';
 import { isInternalRoute } from './../../../helpers/is-internal-route';
+
+type AnchorTriggerProps = {
+  ref: Ref<HTMLAnchorElement>;
+  'aria-describedby': string | undefined;
+  onMouseEnter: MouseEventHandler<HTMLAnchorElement>;
+  onMouseLeave: MouseEventHandler<HTMLAnchorElement>;
+  onFocus: FocusEventHandler<HTMLAnchorElement>;
+  onBlur: FocusEventHandler<HTMLAnchorElement>;
+};
 
 export const IconLink = <T extends string>({
   size = 'md',
@@ -10,53 +29,87 @@ export const IconLink = <T extends string>({
   href,
   children,
   openInNewTab = false,
+  tooltipPlacement = 'bottom',
+  tooltipDisabled = false,
   renderAnchor = ({ children: anchorChildren, ...rest }) => (
     <a {...rest}>{anchorChildren}</a>
   ),
 }: PropsWithChildren<{
   size?: 'sm' | 'md' | 'lg';
   bg?: 'transparent' | 'base' | 'primary' | 'secondary';
-  label?: string;
+  label: string;
   href: T;
   openInNewTab?: boolean;
+  tooltipPlacement?: Placement;
+  tooltipDisabled?: boolean;
   renderAnchor?: (props: {
     href: NoInfer<T>;
     className: string;
     target?: string;
     rel?: string;
     children: ReactNode;
+    'aria-label': string;
+    'aria-describedby': string | undefined;
+    ref: Ref<HTMLAnchorElement> | undefined;
+    onMouseEnter: MouseEventHandler<HTMLAnchorElement> | undefined;
+    onMouseLeave: MouseEventHandler<HTMLAnchorElement> | undefined;
+    onFocus: FocusEventHandler<HTMLAnchorElement> | undefined;
+    onBlur: FocusEventHandler<HTMLAnchorElement> | undefined;
   }) => ReactNode;
 }>) => {
   const type = isInternalRoute(href) && !openInNewTab ? 'internal' : 'external';
-  const props =
+  const externalProps =
     type === 'internal'
       ? {}
       : {
           target: '_blank',
           rel: 'noopener noreferrer',
         };
-  return renderAnchor({
-    href,
-    className: cn(
-      'inline-flex rounded-full transition-colors focus-visible:ring-2 focus-visible:ring-border-info',
-      (bg === 'transparent' || bg === 'base') &&
-        'hover:bg-bg-subtle active:bg-bg-mute',
-      bg === 'base' && 'bg-bg-base',
-      bg === 'transparent' && 'bg-transparent',
-      bg === 'primary' &&
-        'bg-primary-bg hover:bg-primary-bg-emphasize/80 active:bg-primary-bg-emphasize',
-      bg === 'secondary' &&
-        'bg-secondary-bg hover:bg-secondary-bg-emphasize/80 active:bg-secondary-bg-emphasize',
-      size === 'sm' && 'p-1',
-      size === 'md' && 'p-2',
-      size === 'lg' && 'p-3',
-    ),
-    ...props,
-    children: (
-      <>
-        <span className="sr-only">{label}</span>
-        {children}
-      </>
-    ),
-  });
+
+  const className = cn(
+    'inline-flex rounded-full transition-colors focus-visible:ring-2 focus-visible:ring-border-info',
+    (bg === 'transparent' || bg === 'base') &&
+      'hover:bg-bg-subtle active:bg-bg-mute',
+    bg === 'base' && 'bg-bg-base',
+    bg === 'transparent' && 'bg-transparent',
+    bg === 'primary' &&
+      'bg-primary-bg hover:bg-primary-bg-emphasize/80 active:bg-primary-bg-emphasize',
+    bg === 'secondary' &&
+      'bg-secondary-bg hover:bg-secondary-bg-emphasize/80 active:bg-secondary-bg-emphasize',
+    size === 'sm' && 'p-1',
+    size === 'md' && 'p-2',
+    size === 'lg' && 'p-3',
+  );
+
+  const renderAnchorWith = (triggerProps?: AnchorTriggerProps): ReactNode =>
+    renderAnchor({
+      href,
+      className,
+      ...externalProps,
+      'aria-label': label,
+      'aria-describedby': triggerProps?.['aria-describedby'],
+      ref: triggerProps?.ref,
+      onMouseEnter: triggerProps?.onMouseEnter,
+      onMouseLeave: triggerProps?.onMouseLeave,
+      onFocus: triggerProps?.onFocus,
+      onBlur: triggerProps?.onBlur,
+      children,
+    });
+
+  if (tooltipDisabled) {
+    return <>{renderAnchorWith()}</>;
+  }
+
+  return (
+    <Tooltip.Root placement={tooltipPlacement}>
+      <Tooltip.Trigger
+        renderItem={(rawTriggerProps) => (
+          <>
+            {renderAnchorWith(rawTriggerProps as unknown as AnchorTriggerProps)}
+          </>
+        )}
+      />
+      <Tooltip.Content>{label}</Tooltip.Content>
+    </Tooltip.Root>
+  );
 };

--- a/packages/arte-odyssey/src/components/overlays/dialog/dialog.tsx
+++ b/packages/arte-odyssey/src/components/overlays/dialog/dialog.tsx
@@ -71,6 +71,7 @@ const Header: FC<{
             e.stopPropagation();
             onClose();
           }}
+          tooltipDisabled
         >
           <CloseIcon size="sm" />
         </IconButton>

--- a/packages/arte-odyssey/src/components/overlays/drawer/drawer.tsx
+++ b/packages/arte-odyssey/src/components/overlays/drawer/drawer.tsx
@@ -47,6 +47,7 @@ export const Drawer: FC<
                 e.stopPropagation();
                 onClose();
               }}
+              tooltipDisabled
             >
               <CloseIcon size="sm" />
             </IconButton>

--- a/packages/arte-odyssey/src/components/overlays/dropdown-menu/dropdown-menu.tsx
+++ b/packages/arte-odyssey/src/components/overlays/dropdown-menu/dropdown-menu.tsx
@@ -144,7 +144,12 @@ const IconTrigger: FC<{
   return (
     <Popover.Trigger
       renderItem={(props) => (
-        <IconButton bg="base" label={label} {...getTriggerProps(props)}>
+        <IconButton
+          bg="base"
+          label={label}
+          tooltipDisabled
+          {...getTriggerProps(props)}
+        >
           {icon}
         </IconButton>
       )}

--- a/packages/arte-odyssey/src/components/overlays/list-box/list-box.tsx
+++ b/packages/arte-odyssey/src/components/overlays/list-box/list-box.tsx
@@ -178,7 +178,12 @@ const TriggerIcon: FC<{
   return (
     <Popover.Trigger
       renderItem={(props) => (
-        <IconButton label={label} size={size} {...getTriggerProps(props)}>
+        <IconButton
+          label={label}
+          size={size}
+          tooltipDisabled
+          {...getTriggerProps(props)}
+        >
           {icon}
         </IconButton>
       )}

--- a/packages/arte-odyssey/src/components/overlays/popover/hooks.ts
+++ b/packages/arte-odyssey/src/components/overlays/popover/hooks.ts
@@ -174,7 +174,7 @@ export const usePopoverTrigger = (): Omit<
           onMouseLeave: popover.onClose,
           onFocus: popover.onOpen,
           onBlur: popover.onClose,
-          'aria-describedby': `${popover.rootId}_content`,
+          'aria-describedby': popover.isOpen ? listId : undefined,
           ref: popover.setTriggerRef,
         };
       case 'menu':

--- a/packages/arte-odyssey/src/helpers/merge-refs.ts
+++ b/packages/arte-odyssey/src/helpers/merge-refs.ts
@@ -1,0 +1,29 @@
+import type { Ref, RefCallback } from 'react';
+
+export const mergeRefs =
+  <T>(...refs: ReadonlyArray<Ref<T> | undefined>): RefCallback<T> =>
+  (value) => {
+    const cleanups: Array<() => void> = [];
+    for (const ref of refs) {
+      if (typeof ref === 'function') {
+        const result = ref(value);
+        if (typeof result === 'function') {
+          cleanups.push(() => {
+            result();
+          });
+        } else {
+          cleanups.push(() => {
+            ref(null);
+          });
+        }
+      } else if (ref !== null && ref !== undefined) {
+        ref.current = value;
+        cleanups.push(() => {
+          ref.current = null;
+        });
+      }
+    }
+    return () => {
+      for (const cleanup of cleanups) cleanup();
+    };
+  };


### PR DESCRIPTION
## 概要

`IconButton` / `IconLink` にホバー・フォーカス時に表示される `Tooltip` を内蔵し、`label` を視覚的にも確認できるようにした。

## 動機

アイコン単体のボタン/リンクは、押下するか読み上げない限り意味が伝わらない。スクリーンリーダーには `aria-label` で意味を伝えられているが、晴眼ユーザー向けにも視覚的な手がかりを提供することでアクセシビリティと UX を底上げしたい。

## 変更内容

### IconButton / IconLink

- `label` を Tooltip テキストと `aria-label` の両方に使う形で内蔵
- `IconLink` の `label` を必須化（旧: optional）
- `IconLink` の `renderAnchor` シグネチャに Tooltip トリガーに必要な props を追加
  - `aria-label` / `aria-describedby` / `ref` / `onMouseEnter` / `onMouseLeave` / `onFocus` / `onBlur`
  - デフォルト実装は `...rest` で全部スプレッドするので影響なし
- `tooltipPlacement` prop を追加（デフォルト `bottom`）
- `tooltipDisabled` prop を追加。別の Popover のトリガーとして使うときに Tooltip を抑止できる
- `IconButton` 内部の `role` 分岐による `aria-label` / `sr-only` 切り替えロジックを廃止し、常に `aria-label` を設定

### 内部修正

- `Popover` の `tooltip` タイプにおいて `aria-describedby` が存在しない `_content` ID を参照していたバグを `_list` に修正
- `DropdownMenu.IconTrigger` / `ListBox` の IconButton トリガーに `tooltipDisabled` を指定し、Tooltip と Popover の同時表示を回避
- `mergeRefs` ヘルパーを追加（ユーザー提供 ref と内部 Tooltip ref のマージ用）

## 気をつけるポイント

- **breaking change**: `IconLink` の `label` 必須化と `renderAnchor` シグネチャ拡張。Next.js の Link 等でカスタム `renderAnchor` を提供している場合は、新フィールドを `<a>` にスプレッドする必要がある（changeset で major bump）
- `tooltipDisabled` を指定し忘れて `IconButton` を Popover トリガーに使うと、Tooltip と Popover が同時に開く UX になる
- Tooltip 内蔵により内部で `Tooltip.Root` がレンダリングされるため、`useId` などの hook 数が増える

## 影響範囲

- `IconButton` / `IconLink` を使うすべての画面（Tooltip がデフォルトで表示されるようになる）
- `DropdownMenu.IconTrigger` / `ListBox` の IconButton トリガー（内部で `tooltipDisabled` 指定）

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm check`
- [x] `pnpm test`（308/308 passed）