### PR TITLE
chore: update repository URLs after rename to k35o/arte-odyssey

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,7 @@
   "changelog": [
     "@changesets/changelog-github",
     {
-      "repo": "k35o/ArteOdyssey"
+      "repo": "k35o/arte-odyssey"
     }
   ],
   "commit": false,

--- a/.changeset/repo-rename-arte-odyssey.md
+++ b/.changeset/repo-rename-arte-odyssey.md
@@ -1,0 +1,11 @@
+---
+'@k8o/arte-odyssey': patch
+---
+
+リポジトリ名を `k35o/ArteOdyssey` から `k35o/arte-odyssey` に変更したことに伴い、パッケージメタデータを追従させた。
+
+- `packages/arte-odyssey/package.json` の `bugs.url` と `repository.url` を新リポジトリ URL に更新
+- `.changeset/config.json` の `repo` を更新（今後の CHANGELOG 生成リンクが新URLになる）
+- ルート `package.json` の `repository.url` を更新
+
+GitHub のリダイレクトで旧URLは当面動くが、npm 上の "Bug Reports" / "Repository" リンクを新URLに正すため publish に反映する。公開 API・実装の変更はない。

--- a/apps/docs/src/pages/home.tsx
+++ b/apps/docs/src/pages/home.tsx
@@ -91,7 +91,7 @@ export function Home() {
           renderItem={({ className, children }) => (
             <a
               className={className}
-              href="https://github.com/k35o/ArteOdyssey"
+              href="https://github.com/k35o/arte-odyssey"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "k8o",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/k35o/ArteOdyssey.git"
+    "url": "git+https://github.com/k35o/arte-odyssey.git"
   },
   "type": "module",
   "scripts": {

--- a/packages/arte-odyssey/package.json
+++ b/packages/arte-odyssey/package.json
@@ -11,13 +11,13 @@
     "ui"
   ],
   "bugs": {
-    "url": "https://github.com/k35o/ArteOdyssey/issues"
+    "url": "https://github.com/k35o/arte-odyssey/issues"
   },
   "license": "MIT",
   "author": "k8o <kosakanoki@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/k35o/ArteOdyssey.git"
+    "url": "git+https://github.com/k35o/arte-odyssey.git"
   },
   "files": [
     "dist/**",


### PR DESCRIPTION
## 概要

リポジトリ名を `k35o/ArteOdyssey` から `k35o/arte-odyssey` にリネームしたことに伴い、ハードコードされていた旧 URL を新 URL に追従させた。`@k8o/arte-odyssey` の package.json メタデータ更新を次回 publish で npm に反映させるため、`patch` bump の changeset を同梱している。

## 詳細

- [package.json](package.json) の `repository.url`
- [packages/arte-odyssey/package.json](packages/arte-odyssey/package.json) の `bugs.url`（npm "Bug Reports" リンク）と `repository.url`
- [.changeset/config.json](.changeset/config.json) の `repo`（今後の CHANGELOG で新 URL のコミットリンクが生成される）
- [apps/docs/src/pages/home.tsx](apps/docs/src/pages/home.tsx) のヘッダーの GitHub リンク
- `@k8o/arte-odyssey: patch` の changeset を追加

## 気をつけるポイント

- CHANGELOG の過去履歴 (`packages/arte-odyssey/CHANGELOG.md` など) に含まれる旧 URL は **意図的に触っていない**。リダイレクト依存にはなるが、履歴改変を避けるため。GitHub のリポジトリ rename redirect が将来効かなくなった場合のみ問題になる。
- ローカル `git remote` は worktree 経由で更新済み。各開発者の clone には `git remote set-url origin https://github.com/k35o/arte-odyssey.git` の周知が必要。

## 影響範囲

- 公開 API・実装の変更なし
- npm 上の "Bug Reports" / "Repository" リンクが新 URL に更新される（次回 publish 反映）
- docs サイトのヘッダー GitHub リンクが新 URL を指す