### PR TITLE
fix(docs): suppress oxlint false positive on Button.renderItem className

### DIFF
--- a/.changeset/home-render-item-lint.md
+++ b/.changeset/home-render-item-lint.md
@@ -1,0 +1,7 @@
+---
+'@k8o/arte-odyssey': patch
+---
+
+`apps/docs/src/pages/home.tsx` の `Button.renderItem` 内 `className` 代入で `typescript-eslint/no-unsafe-assignment` が偽陽性を出していたため、`oxlint-disable-next-line` で個別抑制した。
+
+`Button.renderItem` 引数の `className` は `string` 型に正しく型付けされているが、oxlint の型推論が分割代入引数を `any` として扱うため発生していた。`@oxlint/plugins` の更新で顕在化したもので、実装の挙動には影響しない。

--- a/apps/docs/src/pages/home.tsx
+++ b/apps/docs/src/pages/home.tsx
@@ -90,6 +90,7 @@ export function Home() {
           color="gray"
           renderItem={({ className, children }) => (
             <a
+              // oxlint-disable-next-line typescript-eslint/no-unsafe-assignment -- renderItem の className は string 型だが oxlint が any と推論する偽陽性
               className={className}
               href="https://github.com/k35o/ArteOdyssey"
               rel="noopener noreferrer"
@@ -107,6 +108,7 @@ export function Home() {
         <Button
           renderItem={({ className, children }) => (
             <a
+              // oxlint-disable-next-line typescript-eslint/no-unsafe-assignment -- renderItem の className は string 型だが oxlint が any と推論する偽陽性
               className={className}
               href={STORYBOOK_URL}
               rel="noopener noreferrer"


### PR DESCRIPTION
## 概要

`apps/docs/src/pages/home.tsx` の `Button.renderItem` 内 `className` 代入で `typescript-eslint/no-unsafe-assignment` が偽陽性を出していたため、対象 2 行に `oxlint-disable-next-line` を付けて個別抑制した。

## 動機

`@oxlint/plugins` の更新後に pre-commit hook (`vp check --fix`) が以下のエラーで止まる事象が顕在化したため。

\`\`\`
typescript-eslint(no-unsafe-assignment): Unsafe assignment of an any value.
  apps/docs/src/pages/home.tsx:93:26
              className={className}
                          ^^^^^^^^^
\`\`\`

[packages/arte-odyssey/src/components/buttons/button/button.tsx:20](packages/arte-odyssey/src/components/buttons/button/button.tsx) で `renderItem?: (props: { className: string; children: ReactNode }) => ReactNode;` と `string` 型に正しく定義されているが、oxlint の型推論が分割代入引数の型を辿りきれず `any` として扱うために発生する偽陽性。

## 詳細

- home.tsx の 2 箇所（GitHub リンクと Storybook リンク）の `className={className}` の直前に `// oxlint-disable-next-line typescript-eslint/no-unsafe-assignment` をコメント理由付きで追加
- `@k8o/arte-odyssey: patch` の changeset を追加（library 実装の変更はないが release ラインに乗せるため）

## 気をつけるポイント

- 抑制範囲は当該 2 行のみ。ルール全体を off にしたり `as` キャストで誤魔化したりはしていない
- 同種の偽陽性が他箇所でも `pnpm install` 後に出る可能性はあるが、本 PR のスコープは home.tsx のみ
- ルートとなる oxlint の挙動改善は upstream 側の課題

## 影響範囲

- `apps/docs` のビルド・実行挙動に変更なし
- `@k8o/arte-odyssey` の publish 内容に変更なし（changeset は release 駆動目的）