### PR TITLE
ci(release): drop `npm install -g npm@latest` step

### DIFF
--- a/.changeset/release-pipeline-pnpm-v11.md
+++ b/.changeset/release-pipeline-pnpm-v11.md
@@ -1,0 +1,11 @@
+---
+'@k8o/arte-odyssey': patch
+---
+
+Release pipeline を pnpm v11 ネイティブ publish に移行し、CI を供給網的に固めた。
+
+- pnpm を 10.33.2 -> 11.0.4 に更新したことで、`changeset publish` が呼ぶ `pnpm publish` が v11 のネイティブ実装に切り替わった（npm CLI への委譲が廃止）
+- `.github/workflows/release.yml` から `npm install -g npm@latest` を削除した。バージョン未固定の `@latest` を CI のたびに取得する挙動は `pnpm-workspace.yaml#minimumReleaseAge: 10080`（7日）など他の供給網保護方針と矛盾するため
+- 残りの `npm info` / `npm profile get` 呼び出しは Node.js 24.15.0 同梱の npm 11.12.1 で動作する
+
+公開 API の変更はなく、library 利用者側で必要な対応はない。

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,6 @@ jobs:
       - name: Install
         uses: ./.github/composite-actions/install
 
-      - name: Install latest npm
-        run: npm install -g npm@latest
-
       - name: Create release Pull Request or publish to NPM
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:


### PR DESCRIPTION
## 概要

リリースワークフローから `npm install -g npm@latest` のステップを削除する。

## 動機

`npm install -g npm@latest` は CI 実行時にバージョン未固定の最新 npm を取得していた。直近で `pnpm-workspace.yaml` の `minimumReleaseAge` を 10080 分（7日）に拡張するなど供給網保護を強化した方針と矛盾しており、`@latest` で都度取得する CI ステップは攻撃面となるため削除する。

## 詳細

- `.github/workflows/release.yml` から `Install latest npm` ステップを削除

## 影響範囲

- `pnpm release` -> `changeset publish` の publish フローのみ
- changesets/cli は内部で以下の npm コマンドを直接 spawn するが、いずれも Node.js 24.15.0 同梱の npm 11.12.1 で動作する基本コマンドであり、`@latest` を必要としない:
  - `npm info <pkg> --json` (公開済みバージョン確認)
  - `npm profile get --json` (トークン確認)
- publish 本体は pnpm v11 のネイティブ `pnpm publish` が呼ばれる（changesets が `packageManager` から pnpm を検出するため）
- Node.js のバージョンは `mise.toml` で `24.15.0` に固定済みのため、同梱 npm のバージョンも実質固定される

## 注意点

- 初回リリース時に `npm info` / `npm profile get` がエラーなく動作するか CI ログを確認する
- 認証は changesets/action が生成する `~/.npmrc` の `_authToken` で動作（pnpm v11 でも `~/.npmrc` を auth フォールバックとして読む）