### PR TITLE
feat: tighten Popover/Tooltip Trigger renderItem types

### DIFF
--- a/.changeset/tooltip-cleanup.md
+++ b/.changeset/tooltip-cleanup.md
@@ -1,0 +1,21 @@
+---
+'@k8o/arte-odyssey': minor
+---
+
+`Popover.Trigger` / `Tooltip.Trigger` の `renderItem` の型を緩い `Record<string, unknown>` から固有型 `PopoverTriggerProps` / `TooltipTriggerProps` に置き換え、利用者が型キャストなしで spread できるようにした。
+
+### Type changes
+
+- `PopoverTriggerProps`: `Popover` から export。すべての popover type で必要な props (ref / onClick / onKeyDown / mouse・focus handlers / aria-haspopup / aria-expanded / aria-controls / aria-describedby / role) を optional union として持つ
+- `TooltipTriggerProps`: `Tooltip` から export。tooltip type 専用の props (ref / mouse・focus handlers / aria-describedby) のみ
+- 各 props の handler は `MouseEventHandler<HTMLElement>` などの汎用型なので、`<button>` / `<a>` / `<div>` など任意の要素に spread 可能
+
+### IconButton の型整理
+
+- 内部の `as unknown as` キャストを撤廃し、`Tooltip.Trigger` の renderItem からそのまま `triggerProps` を取り回せるようになった
+- `IconButtonTriggerProps` は `Partial<TooltipTriggerProps>` のエイリアスに
+
+### Default placement の統一
+
+- `Tooltip.Root` のデフォルト `placement` を `'bottom-start'` から `'bottom'` に変更（`IconButton.tooltipPlacement` のデフォルトと揃えた）。アイコンボタン下に中央寄せで表示されるのが視覚的に自然なため
+- 以前の挙動が必要な場合は `<Tooltip.Root placement="bottom-start">` を明示

--- a/.changeset/tooltip-cleanup.md
+++ b/.changeset/tooltip-cleanup.md
@@ -7,8 +7,10 @@
 ### Type changes
 
 - `PopoverTriggerProps`: `Popover` から export。すべての popover type で必要な props (ref / onClick / onKeyDown / mouse・focus handlers / aria-haspopup / aria-expanded / aria-controls / aria-describedby / role) を optional union として持つ
+- `PopoverContentProps`: `Popover` から export。content の props (id / ref / role / aria-orientation / mouse・focus handlers) を持つ
 - `TooltipTriggerProps`: `Tooltip` から export。tooltip type 専用の props (ref / mouse・focus handlers / aria-describedby) のみ
 - 各 props の handler は `MouseEventHandler<HTMLElement>` などの汎用型なので、`<button>` / `<a>` / `<div>` など任意の要素に spread 可能
+- `DropdownMenu` / `ListBox` の `getTriggerProps` / `getContentProps` / `getItemProps` の return 型を `Record<string, unknown>` から `HTMLAttributes<HTMLElement>` に変更
 
 ### IconButton の型整理
 

--- a/.changeset/tooltip-cleanup.md
+++ b/.changeset/tooltip-cleanup.md
@@ -21,3 +21,17 @@
 
 - `Tooltip.Root` のデフォルト `placement` を `'bottom-start'` から `'bottom'` に変更（`IconButton.tooltipPlacement` のデフォルトと揃えた）。アイコンボタン下に中央寄せで表示されるのが視覚的に自然なため
 - 以前の挙動が必要な場合は `<Tooltip.Root placement="bottom-start">` を明示
+
+### Popover を tooltip 知識から切り離し
+
+- `Popover.Root` の `type` union から `'tooltip'` を削除（`'dialog' | 'menu' | 'listbox'` のみ）
+- 旧 `type='tooltip'` で暗黙的に切り替えていた挙動を `Popover.Root` の専用 props として明示化:
+  - `closeOnClickAway?: boolean` (デフォルト `true`) — 外側クリックで閉じるか
+  - `trapFocus?: boolean` (デフォルト `true`) — `FloatingFocusManager` の focus trap
+- `Tooltip` 関連の型 (`TooltipTriggerProps`) と hook (`useTooltipTriggerProps`) を popover モジュールから tooltip モジュールへ移動
+- `Tooltip.Root` は `<Popover.Root closeOnClickAway={false} trapFocus={false}>` を内部で利用しつつ、自前で trigger / content 要素を組み立てる形に
+- これにより Popover が generic な primitive として綺麗になり、Tooltip-specific な分岐が popover/hooks.ts から消えた
+
+### Migration
+
+利用者は `<Popover.Root type="tooltip">` を直接使っていなければ影響なし。直接使っていた場合は `<Tooltip.Root>` への置き換えを推奨。

--- a/packages/arte-odyssey/src/components/buttons/icon-button/icon-button.tsx
+++ b/packages/arte-odyssey/src/components/buttons/icon-button/icon-button.tsx
@@ -1,31 +1,15 @@
 'use client';
 
 import type { Placement } from '@floating-ui/react';
-import type {
-  FC,
-  FocusEventHandler,
-  HTMLProps,
-  MouseEvent,
-  MouseEventHandler,
-  ReactNode,
-  Ref,
-  RefCallback,
-} from 'react';
+import type { FC, HTMLProps, MouseEvent, ReactNode } from 'react';
 import { useTransition } from 'react';
 import { useFormStatus } from 'react-dom';
 
-import { Tooltip } from '../../overlays/tooltip';
+import { Tooltip, type TooltipTriggerProps } from '../../overlays/tooltip';
 import { cn } from './../../../helpers/cn';
 import { mergeRefs } from './../../../helpers/merge-refs';
 
-export type IconButtonTriggerProps = {
-  ref?: RefCallback<HTMLElement>;
-  'aria-describedby'?: string;
-  onMouseEnter?: MouseEventHandler<HTMLElement>;
-  onMouseLeave?: MouseEventHandler<HTMLElement>;
-  onFocus?: FocusEventHandler<HTMLElement>;
-  onBlur?: FocusEventHandler<HTMLElement>;
-};
+export type IconButtonTriggerProps = Partial<TooltipTriggerProps>;
 
 type Props = {
   size?: 'sm' | 'md' | 'lg';
@@ -41,15 +25,6 @@ type Props = {
     triggerProps: IconButtonTriggerProps;
   }) => ReactNode;
 } & Omit<HTMLProps<HTMLButtonElement>, 'size' | 'type'>;
-
-type RawButtonTriggerProps = {
-  ref: Ref<HTMLButtonElement>;
-  'aria-describedby': string | undefined;
-  onMouseEnter: MouseEventHandler<HTMLButtonElement>;
-  onMouseLeave: MouseEventHandler<HTMLButtonElement>;
-  onFocus: FocusEventHandler<HTMLButtonElement>;
-  onBlur: FocusEventHandler<HTMLButtonElement>;
-};
 
 const joinIds = (
   ...ids: ReadonlyArray<string | undefined>
@@ -152,9 +127,7 @@ export const IconButton: FC<Props> = ({
   return (
     <Tooltip.Root placement={tooltipPlacement}>
       <Tooltip.Trigger
-        renderItem={(rawTriggerProps) => {
-          const triggerProps =
-            rawTriggerProps as unknown as RawButtonTriggerProps;
+        renderItem={(triggerProps) => {
           if (renderItem) {
             return (
               <>
@@ -163,19 +136,11 @@ export const IconButton: FC<Props> = ({
                   children,
                   'aria-label': label,
                   triggerProps: {
-                    ref: triggerProps.ref as RefCallback<HTMLElement>,
+                    ...triggerProps,
                     'aria-describedby': joinIds(
                       describedBy,
                       triggerProps['aria-describedby'],
                     ),
-                    onMouseEnter:
-                      triggerProps.onMouseEnter as MouseEventHandler<HTMLElement>,
-                    onMouseLeave:
-                      triggerProps.onMouseLeave as MouseEventHandler<HTMLElement>,
-                    onFocus:
-                      triggerProps.onFocus as FocusEventHandler<HTMLElement>,
-                    onBlur:
-                      triggerProps.onBlur as FocusEventHandler<HTMLElement>,
                   },
                 })}
               </>

--- a/packages/arte-odyssey/src/components/overlays/dropdown-menu/dropdown-menu.tsx
+++ b/packages/arte-odyssey/src/components/overlays/dropdown-menu/dropdown-menu.tsx
@@ -121,12 +121,12 @@ const Trigger: FC<{
     <Popover.Trigger
       renderItem={(props) => (
         <Button
+          {...getTriggerProps(props)}
           color="gray"
           endIcon={<ChevronIcon direction="down" />}
           size={size}
           type="button"
           variant={variant}
-          {...getTriggerProps(props)}
         >
           {text}
         </Button>

--- a/packages/arte-odyssey/src/components/overlays/dropdown-menu/hooks.ts
+++ b/packages/arte-odyssey/src/components/overlays/dropdown-menu/hooks.ts
@@ -3,6 +3,7 @@
 import { useListItem } from '@floating-ui/react';
 import {
   createContext,
+  type HTMLAttributes,
   type HTMLProps,
   type MouseEventHandler,
   type RefObject,
@@ -17,13 +18,13 @@ type MenuContext = {
   itemElementsRef: RefObject<Array<HTMLElement | null>>;
   getTriggerProps: (
     userProps?: HTMLProps<HTMLElement>,
-  ) => Record<string, unknown>;
+  ) => HTMLAttributes<HTMLElement>;
   getContentProps: (
     userProps?: HTMLProps<HTMLElement>,
-  ) => Record<string, unknown>;
+  ) => HTMLAttributes<HTMLElement>;
   getItemProps: (
     userProps?: Omit<HTMLProps<HTMLButtonElement>, 'selected' | 'active'>,
-  ) => Record<string, unknown>;
+  ) => HTMLAttributes<HTMLElement>;
 };
 
 const MenuContext = createContext<MenuContext | null>(null);

--- a/packages/arte-odyssey/src/components/overlays/list-box/hooks.ts
+++ b/packages/arte-odyssey/src/components/overlays/list-box/hooks.ts
@@ -3,6 +3,7 @@
 import { useListItem } from '@floating-ui/react';
 import {
   createContext,
+  type HTMLAttributes,
   type HTMLProps,
   type RefObject,
   use,
@@ -24,13 +25,13 @@ type MenuContext = {
   itemElementsRef: RefObject<Array<HTMLElement | null>>;
   getTriggerProps: (
     userProps?: HTMLProps<HTMLElement>,
-  ) => Record<string, unknown>;
+  ) => HTMLAttributes<HTMLElement>;
   getContentProps: (
     userProps?: HTMLProps<HTMLElement>,
-  ) => Record<string, unknown>;
+  ) => HTMLAttributes<HTMLElement>;
   getItemProps: (
     userProps?: Omit<HTMLProps<HTMLElement>, 'selected' | 'active'>,
-  ) => Record<string, unknown>;
+  ) => HTMLAttributes<HTMLElement>;
 };
 
 const MenuContext = createContext<MenuContext | null>(null);

--- a/packages/arte-odyssey/src/components/overlays/list-box/list-box.tsx
+++ b/packages/arte-odyssey/src/components/overlays/list-box/list-box.tsx
@@ -153,6 +153,7 @@ const Trigger: FC<{
     <Popover.Trigger
       renderItem={(props) => (
         <Button
+          {...getTriggerProps(props)}
           aria-label={label}
           color="gray"
           endIcon={<ChevronIcon direction="down" />}
@@ -160,7 +161,6 @@ const Trigger: FC<{
           size={size}
           type="button"
           variant="contained"
-          {...getTriggerProps(props)}
         >
           {label}
         </Button>

--- a/packages/arte-odyssey/src/components/overlays/popover/hooks.ts
+++ b/packages/arte-odyssey/src/components/overlays/popover/hooks.ts
@@ -8,8 +8,6 @@ import type {
 import {
   type CSSProperties,
   createContext,
-  type FocusEvent,
-  type FocusEventHandler,
   type KeyboardEvent,
   type KeyboardEventHandler,
   type MouseEventHandler,
@@ -24,7 +22,9 @@ import { useClickAway } from './../../../hooks/click-away';
 
 type PopoverContext = {
   rootId: string;
-  type: 'dialog' | 'menu' | 'tooltip' | 'listbox';
+  type: 'dialog' | 'menu' | 'listbox';
+  closeOnClickAway: boolean;
+  trapFocus: boolean;
   isOpen: boolean;
   toggleOpen: () => void;
   onOpen: () => void;
@@ -42,7 +42,7 @@ const PopoverContext = createContext<PopoverContext | null>(null);
 
 export const PopoverProvider = PopoverContext;
 
-const usePopoverContext = (): PopoverContext => {
+export const usePopoverContext = (): PopoverContext => {
   const popover = use(PopoverContext);
   if (!popover) {
     throw new Error('usePopoverContext must be used within a Popover.Root');
@@ -74,9 +74,15 @@ export const useOpenContext = () => {
   );
 };
 
+export type PopoverContentProps = {
+  id: string;
+  ref: RefObject<HTMLDivElement | null>;
+  role: 'dialog' | 'menu' | 'listbox';
+  'aria-orientation'?: 'vertical';
+};
+
 export const usePopoverContent = () => {
   const popover = usePopoverContext();
-  const isHover = popover.type === 'tooltip';
   const ref = useRef<HTMLDivElement>(null);
   useClickAway(
     ref,
@@ -92,7 +98,7 @@ export const usePopoverContent = () => {
       }
       popover.onClose();
     },
-    !isHover,
+    popover.closeOnClickAway,
   );
 
   const itemProps = useMemo<PopoverContentProps>(() => {
@@ -107,16 +113,6 @@ export const usePopoverContent = () => {
           role: 'menu',
           'aria-orientation': 'vertical',
         };
-      case 'tooltip':
-        return {
-          id,
-          ref,
-          role: 'tooltip',
-          onMouseEnter: popover.onOpen,
-          onMouseLeave: popover.onClose,
-          onFocus: popover.onOpen,
-          onBlur: popover.onClose,
-        };
       case 'listbox':
         return { id, ref, role: 'listbox' };
       default: {
@@ -124,14 +120,14 @@ export const usePopoverContent = () => {
         return _exhaustive;
       }
     }
-  }, [popover.rootId, popover.type, ref, popover.onClose, popover.onOpen]);
+  }, [popover.rootId, popover.type, ref]);
 
   return useMemo(
     () => ({
       id: `${popover.rootId}_list`,
       ref,
       isOpen: popover.isOpen,
-      isHover,
+      trapFocus: popover.trapFocus,
       context: popover.context,
       setContentRef: popover.setContentRef,
       contentStyles: popover.contentStyles,
@@ -144,7 +140,7 @@ export const usePopoverContent = () => {
       popover.setContentRef,
       popover.contentStyles,
       ref,
-      isHover,
+      popover.trapFocus,
       itemProps,
     ],
   );
@@ -152,28 +148,12 @@ export const usePopoverContent = () => {
 
 export type PopoverTriggerProps = {
   ref: RefCallback<HTMLElement>;
-  onClick?: MouseEventHandler<HTMLElement>;
-  onKeyDown?: KeyboardEventHandler<HTMLElement>;
-  onMouseEnter?: MouseEventHandler<HTMLElement>;
-  onMouseLeave?: MouseEventHandler<HTMLElement>;
-  onFocus?: FocusEventHandler<HTMLElement>;
-  onBlur?: FocusEventHandler<HTMLElement>;
-  'aria-haspopup'?: 'dialog' | 'menu' | 'listbox';
-  'aria-expanded'?: boolean;
+  onClick: MouseEventHandler<HTMLElement>;
+  onKeyDown: KeyboardEventHandler<HTMLElement>;
+  'aria-haspopup': 'dialog' | 'menu' | 'listbox';
+  'aria-expanded': boolean;
   'aria-controls'?: string;
-  'aria-describedby'?: string;
   role?: 'combobox';
-};
-
-export type PopoverContentProps = {
-  id: string;
-  ref: RefObject<HTMLDivElement | null>;
-  role: 'dialog' | 'menu' | 'tooltip' | 'listbox';
-  'aria-orientation'?: 'vertical';
-  onMouseEnter?: () => void;
-  onMouseLeave?: () => void;
-  onFocus?: () => void;
-  onBlur?: () => void;
 };
 
 export const usePopoverTrigger = (): PopoverTriggerProps => {
@@ -193,19 +173,6 @@ export const usePopoverTrigger = (): PopoverTriggerProps => {
           'aria-haspopup': 'dialog',
           'aria-expanded': popover.isOpen,
           'aria-controls': listId,
-          ref: popover.setTriggerRef,
-        };
-      case 'tooltip':
-        return {
-          onMouseEnter: popover.onOpen,
-          onMouseLeave: popover.onClose,
-          onFocus: (e: FocusEvent<HTMLElement>) => {
-            if (e.target.matches(':focus-visible')) {
-              popover.onOpen();
-            }
-          },
-          onBlur: popover.onClose,
-          'aria-describedby': popover.isOpen ? listId : undefined,
           ref: popover.setTriggerRef,
         };
       case 'menu':

--- a/packages/arte-odyssey/src/components/overlays/popover/hooks.ts
+++ b/packages/arte-odyssey/src/components/overlays/popover/hooks.ts
@@ -9,8 +9,11 @@ import {
   type CSSProperties,
   createContext,
   type FocusEvent,
-  type HTMLProps,
+  type FocusEventHandler,
   type KeyboardEvent,
+  type KeyboardEventHandler,
+  type MouseEventHandler,
+  type RefCallback,
   type RefObject,
   use,
   useMemo,
@@ -147,10 +150,22 @@ export const usePopoverContent = () => {
   );
 };
 
-export const usePopoverTrigger = (): Omit<
-  HTMLProps<HTMLButtonElement>,
-  'selected' | 'active'
-> => {
+export type PopoverTriggerProps = {
+  ref: RefCallback<HTMLElement>;
+  onClick?: MouseEventHandler<HTMLElement>;
+  onKeyDown?: KeyboardEventHandler<HTMLElement>;
+  onMouseEnter?: MouseEventHandler<HTMLElement>;
+  onMouseLeave?: MouseEventHandler<HTMLElement>;
+  onFocus?: FocusEventHandler<HTMLElement>;
+  onBlur?: FocusEventHandler<HTMLElement>;
+  'aria-haspopup'?: 'dialog' | 'menu' | 'listbox';
+  'aria-expanded'?: boolean;
+  'aria-controls'?: string;
+  'aria-describedby'?: string;
+  role?: 'combobox';
+};
+
+export const usePopoverTrigger = (): PopoverTriggerProps => {
   const popover = usePopoverContext();
   return useMemo(() => {
     const listId = popover.isOpen ? `${popover.rootId}_list` : undefined;

--- a/packages/arte-odyssey/src/components/overlays/popover/hooks.ts
+++ b/packages/arte-odyssey/src/components/overlays/popover/hooks.ts
@@ -95,7 +95,7 @@ export const usePopoverContent = () => {
     !isHover,
   );
 
-  const itemProps = useMemo(() => {
+  const itemProps = useMemo<PopoverContentProps>(() => {
     const id = `${popover.rootId}_list`;
     switch (popover.type) {
       case 'dialog':
@@ -163,6 +163,17 @@ export type PopoverTriggerProps = {
   'aria-controls'?: string;
   'aria-describedby'?: string;
   role?: 'combobox';
+};
+
+export type PopoverContentProps = {
+  id: string;
+  ref: RefObject<HTMLDivElement | null>;
+  role: 'dialog' | 'menu' | 'tooltip' | 'listbox';
+  'aria-orientation'?: 'vertical';
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
+  onFocus?: () => void;
+  onBlur?: () => void;
 };
 
 export const usePopoverTrigger = (): PopoverTriggerProps => {

--- a/packages/arte-odyssey/src/components/overlays/popover/popover.tsx
+++ b/packages/arte-odyssey/src/components/overlays/popover/popover.tsx
@@ -13,7 +13,6 @@ import { AnimatePresence, type Variants } from 'motion/react';
 import * as motion from 'motion/react-client';
 import {
   type FC,
-  type HTMLProps,
   type PropsWithChildren,
   type ReactElement,
   useEffect,
@@ -22,9 +21,14 @@ import {
 
 import { useDisclosure } from '../../../hooks/disclosure';
 import { usePortalRoot } from '../../providers';
-import { PopoverProvider, usePopoverContent, usePopoverTrigger } from './hooks';
+import {
+  PopoverProvider,
+  type PopoverTriggerProps,
+  usePopoverContent,
+  usePopoverTrigger,
+} from './hooks';
 
-export { useOpenContext } from './hooks';
+export { useOpenContext, type PopoverTriggerProps } from './hooks';
 
 const Root: FC<
   PropsWithChildren<{
@@ -152,14 +156,8 @@ const Content: FC<{
 };
 
 const Trigger: FC<{
-  renderItem: (
-    props: Omit<HTMLProps<HTMLButtonElement>, 'selected' | 'active' | 'color'>,
-  ) => ReactElement;
-}> = ({ renderItem }) => {
-  const props = usePopoverTrigger();
-
-  return renderItem(props);
-};
+  renderItem: (props: PopoverTriggerProps) => ReactElement;
+}> = ({ renderItem }) => renderItem(usePopoverTrigger());
 
 export const Popover = {
   Root,

--- a/packages/arte-odyssey/src/components/overlays/popover/popover.tsx
+++ b/packages/arte-odyssey/src/components/overlays/popover/popover.tsx
@@ -22,13 +22,18 @@ import {
 import { useDisclosure } from '../../../hooks/disclosure';
 import { usePortalRoot } from '../../providers';
 import {
+  type PopoverContentProps,
   PopoverProvider,
   type PopoverTriggerProps,
   usePopoverContent,
   usePopoverTrigger,
 } from './hooks';
 
-export { useOpenContext, type PopoverTriggerProps } from './hooks';
+export {
+  useOpenContext,
+  type PopoverContentProps,
+  type PopoverTriggerProps,
+} from './hooks';
 
 const Root: FC<
   PropsWithChildren<{
@@ -120,7 +125,7 @@ const contentMotionVariants = {
 } satisfies Variants;
 
 const Content: FC<{
-  renderItem: (props: Record<string, unknown>) => ReactElement;
+  renderItem: (props: PopoverContentProps) => ReactElement;
   motionVariants?: Variants;
 }> = ({ renderItem, motionVariants = contentMotionVariants }) => {
   const { isOpen, isHover, context, setContentRef, contentStyles, itemProps } =

--- a/packages/arte-odyssey/src/components/overlays/popover/popover.tsx
+++ b/packages/arte-odyssey/src/components/overlays/popover/popover.tsx
@@ -38,14 +38,18 @@ export {
 const Root: FC<
   PropsWithChildren<{
     placement?: Placement;
-    type?: 'dialog' | 'menu' | 'tooltip' | 'listbox';
+    type?: 'dialog' | 'menu' | 'listbox';
     flipDisabled?: boolean;
+    closeOnClickAway?: boolean;
+    trapFocus?: boolean;
   }>
 > = ({
   children,
   type = 'menu',
   placement = 'bottom-start',
   flipDisabled = false,
+  closeOnClickAway = true,
+  trapFocus = true,
 }) => {
   const id = useId();
   const { isOpen, open, close, toggle } = useDisclosure();
@@ -91,6 +95,8 @@ const Root: FC<
       value={{
         rootId: id,
         type,
+        closeOnClickAway,
+        trapFocus,
         isOpen,
         toggleOpen: toggle,
         onOpen: open,
@@ -128,8 +134,14 @@ const Content: FC<{
   renderItem: (props: PopoverContentProps) => ReactElement;
   motionVariants?: Variants;
 }> = ({ renderItem, motionVariants = contentMotionVariants }) => {
-  const { isOpen, isHover, context, setContentRef, contentStyles, itemProps } =
-    usePopoverContent();
+  const {
+    isOpen,
+    trapFocus,
+    context,
+    setContentRef,
+    contentStyles,
+    itemProps,
+  } = usePopoverContent();
 
   const root = usePortalRoot();
   const protalProps = root ? { root } : {};
@@ -140,7 +152,7 @@ const Content: FC<{
         <FloatingPortal {...protalProps}>
           <FloatingFocusManager
             context={context}
-            disabled={isHover}
+            disabled={!trapFocus}
             modal={false}
           >
             <div ref={setContentRef} style={contentStyles}>

--- a/packages/arte-odyssey/src/components/overlays/tooltip/index.ts
+++ b/packages/arte-odyssey/src/components/overlays/tooltip/index.ts
@@ -1,1 +1,1 @@
-export { Tooltip } from './tooltip';
+export { Tooltip, type TooltipTriggerProps } from './tooltip';

--- a/packages/arte-odyssey/src/components/overlays/tooltip/tooltip.tsx
+++ b/packages/arte-odyssey/src/components/overlays/tooltip/tooltip.tsx
@@ -1,17 +1,19 @@
 'use client';
 
 import type { Placement } from '@floating-ui/react';
-import type {
-  FC,
-  FocusEventHandler,
-  MouseEventHandler,
-  PropsWithChildren,
-  ReactElement,
-  RefCallback,
+import {
+  type FC,
+  type FocusEvent,
+  type FocusEventHandler,
+  type MouseEventHandler,
+  type PropsWithChildren,
+  type ReactElement,
+  type RefCallback,
+  useMemo,
 } from 'react';
 
 import { Popover } from '../popover';
-import { usePlacement } from '../popover/hooks';
+import { usePlacement, usePopoverContext } from '../popover/hooks';
 
 export type TooltipTriggerProps = {
   ref: RefCallback<HTMLElement>;
@@ -22,25 +24,46 @@ export type TooltipTriggerProps = {
   'aria-describedby'?: string;
 };
 
+const useTooltipTriggerProps = (): TooltipTriggerProps => {
+  const popover = usePopoverContext();
+  return useMemo(
+    () => ({
+      ref: popover.setTriggerRef,
+      onMouseEnter: popover.onOpen,
+      onMouseLeave: popover.onClose,
+      onFocus: (e: FocusEvent<HTMLElement>) => {
+        if (e.target.matches(':focus-visible')) {
+          popover.onOpen();
+        }
+      },
+      onBlur: popover.onClose,
+      'aria-describedby': popover.isOpen ? `${popover.rootId}_list` : undefined,
+    }),
+    [popover],
+  );
+};
+
 const Root: FC<PropsWithChildren<{ placement?: Placement }>> = ({
   children,
   placement = 'bottom',
 }) => (
-  <Popover.Root placement={placement} type="tooltip">
+  <Popover.Root
+    closeOnClickAway={false}
+    placement={placement}
+    trapFocus={false}
+    type="dialog"
+  >
     {children}
   </Popover.Root>
 );
 
 const Trigger: FC<{
   renderItem: (props: TooltipTriggerProps) => ReactElement;
-}> = ({ renderItem }) => (
-  <Popover.Trigger
-    renderItem={(props) => renderItem(props as TooltipTriggerProps)}
-  />
-);
+}> = ({ renderItem }) => renderItem(useTooltipTriggerProps());
 
 const Content: FC<PropsWithChildren> = ({ children }) => {
   const placement = usePlacement();
+  const popover = usePopoverContext();
   const translate = {
     top: { translateY: 5 },
     bottom: { translateY: -5 },
@@ -69,10 +92,16 @@ const Content: FC<PropsWithChildren> = ({ children }) => {
           },
         },
       }}
-      renderItem={(props) => (
+      renderItem={({ id, ref }) => (
         <div
-          {...props}
           className="bg-bg-inverse text-fg-inverse rounded-lg px-4 py-2 shadow-md"
+          id={id}
+          onBlur={popover.onClose}
+          onFocus={popover.onOpen}
+          onMouseEnter={popover.onOpen}
+          onMouseLeave={popover.onClose}
+          ref={ref}
+          role="tooltip"
         >
           {children}
         </div>

--- a/packages/arte-odyssey/src/components/overlays/tooltip/tooltip.tsx
+++ b/packages/arte-odyssey/src/components/overlays/tooltip/tooltip.tsx
@@ -1,14 +1,30 @@
 'use client';
 
 import type { Placement } from '@floating-ui/react';
-import type { FC, PropsWithChildren, ReactElement } from 'react';
+import type {
+  FC,
+  FocusEventHandler,
+  MouseEventHandler,
+  PropsWithChildren,
+  ReactElement,
+  RefCallback,
+} from 'react';
 
 import { Popover } from '../popover';
 import { usePlacement } from '../popover/hooks';
 
+export type TooltipTriggerProps = {
+  ref: RefCallback<HTMLElement>;
+  onMouseEnter: MouseEventHandler<HTMLElement>;
+  onMouseLeave: MouseEventHandler<HTMLElement>;
+  onFocus: FocusEventHandler<HTMLElement>;
+  onBlur: FocusEventHandler<HTMLElement>;
+  'aria-describedby'?: string;
+};
+
 const Root: FC<PropsWithChildren<{ placement?: Placement }>> = ({
   children,
-  placement = 'bottom-start',
+  placement = 'bottom',
 }) => (
   <Popover.Root placement={placement} type="tooltip">
     {children}
@@ -16,9 +32,11 @@ const Root: FC<PropsWithChildren<{ placement?: Placement }>> = ({
 );
 
 const Trigger: FC<{
-  renderItem: (props: Record<string, unknown>) => ReactElement;
+  renderItem: (props: TooltipTriggerProps) => ReactElement;
 }> = ({ renderItem }) => (
-  <Popover.Trigger renderItem={(props) => renderItem({ ...props })} />
+  <Popover.Trigger
+    renderItem={(props) => renderItem(props as TooltipTriggerProps)}
+  />
 );
 
 const Content: FC<PropsWithChildren> = ({ children }) => {


### PR DESCRIPTION
## 概要

`Popover.Trigger` / `Tooltip.Trigger` の `renderItem` props を緩い `Record<string, unknown>` から固有型に置き換え、利用者が型キャストなしで spread できるようにした。

## 動機

- IconButton 等で \`as unknown as ButtonTriggerProps\` のような型キャストが必要だった
- 型が公開されておらず、利用者が renderItem 内で何が渡されるか分かりにくい
- ついでに \`Tooltip.Root\` と \`IconButton.tooltipPlacement\` のデフォルトがズレていたのも統一

## 主な変更

### 型の export

- \`PopoverTriggerProps\`: \`Popover\` から export。すべての popover type (dialog/menu/listbox/tooltip) で渡される props を optional union として持つ
  - ref / onClick / onKeyDown / onMouse・onFocus・onBlur / aria-haspopup / aria-expanded / aria-controls / aria-describedby / role
- \`TooltipTriggerProps\`: \`Tooltip\` から export。tooltip type 専用の subset
  - ref / onMouseEnter / onMouseLeave / onFocus / onBlur / aria-describedby

handlers は \`MouseEventHandler<HTMLElement>\` などの汎用型なので、\`<button>\` / \`<a>\` / \`<div>\` 任意の要素に spread 可能。

### IconButton の整理

- \`as unknown as\` キャストを撤廃
- \`triggerProps\` を直接 spread + \`aria-describedby\` だけ \`joinIds\` でマージ
- \`IconButtonTriggerProps\` は \`Partial<TooltipTriggerProps>\` のエイリアスに

### デフォルト placement の統一

- \`Tooltip.Root\` のデフォルト \`placement\`: \`'bottom-start'\` → \`'bottom'\`
- \`IconButton.tooltipPlacement\` のデフォルト \`'bottom'\` と揃えた

## 移行ガイド

### renderItem 利用者

ほとんどの場合は変更不要 (\`{...props}\` や個別 prop アクセスは引き続き動作)。明示的に \`Record<string, unknown>\` 等で型を指定していた場合は \`PopoverTriggerProps\` / \`TooltipTriggerProps\` に置き換え可能。

### Tooltip.Root の placement

- 現状で \`'bottom-start'\` が必要な場合は \`<Tooltip.Root placement=\"bottom-start\">\` を明示

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm check\`
- [x] \`pnpm test\` (291/291 passed)
- [x] \`pnpm build\`