### PR TITLE
feat: accept HTMLAttributes on styled element components

### DIFF
--- a/.changeset/styled-element-html-attrs.md
+++ b/.changeset/styled-element-html-attrs.md
@@ -1,0 +1,35 @@
+---
+'@k8o/arte-odyssey': minor
+---
+
+Styled element 系コンポーネントが `HTMLAttributes` を受けるようになった。`id` / `data-*` / `aria-*` / `style` / event handlers / `className` 等が普通に渡せるようになり、テストや analytics の attrs を component 編集なしで追加できる。
+
+### 対象
+
+| Component | 受ける attrs |
+|---|---|
+| `Avatar` | `HTMLAttributes<HTMLSpanElement>` |
+| `Badge` | `HTMLAttributes<HTMLElement>` (interactive モードでは `<button>` に渡る) |
+| `Card` / `InteractiveCard` | `HTMLAttributes<HTMLDivElement>` |
+| `Code` | `HTMLAttributes<HTMLElement>` |
+| `Heading` | `HTMLAttributes<HTMLHeadingElement>` |
+| `Spinner` | `OutputHTMLAttributes<HTMLOutputElement>` |
+| `Skeleton` | `HTMLAttributes<HTMLDivElement>` |
+| `Progress` | `HTMLAttributes<HTMLDivElement>` |
+| `Alert` | `HTMLAttributes<HTMLDivElement>` |
+| `Separator` | `HTMLAttributes<HTMLSpanElement>` |
+| `Anchor` | `AnchorHTMLAttributes<HTMLAnchorElement>` |
+
+`className` を渡した場合はコンポーネント内部の class とマージされる。`role` / `aria-orientation` / `aria-label` (component が責任を持つもの) は `Omit` で除外。
+
+### 例
+
+```tsx
+<Avatar id="user" data-testid="avatar" name="k8o" />
+<Heading id="section-1" type="h2">タイトル</Heading>
+<Card onClick={...} className="custom-class">...</Card>
+```
+
+### Anchor の `renderAnchor` シグネチャ拡張
+
+`renderAnchor` のコールバック引数に `AnchorHTMLAttributes` の rest props が含まれるようになった。デフォルト実装は spread するので影響なし。カスタム `renderAnchor` を提供している場合、追加された attrs を `<a>` (or `<Link>`) にスプレッドし忘れないよう注意。

--- a/apps/docs/src/i18n/messages/en.ts
+++ b/apps/docs/src/i18n/messages/en.ts
@@ -72,7 +72,7 @@ export const en = {
   'components.common.usageTitle': 'Usage',
   'components.common.propsTitle': 'Props',
   'components.common.inheritsLabel':
-    'In addition, the following HTML attributes can be passed:',
+    'Type base (some attrs are managed internally):',
   'components.button.description':
     'A button component that triggers user actions.',
   'components.button.variantsTitle': 'Variants',
@@ -89,6 +89,9 @@ export const en = {
   'components.iconButton.renderItemTitle': 'Render as Link',
   'components.anchor.description': 'A text link component.',
   'components.anchor.openInNewTabTitle': 'Open in New Tab',
+  'components.anchor.renderAnchorTitle': 'Swap element via render prop',
+  'components.anchor.renderAnchorDescription':
+    'Pass renderAnchor to swap the element to a framework-specific anchor (e.g. Next.js Link, react-router Link). Spread all received props onto the replacement element.',
   'components.textField.description': 'A text input field.',
   'components.textField.placeholderTitle': 'Placeholder',
   'components.textField.disabledTitle': 'Disabled',

--- a/apps/docs/src/i18n/messages/ja.ts
+++ b/apps/docs/src/i18n/messages/ja.ts
@@ -71,7 +71,7 @@ export const ja = {
   'components.common.usageTitle': '使い方',
   'components.common.propsTitle': 'Props',
   'components.common.inheritsLabel':
-    'これらに加えて、以下の HTML 属性を渡せます:',
+    '型ベース（内部で固定する一部 attrs は除外）:',
   'components.button.description':
     'ユーザーのアクションを受け付けるボタンコンポーネントです。',
   'components.button.variantsTitle': 'バリアント',
@@ -89,6 +89,9 @@ export const ja = {
   'components.iconButton.renderItemTitle': 'リンクとしてレンダリング',
   'components.anchor.description': 'テキストリンクコンポーネントです。',
   'components.anchor.openInNewTabTitle': '新しいタブで開く',
+  'components.anchor.renderAnchorTitle': 'render prop で要素差し替え',
+  'components.anchor.renderAnchorDescription':
+    'Next.js の Link や react-router の Link など、フレームワーク固有の anchor コンポーネントに差し替えるには renderAnchor を渡してください。受け取った props はすべて差し替え後の要素にスプレッドしてください。',
   'components.textField.description': 'テキスト入力フィールドです。',
   'components.textField.placeholderTitle': 'プレースホルダー',
   'components.textField.disabledTitle': '無効',

--- a/apps/docs/src/i18n/types.ts
+++ b/apps/docs/src/i18n/types.ts
@@ -77,6 +77,8 @@ export const MESSAGE_KEYS = [
   'components.iconButton.renderItemTitle',
   'components.anchor.description',
   'components.anchor.openInNewTabTitle',
+  'components.anchor.renderAnchorTitle',
+  'components.anchor.renderAnchorDescription',
   'components.textField.description',
   'components.textField.placeholderTitle',
   'components.textField.disabledTitle',

--- a/apps/docs/src/pages/components/_previews/button-previews.tsx
+++ b/apps/docs/src/pages/components/_previews/button-previews.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { Button } from '@k8o/arte-odyssey';
+
+export function ButtonAsLinkPreview() {
+  return (
+    <Button
+      renderItem={({ className, children }) => (
+        <a className={className} href="https://example.com">
+          {children}
+        </a>
+      )}
+    >
+      Visit
+    </Button>
+  );
+}

--- a/apps/docs/src/pages/components/_previews/icon-button-previews.tsx
+++ b/apps/docs/src/pages/components/_previews/icon-button-previews.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { CloseIcon, IconButton } from '@k8o/arte-odyssey';
+
+export function IconButtonAsLinkPreview() {
+  return (
+    <IconButton
+      label="Close"
+      renderItem={({
+        className,
+        children,
+        'aria-label': ariaLabel,
+        triggerProps,
+      }) => (
+        <a
+          aria-label={ariaLabel}
+          className={className}
+          href="https://example.com"
+          {...triggerProps}
+        >
+          {children}
+        </a>
+      )}
+    >
+      <CloseIcon size="sm" />
+    </IconButton>
+  );
+}

--- a/apps/docs/src/pages/components/alert-page.tsx
+++ b/apps/docs/src/pages/components/alert-page.tsx
@@ -117,7 +117,10 @@ export function AlertPage() {
         <Heading type="h2">
           <T k="components.common.propsTitle" />
         </Heading>
-        <PropsTable items={alertProps} />
+        <PropsTable
+          inherits="HTMLAttributes<HTMLDivElement>"
+          items={alertProps}
+        />
       </section>
     </div>
   );

--- a/apps/docs/src/pages/components/anchor-page.tsx
+++ b/apps/docs/src/pages/components/anchor-page.tsx
@@ -89,7 +89,10 @@ export function AnchorPage() {
         <Heading type="h2">
           <T k="components.common.propsTitle" />
         </Heading>
-        <PropsTable items={anchorProps} />
+        <PropsTable
+          inherits="AnchorHTMLAttributes<HTMLAnchorElement>"
+          items={anchorProps}
+        />
       </section>
     </div>
   );

--- a/apps/docs/src/pages/components/anchor-page.tsx
+++ b/apps/docs/src/pages/components/anchor-page.tsx
@@ -10,6 +10,11 @@ import { STORYBOOK_URL } from '../../constants';
 const anchorProps: PropItem[] = [
   { name: 'href', types: ['string'], defaultValue: null },
   { name: 'openInNewTab', types: ['boolean'], defaultValue: 'false' },
+  {
+    name: 'renderAnchor',
+    types: ['(props) => ReactNode'],
+    defaultValue: null,
+  },
   { name: 'children', types: ['ReactNode'], defaultValue: null },
 ];
 
@@ -80,6 +85,30 @@ export function AnchorPage() {
               New Tab Link
             </Anchor>
           </ComponentPreview>
+        </div>
+
+        {/* renderAnchor */}
+        <div className="flex flex-col gap-4">
+          <Heading type="h3">
+            <T k="components.anchor.renderAnchorTitle" />
+          </Heading>
+          <p className="text-fg-mute text-sm">
+            <T k="components.anchor.renderAnchorDescription" />
+          </p>
+          <CodeBlock
+            code={`// Next.js の Link で差し替え
+import Link from 'next/link';
+
+<Anchor
+  href="/about"
+  renderAnchor={({ children, ...rest }) => (
+    <Link {...rest}>{children}</Link>
+  )}
+>
+  About
+</Anchor>`}
+            lang="tsx"
+          />
         </div>
       </section>
       <Separator color="mute" />

--- a/apps/docs/src/pages/components/avatar-page.tsx
+++ b/apps/docs/src/pages/components/avatar-page.tsx
@@ -93,7 +93,10 @@ export function AvatarPage() {
         <Heading type="h2">
           <T k="components.common.propsTitle" />
         </Heading>
-        <PropsTable items={avatarProps} />
+        <PropsTable
+          inherits="HTMLAttributes<HTMLSpanElement>"
+          items={avatarProps}
+        />
       </section>
     </div>
   );

--- a/apps/docs/src/pages/components/badge-page.tsx
+++ b/apps/docs/src/pages/components/badge-page.tsx
@@ -150,7 +150,7 @@ export function BadgePage() {
         <Heading type="h2">
           <T k="components.common.propsTitle" />
         </Heading>
-        <PropsTable items={badgeProps} />
+        <PropsTable inherits="HTMLAttributes<HTMLElement>" items={badgeProps} />
       </section>
     </div>
   );

--- a/apps/docs/src/pages/components/button-page.tsx
+++ b/apps/docs/src/pages/components/button-page.tsx
@@ -229,7 +229,10 @@ export function ButtonPage() {
         <Heading type="h2">
           <T k="components.common.propsTitle" />
         </Heading>
-        <PropsTable items={buttonProps} />
+        <PropsTable
+          inherits="ButtonHTMLAttributes<HTMLButtonElement>"
+          items={buttonProps}
+        />
       </section>
     </div>
   );

--- a/apps/docs/src/pages/components/button-page.tsx
+++ b/apps/docs/src/pages/components/button-page.tsx
@@ -13,6 +13,7 @@ import type { PropItem } from '../../components/props-table';
 import { PropsTable } from '../../components/props-table';
 import { T } from '../../components/t';
 import { STORYBOOK_URL } from '../../constants';
+import { ButtonAsLinkPreview } from './_previews/button-previews';
 
 const buttonProps: PropItem[] = [
   {
@@ -210,15 +211,7 @@ export function ButtonPage() {
   Visit
 </Button>`}
           >
-            <Button
-              renderItem={({ className, children }) => (
-                <a className={className} href="https://example.com">
-                  {children}
-                </a>
-              )}
-            >
-              Visit
-            </Button>
+            <ButtonAsLinkPreview />
           </ComponentPreview>
         </div>
       </section>

--- a/apps/docs/src/pages/components/card-page.tsx
+++ b/apps/docs/src/pages/components/card-page.tsx
@@ -93,7 +93,10 @@ export function CardPage() {
         <Heading type="h2">
           <T k="components.common.propsTitle" />
         </Heading>
-        <PropsTable items={cardProps} />
+        <PropsTable
+          inherits="HTMLAttributes<HTMLDivElement>"
+          items={cardProps}
+        />
       </section>
     </div>
   );

--- a/apps/docs/src/pages/components/code-page.tsx
+++ b/apps/docs/src/pages/components/code-page.tsx
@@ -81,7 +81,7 @@ export function CodePage() {
         <Heading type="h2">
           <T k="components.common.propsTitle" />
         </Heading>
-        <PropsTable items={codeProps} />
+        <PropsTable inherits="HTMLAttributes<HTMLElement>" items={codeProps} />
       </section>
     </div>
   );

--- a/apps/docs/src/pages/components/heading-page.tsx
+++ b/apps/docs/src/pages/components/heading-page.tsx
@@ -112,7 +112,10 @@ export function HeadingPage() {
         <Heading type="h2">
           <T k="components.common.propsTitle" />
         </Heading>
-        <PropsTable items={headingProps} />
+        <PropsTable
+          inherits="HTMLAttributes<HTMLHeadingElement>"
+          items={headingProps}
+        />
       </section>
     </div>
   );

--- a/apps/docs/src/pages/components/icon-button-page.tsx
+++ b/apps/docs/src/pages/components/icon-button-page.tsx
@@ -12,6 +12,7 @@ import type { PropItem } from '../../components/props-table';
 import { PropsTable } from '../../components/props-table';
 import { T } from '../../components/t';
 import { STORYBOOK_URL } from '../../constants';
+import { IconButtonAsLinkPreview } from './_previews/icon-button-previews';
 
 const iconButtonProps: PropItem[] = [
   {
@@ -203,26 +204,7 @@ export function IconButtonPage() {
   <CloseIcon size="sm" />
 </IconButton>`}
           >
-            <IconButton
-              label="Close"
-              renderItem={({
-                className,
-                children,
-                'aria-label': ariaLabel,
-                triggerProps,
-              }) => (
-                <a
-                  aria-label={ariaLabel}
-                  className={className}
-                  href="https://example.com"
-                  {...triggerProps}
-                >
-                  {children}
-                </a>
-              )}
-            >
-              <CloseIcon size="sm" />
-            </IconButton>
+            <IconButtonAsLinkPreview />
           </ComponentPreview>
         </div>
       </section>

--- a/apps/docs/src/pages/components/icon-button-page.tsx
+++ b/apps/docs/src/pages/components/icon-button-page.tsx
@@ -233,7 +233,10 @@ export function IconButtonPage() {
         <Heading type="h2">
           <T k="components.common.propsTitle" />
         </Heading>
-        <PropsTable items={iconButtonProps} />
+        <PropsTable
+          inherits="ButtonHTMLAttributes<HTMLButtonElement>"
+          items={iconButtonProps}
+        />
       </section>
     </div>
   );

--- a/apps/docs/src/pages/components/progress-page.tsx
+++ b/apps/docs/src/pages/components/progress-page.tsx
@@ -108,7 +108,10 @@ export function ProgressPage() {
         <Heading type="h2">
           <T k="components.common.propsTitle" />
         </Heading>
-        <PropsTable items={progressProps} />
+        <PropsTable
+          inherits="HTMLAttributes<HTMLDivElement>"
+          items={progressProps}
+        />
       </section>
     </div>
   );

--- a/apps/docs/src/pages/components/separator-page.tsx
+++ b/apps/docs/src/pages/components/separator-page.tsx
@@ -116,7 +116,10 @@ export function SeparatorPage() {
         <Heading type="h2">
           <T k="components.common.propsTitle" />
         </Heading>
-        <PropsTable items={separatorProps} />
+        <PropsTable
+          inherits="HTMLAttributes<HTMLSpanElement>"
+          items={separatorProps}
+        />
       </section>
     </div>
   );

--- a/apps/docs/src/pages/components/skeleton-page.tsx
+++ b/apps/docs/src/pages/components/skeleton-page.tsx
@@ -100,7 +100,10 @@ export function SkeletonPage() {
         <Heading type="h2">
           <T k="components.common.propsTitle" />
         </Heading>
-        <PropsTable items={skeletonProps} />
+        <PropsTable
+          inherits="HTMLAttributes<HTMLDivElement>"
+          items={skeletonProps}
+        />
       </section>
     </div>
   );

--- a/apps/docs/src/pages/components/spinner-page.tsx
+++ b/apps/docs/src/pages/components/spinner-page.tsx
@@ -73,7 +73,10 @@ export function SpinnerPage() {
         <Heading type="h2">
           <T k="components.common.propsTitle" />
         </Heading>
-        <PropsTable items={spinnerProps} />
+        <PropsTable
+          inherits="OutputHTMLAttributes<HTMLOutputElement>"
+          items={spinnerProps}
+        />
       </section>
     </div>
   );

--- a/packages/arte-odyssey/src/components/data-display/avatar/avatar.tsx
+++ b/packages/arte-odyssey/src/components/data-display/avatar/avatar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { FC } from 'react';
+import type { FC, HTMLAttributes } from 'react';
 import { useState } from 'react';
 
 import { cn } from '../../../helpers/cn';
@@ -11,7 +11,7 @@ type Props = {
   name?: string;
   size?: 'sm' | 'md' | 'lg';
   src?: string;
-};
+} & Omit<HTMLAttributes<HTMLSpanElement>, 'role' | 'aria-label'>;
 
 const getInitials = (name?: string) => {
   if (name === undefined || name === '') {
@@ -34,6 +34,8 @@ export const Avatar: FC<Props> = ({
   name,
   size = 'md',
   src,
+  className,
+  ...rest
 }) => {
   const [failedSrc, setFailedSrc] = useState<string | null>(null);
   const showImage = Boolean(src) && failedSrc !== src;
@@ -42,12 +44,14 @@ export const Avatar: FC<Props> = ({
 
   return (
     <span
+      {...rest}
       aria-label={label}
       className={cn(
         'inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full border border-border-base bg-bg-mute font-medium text-fg-base',
         size === 'sm' && 'size-8 text-xs',
         size === 'md' && 'size-10 text-sm',
         size === 'lg' && 'size-14 text-lg',
+        className,
       )}
       role="img"
     >

--- a/packages/arte-odyssey/src/components/data-display/badge/badge.tsx
+++ b/packages/arte-odyssey/src/components/data-display/badge/badge.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { FC, HTMLAttributes } from 'react';
 
 import { cn } from '../../../helpers/cn';
 
@@ -8,7 +8,7 @@ type Props = {
   interactive?: boolean;
   tone?: 'neutral' | 'info' | 'success' | 'warning' | 'error';
   variant?: 'solid' | 'outline';
-};
+} & Omit<HTMLAttributes<HTMLElement>, 'children'>;
 
 export const Badge: FC<Props> = ({
   interactive = false,
@@ -16,6 +16,8 @@ export const Badge: FC<Props> = ({
   text,
   tone = 'neutral',
   variant = 'solid',
+  className,
+  ...rest
 }) => {
   const interactiveClassName = cn(
     interactive &&
@@ -101,11 +103,15 @@ export const Badge: FC<Props> = ({
 
   if (interactive) {
     return (
-      <button className={badgeClassName} type="button">
+      <button {...rest} className={cn(badgeClassName, className)} type="button">
         {text}
       </button>
     );
   }
 
-  return <span className={badgeClassName}>{text}</span>;
+  return (
+    <span {...rest} className={cn(badgeClassName, className)}>
+      {text}
+    </span>
+  );
 };

--- a/packages/arte-odyssey/src/components/data-display/card/card.tsx
+++ b/packages/arte-odyssey/src/components/data-display/card/card.tsx
@@ -7,8 +7,11 @@ export const Card: FC<CardProps> = ({
   children,
   width = 'full',
   appearance = 'shadow',
+  className,
+  ...rest
 }) => (
   <div
+    {...rest}
     className={cn(
       'rounded-xl',
       appearance === 'shadow' && 'shadow-sm',
@@ -16,6 +19,7 @@ export const Card: FC<CardProps> = ({
       width === 'full' && 'w-full',
       width === 'fit' && 'w-fit',
       'bg-bg-base',
+      className,
     )}
   >
     {children}

--- a/packages/arte-odyssey/src/components/data-display/card/interactive-card.tsx
+++ b/packages/arte-odyssey/src/components/data-display/card/interactive-card.tsx
@@ -7,8 +7,11 @@ export const InteractiveCard: FC<CardProps> = ({
   children,
   width = 'full',
   appearance = 'shadow',
+  className,
+  ...rest
 }) => (
   <div
+    {...rest}
     className={cn(
       'rounded-xl transition-transform hover:scale-[1.02] active:scale-[0.98]',
       appearance === 'shadow' && 'shadow-sm',
@@ -16,6 +19,7 @@ export const InteractiveCard: FC<CardProps> = ({
       width === 'full' && 'w-full',
       width === 'fit' && 'w-fit',
       'bg-bg-base',
+      className,
     )}
   >
     {children}

--- a/packages/arte-odyssey/src/components/data-display/card/type.ts
+++ b/packages/arte-odyssey/src/components/data-display/card/type.ts
@@ -1,6 +1,6 @@
-import type { PropsWithChildren } from 'react';
+import type { HTMLAttributes } from 'react';
 
-export type CardProps = PropsWithChildren<{
+export type CardProps = {
   width?: 'full' | 'fit';
   appearance?: 'shadow' | 'bordered';
-}>;
+} & HTMLAttributes<HTMLDivElement>;

--- a/packages/arte-odyssey/src/components/data-display/code/code.tsx
+++ b/packages/arte-odyssey/src/components/data-display/code/code.tsx
@@ -1,15 +1,24 @@
-import { type FC, Fragment } from 'react';
+import { type FC, Fragment, type HTMLAttributes } from 'react';
 
+import { cn } from './../../../helpers/cn';
 import { findAllColors } from './../../../helpers/color/find-all-colors';
 
-export const Code: FC<{
+type Props = {
   children: string;
-}> = ({ children }) => {
+} & Omit<HTMLAttributes<HTMLElement>, 'children'>;
+
+export const Code: FC<Props> = ({ children, className, ...rest }) => {
   const colors = findAllColors(children);
 
   if (colors.length === 0) {
     return (
-      <code className="bg-bg-mute m-0.5 rounded-md px-1.5 sm:py-0.5">
+      <code
+        {...rest}
+        className={cn(
+          'bg-bg-mute m-0.5 rounded-md px-1.5 sm:py-0.5',
+          className,
+        )}
+      >
         {children}
       </code>
     );
@@ -47,7 +56,13 @@ export const Code: FC<{
   }
 
   return (
-    <code className="bg-bg-mute m-0.5 inline-flex items-center gap-1 rounded-md px-1.5 sm:py-0.5">
+    <code
+      {...rest}
+      className={cn(
+        'bg-bg-mute m-0.5 inline-flex items-center gap-1 rounded-md px-1.5 sm:py-0.5',
+        className,
+      )}
+    >
       {parts}
     </code>
   );

--- a/packages/arte-odyssey/src/components/data-display/heading/heading.tsx
+++ b/packages/arte-odyssey/src/components/data-display/heading/heading.tsx
@@ -1,21 +1,31 @@
-import type { FC, PropsWithChildren } from 'react';
+import type { FC, HTMLAttributes } from 'react';
 
 import { cn } from './../../../helpers/cn';
 
-type Props = PropsWithChildren<{
-  id?: string;
+type Props = {
   type: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
   lineClamp?: number;
-}>;
+} & HTMLAttributes<HTMLHeadingElement>;
 
-export const Heading: FC<Props> = ({ children, id, type, lineClamp }) => {
+export const Heading: FC<Props> = ({
+  children,
+  type,
+  lineClamp,
+  className,
+  ...rest
+}) => {
+  const lineClampClass = {
+    [`line-clamp-${lineClamp?.toString() ?? ''}`]: lineClamp,
+  };
   if (type === 'h1') {
     return (
       <h1
-        className={cn('font-bold text-2xl md:text-3xl', {
-          [`line-clamp-${lineClamp?.toString() ?? ''}`]: lineClamp,
-        })}
-        id={id}
+        {...rest}
+        className={cn(
+          'font-bold text-2xl md:text-3xl',
+          lineClampClass,
+          className,
+        )}
       >
         {children}
       </h1>
@@ -24,10 +34,12 @@ export const Heading: FC<Props> = ({ children, id, type, lineClamp }) => {
   if (type === 'h2') {
     return (
       <h2
-        className={cn('font-bold text-xl md:text-2xl', {
-          [`line-clamp-${lineClamp?.toString() ?? ''}`]: lineClamp,
-        })}
-        id={id}
+        {...rest}
+        className={cn(
+          'font-bold text-xl md:text-2xl',
+          lineClampClass,
+          className,
+        )}
       >
         {children}
       </h2>
@@ -36,10 +48,12 @@ export const Heading: FC<Props> = ({ children, id, type, lineClamp }) => {
   if (type === 'h3') {
     return (
       <h3
-        className={cn('font-bold text-lg md:text-xl', {
-          [`line-clamp-${lineClamp?.toString() ?? ''}`]: lineClamp,
-        })}
-        id={id}
+        {...rest}
+        className={cn(
+          'font-bold text-lg md:text-xl',
+          lineClampClass,
+          className,
+        )}
       >
         {children}
       </h3>
@@ -48,10 +62,12 @@ export const Heading: FC<Props> = ({ children, id, type, lineClamp }) => {
   if (type === 'h4') {
     return (
       <h4
-        className={cn('font-bold text-md md:text-lg', {
-          [`line-clamp-${lineClamp?.toString() ?? ''}`]: lineClamp,
-        })}
-        id={id}
+        {...rest}
+        className={cn(
+          'font-bold text-md md:text-lg',
+          lineClampClass,
+          className,
+        )}
       >
         {children}
       </h4>
@@ -60,10 +76,12 @@ export const Heading: FC<Props> = ({ children, id, type, lineClamp }) => {
   if (type === 'h5') {
     return (
       <h5
-        className={cn('font-bold text-sm md:text-md', {
-          [`line-clamp-${lineClamp?.toString() ?? ''}`]: lineClamp,
-        })}
-        id={id}
+        {...rest}
+        className={cn(
+          'font-bold text-sm md:text-md',
+          lineClampClass,
+          className,
+        )}
       >
         {children}
       </h5>
@@ -71,10 +89,8 @@ export const Heading: FC<Props> = ({ children, id, type, lineClamp }) => {
   }
   return (
     <h6
-      className={cn('font-bold text-xs md:text-sm', {
-        [`line-clamp-${lineClamp?.toString() ?? ''}`]: lineClamp,
-      })}
-      id={id}
+      {...rest}
+      className={cn('font-bold text-xs md:text-sm', lineClampClass, className)}
     >
       {children}
     </h6>

--- a/packages/arte-odyssey/src/components/feedback/alert/alert.tsx
+++ b/packages/arte-odyssey/src/components/feedback/alert/alert.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { FC, HTMLAttributes } from 'react';
 
 import { AlertIcon } from '../../icons';
 import { cn } from './../../../helpers/cn';
@@ -7,7 +7,7 @@ import type { Status } from './../../../types/variables';
 type Props = {
   status: Status;
   message: string | string[];
-};
+} & Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'role'>;
 
 const STATUS_LABEL = {
   success: '成功',
@@ -16,14 +16,16 @@ const STATUS_LABEL = {
   error: 'エラー',
 } as const satisfies Record<Status, string>;
 
-export const Alert: FC<Props> = ({ status, message }) => (
+export const Alert: FC<Props> = ({ status, message, className, ...rest }) => (
   <div
+    {...rest}
     className={cn(
       'flex items-center gap-3 rounded-lg p-4',
       status === 'success' && 'bg-bg-success',
       status === 'info' && 'bg-bg-info',
       status === 'warning' && 'bg-bg-warning',
       status === 'error' && 'bg-bg-error',
+      className,
     )}
     role={status === 'error' || status === 'warning' ? 'alert' : 'status'}
   >

--- a/packages/arte-odyssey/src/components/feedback/progress/progress.tsx
+++ b/packages/arte-odyssey/src/components/feedback/progress/progress.tsx
@@ -1,14 +1,27 @@
-import type { FC } from 'react';
+import type { FC, HTMLAttributes } from 'react';
 
+import { cn } from './../../../helpers/cn';
 import { toPrecision } from './../../../helpers/number';
 
-export const Progress: FC<{
+type Props = {
   progress: number;
   maxProgress: number;
   minProgress?: number;
   label?: string;
-}> = ({ progress, maxProgress, minProgress = 0, label }) => (
-  <div className="bg-bg-emphasize w-full rounded-full">
+} & Omit<HTMLAttributes<HTMLDivElement>, 'children'>;
+
+export const Progress: FC<Props> = ({
+  progress,
+  maxProgress,
+  minProgress = 0,
+  label,
+  className,
+  ...rest
+}) => (
+  <div
+    {...rest}
+    className={cn('bg-bg-emphasize w-full rounded-full', className)}
+  >
     <div
       aria-label={label ?? `${toPrecision(progress / maxProgress).toString()}%`}
       aria-valuemax={maxProgress}

--- a/packages/arte-odyssey/src/components/feedback/skeleton/skeleton.tsx
+++ b/packages/arte-odyssey/src/components/feedback/skeleton/skeleton.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { FC, HTMLAttributes } from 'react';
 
 import { cn } from '../../../helpers/cn';
 
@@ -6,14 +6,17 @@ type Props = {
   animate?: boolean;
   shape?: 'rect' | 'circle';
   size?: 'sm' | 'md' | 'lg';
-};
+} & Omit<HTMLAttributes<HTMLDivElement>, 'children'>;
 
 export const Skeleton: FC<Props> = ({
   animate = true,
   shape = 'rect',
   size = 'md',
+  className,
+  ...rest
 }) => (
   <div
+    {...rest}
     aria-hidden
     className={cn(
       'bg-bg-mute',
@@ -26,6 +29,7 @@ export const Skeleton: FC<Props> = ({
       shape === 'circle' && size === 'sm' && 'size-8',
       shape === 'circle' && size === 'md' && 'size-12',
       shape === 'circle' && size === 'lg' && 'size-16',
+      className,
     )}
   />
 );

--- a/packages/arte-odyssey/src/components/feedback/spinner/spinner.tsx
+++ b/packages/arte-odyssey/src/components/feedback/spinner/spinner.tsx
@@ -1,17 +1,23 @@
-import type { FC } from 'react';
+import type { FC, OutputHTMLAttributes } from 'react';
 
 import { cn } from '../../../helpers/cn';
 
 type Props = {
   label?: string;
   size?: 'sm' | 'md' | 'lg';
-};
+} & Omit<OutputHTMLAttributes<HTMLOutputElement>, 'children' | 'aria-label'>;
 
-export const Spinner: FC<Props> = ({ label = 'Loading', size = 'md' }) => (
+export const Spinner: FC<Props> = ({
+  label = 'Loading',
+  size = 'md',
+  className,
+  ...rest
+}) => (
   <output
+    {...rest}
     aria-label={label}
     aria-live="polite"
-    className="inline-flex items-center justify-center"
+    className={cn('inline-flex items-center justify-center', className)}
   >
     <span
       aria-hidden

--- a/packages/arte-odyssey/src/components/layout/separator/separator.tsx
+++ b/packages/arte-odyssey/src/components/layout/separator/separator.tsx
@@ -1,14 +1,25 @@
-import type { FC } from 'react';
+import type { FC, HTMLAttributes } from 'react';
 
 import { cn } from './../../../helpers/cn';
 
-export const Separator: FC<{
+type Props = {
   orientation?: 'horizontal' | 'vertical';
   color?: 'base' | 'mute' | 'subtle';
-}> = ({ orientation = 'horizontal', color = 'base' }) => {
+} & Omit<
+  HTMLAttributes<HTMLSpanElement>,
+  'children' | 'role' | 'aria-orientation'
+>;
+
+export const Separator: FC<Props> = ({
+  orientation = 'horizontal',
+  color = 'base',
+  className,
+  ...rest
+}) => {
   const isVertical = orientation === 'vertical';
   return (
     <span
+      {...rest}
       aria-orientation={orientation}
       className={cn(
         'block',
@@ -19,6 +30,7 @@ export const Separator: FC<{
         color === 'base' && 'bg-border-base',
         color === 'mute' && 'bg-border-mute',
         color === 'subtle' && 'bg-border-subtle',
+        className,
       )}
       role="separator"
     />

--- a/packages/arte-odyssey/src/components/navigation/anchor/anchor.tsx
+++ b/packages/arte-odyssey/src/components/navigation/anchor/anchor.tsx
@@ -1,7 +1,28 @@
-import type { ReactNode } from 'react';
+import type { AnchorHTMLAttributes, ReactNode } from 'react';
 
 import { ExternalLinkIcon } from '../../icons';
 import { isInternalRoute } from './../../../helpers/is-internal-route';
+
+type RestProps = Omit<
+  AnchorHTMLAttributes<HTMLAnchorElement>,
+  'href' | 'children' | 'target' | 'rel' | 'className'
+>;
+
+type Props<T extends string> = {
+  href: T;
+  children: ReactNode;
+  openInNewTab?: boolean;
+  renderAnchor?: (
+    props: {
+      type: 'internal' | 'external';
+      href: NoInfer<T>;
+      className: string;
+      target?: string;
+      rel?: string;
+      children: ReactNode;
+    } & RestProps,
+  ) => ReactNode;
+} & RestProps;
 
 export const Anchor = <T extends string>({
   href,
@@ -10,19 +31,8 @@ export const Anchor = <T extends string>({
   renderAnchor = ({ children: anchorChildren, ...rest }) => (
     <a {...rest}>{anchorChildren}</a>
   ),
-}: {
-  href: T;
-  children: ReactNode;
-  openInNewTab?: boolean;
-  renderAnchor?: (props: {
-    type: 'internal' | 'external';
-    href: NoInfer<T>;
-    className: string;
-    target?: string;
-    rel?: string;
-    children: ReactNode;
-  }) => ReactNode;
-}) => {
+  ...rest
+}: Props<T>) => {
   const type = isInternalRoute(href) && !openInNewTab ? 'internal' : 'external';
   const baseClassName =
     'text-fg-info underline transition-colors hover:text-fg-info/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-info focus-visible:rounded-sm';
@@ -44,6 +54,7 @@ export const Anchor = <T extends string>({
           ),
         };
   return renderAnchor({
+    ...rest,
     type,
     href,
     ...props,


### PR DESCRIPTION
> Stacked on #450 (form-html-attrs)。マージ後に main 向けに rebase される。

## 概要

Styled element 系コンポーネントが対応する `HTMLAttributes` を受けるようにし、`id` / `data-*` / `aria-*` / `style` / event handlers / `className` 等が普通に渡せるようになった。

## 動機

> 軸 1: そのコンポーネントが「何の抽象」か
> - 「styled element」抽象 (Avatar, Badge, Card, Heading, Anchor, Spinner, Separator…): 利用者の頭の中では `<div>` / `<a>` / `<img>` の置き換え。なので HTML attrs を受けるのが直感的。

利用するたびに「`id` 渡したい」「`data-testid` 渡したい」と component 側を編集してた煩わしさを解消する。

## 対象

| Component | 受ける attrs |
|---|---|
| `Avatar` | `HTMLAttributes<HTMLSpanElement>` |
| `Badge` | `HTMLAttributes<HTMLElement>` (interactive モードでは `<button>` に渡る) |
| `Card` / `InteractiveCard` | `HTMLAttributes<HTMLDivElement>` |
| `Code` | `HTMLAttributes<HTMLElement>` |
| `Heading` | `HTMLAttributes<HTMLHeadingElement>` |
| `Spinner` | `OutputHTMLAttributes<HTMLOutputElement>` |
| `Skeleton` | `HTMLAttributes<HTMLDivElement>` |
| `Progress` | `HTMLAttributes<HTMLDivElement>` |
| `Alert` | `HTMLAttributes<HTMLDivElement>` |
| `Separator` | `HTMLAttributes<HTMLSpanElement>` |
| `Anchor` | `AnchorHTMLAttributes<HTMLAnchorElement>` |

## 設計

- `className` を渡した場合はコンポーネント内部の class とマージ (`cn()`)
- `role` / `aria-orientation` / `aria-label` 等、component が責任を持つ attrs は `Omit` で除外（誤上書き防止）
- `Anchor` の `renderAnchor` のコールバック引数に rest props が追加される（デフォルト実装は spread するので影響なし、カスタム renderAnchor の利用者は新規の attrs を spread し忘れないよう注意）

## 例

```tsx
<Avatar id="user" data-testid="avatar" name="k8o" />
<Heading id="section-1" type="h2">タイトル</Heading>
<Card onClick={...} className="custom-class">...</Card>
```

## 影響範囲

- `@k8o/arte-odyssey` の minor bump
- 既存利用は破壊しない（top-level に新たな attrs を受けるだけ）

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm check`
- [x] `pnpm test` (291/291 passed)
- [x] `pnpm build`