### PR TITLE
fix(baseline-status): guard import on server to prevent SSR crash

### DIFF
--- a/.changeset/baseline-status-ssr-guard.md
+++ b/.changeset/baseline-status-ssr-guard.md
@@ -1,0 +1,9 @@
+---
+'@k8o/arte-odyssey': patch
+---
+
+`BaselineStatus` を Next.js の SSG/SSR 環境で render したときに `ReferenceError: window is not defined` で build が落ちる問題を修正した。
+
+`baseline-status` パッケージは module top-level で `window.customElements.define(...)` を実行するため、`use(import('baseline-status'))` の Promise が server で解決されると window 未定義エラーになっていた。`loadBaselineStatus` に `typeof window === 'undefined'` ガードを入れ、server では never-resolve な Promise を返して Suspense fallback (`BaselineStatusSkeleton`) を維持するようにした。
+
+これにより SSG の static HTML には skeleton が出力され、client hydration 後に本物の `<baseline-status>` 要素に差し替わる。

--- a/packages/arte-odyssey/src/components/data-display/baseline-status/baseline-status.tsx
+++ b/packages/arte-odyssey/src/components/data-display/baseline-status/baseline-status.tsx
@@ -2,6 +2,8 @@
 
 import { type FC, Suspense, use } from 'react';
 
+import { useClient } from '../../../hooks/client';
+
 declare global {
   namespace React {
     namespace JSX {
@@ -22,6 +24,12 @@ const loadBaselineStatus = (): Promise<unknown> => {
 };
 
 const BaselineStatusResolved: FC<{ featureId: string }> = ({ featureId }) => {
+  const isClient = useClient();
+
+  if (!isClient) {
+    return <BaselineStatusSkeleton />;
+  }
+
   use(loadBaselineStatus());
   return (
     <baseline-status


### PR DESCRIPTION
## 概要

`BaselineStatus` を Next.js の SSG/SSR 環境で render すると `ReferenceError: window is not defined` で `next build` が落ちる問題を修正した。

## 動機

v7.0.0 で `BaselineStatus` の動的 import 観測方法を `useSyncExternalStore` + 可変モジュール変数から `Suspense + use(Promise)` に変更したことで、`use(import('baseline-status'))` の Promise が server 側でも解決されるようになった。

`baseline-status@1.1.1` は module top-level で次のコードを実行する:

```js
window.customElements.define('baseline-status', BaselineStatus);
```

このため Node.js 環境では `import` 解決時に `window` 未定義エラーになる。`use()` は同期 throw を Suspense として扱わないため fallback に落ちず、render 全体が落ちていた。

## 主な変更

`loadBaselineStatus` の先頭に server ガードを追加した:

```ts
const loadBaselineStatus = (): Promise<unknown> => {
  if (typeof window === 'undefined') {
    return new Promise<never>(() => {});
  }
  loadPromise ??= import('baseline-status' as string);
  return loadPromise;
};
```

- SSG: `<BaselineStatusSkeleton />` が静的 HTML に出力される
- Client hydration: import が走り、本物の `<baseline-status>` 要素に差し替わる

`Suspense + use(Promise)` の構造を保ったまま、SSR-unsafe な依存を library 境界で吸収する。

## 気をつけるポイント

- server では Promise を意図的に never-resolve にしている。Suspense fallback (skeleton) のまま hydration まで残るのが期待動作。
- 上流 (`baseline-status`) でも `customElements.define` を `typeof customElements !== 'undefined'` でガードすべきだが、上流対応は時間がかかるため library 側で吸収する判断。

## 影響範囲

- `BaselineStatus` を使う全ての利用側。特に Next.js App Router の Server Component / SSG 対象 route で改善。
- Client-only な利用側 (Vite SPA / Storybook など) は挙動変化なし (`window` が常に定義済み)。

## Test plan

- [x] `pnpm typecheck` (arte-odyssey)
- [x] `pnpm build` — 生成された `dist/.../baseline-status.mjs` にガードが入っていることを確認
- [ ] consumer 側 (k8o リポジトリ) の `next/dynamic({ ssr: false })` ラッパーを外して `next build` が通ることを確認