### PR TITLE
chore(ci): install Pavo for AI PR review

### DIFF
--- a/.github/workflows/pavo.yml
+++ b/.github/workflows/pavo.yml
@@ -29,7 +29,7 @@ jobs:
           client-id: ${{ secrets.K35O_BOT_CLIENT_ID }}
           private-key: ${{ secrets.K35O_BOT_PRIVATE_KEY }}
 
-      - uses: k35o/pavo@ee23767cfa7706afbc7f9d1e7af7e2f7e4c9a087 # main
+      - uses: k35o/pavo@42636a821024e801b5a0acda2ef97608634306df # main
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           app_slug: ${{ steps.app-token.outputs.app-slug }}

--- a/.github/workflows/pavo.yml
+++ b/.github/workflows/pavo.yml
@@ -1,0 +1,40 @@
+name: Pavo
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  pull_request_review_comment:
+    types: [created]
+
+# Same-PR pushes cancel earlier in-flight reviews so only the latest commit is reviewed.
+# event_name in the group keeps review and reply jobs from cancelling each other.
+concurrency:
+  group: pavo-${{ github.event_name }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  pavo:
+    # Skip on PRs from forks: secrets are not exposed to fork workflows so the App
+    # token step would fail anyway, and we don't want a permanent red Actions run.
+    if: ${{ github.event.pull_request.head.repo.fork != true }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.K35O_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.K35O_BOT_PRIVATE_KEY }}
+
+      - uses: k35o/pavo@ee23767cfa7706afbc7f9d1e7af7e2f7e4c9a087 # main
+        with:
+          github_token: ${{ steps.app-token.outputs.token }}
+          app_slug: ${{ steps.app-token.outputs.app-slug }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          instructions: default,react
+          extra_prompt: |
+            React コンポーネントライブラリ（デザインシステム）です。
+            Storybook で各コンポーネントの表示・操作テストを書いており、Chromatic で視覚回帰テストを行っています。


### PR DESCRIPTION
## Summary

[k35o/pavo](https://github.com/k35o/pavo) を caller として組み込み、PR のオープン・更新・再オープンと、Pavo bot のインラインコメントへの返信に反応してレビュー / 会話を行う。

## 構成

- **観点**: `default,react`（依存解決で `frontend` も自動ロード）
- **extra_prompt**: 「React コンポーネントライブラリ + Storybook + Chromatic」
- **モデル**: caller 側非指定（pavo 側で Sonnet 4.6）
- **runtime**: 平均 ~1m45s

## 必要な secret

すでに org / k8o レベルで設定済みの 3 つを継承:
- `CLAUDE_CODE_OAUTH_TOKEN`
- `K35O_BOT_CLIENT_ID`
- `K35O_BOT_PRIVATE_KEY`

## hygiene

k35o/pavo + k35o/k8o と同じ shape:
- SHA pin
- `timeout-minutes: 10`
- event 別 `concurrency` (review/reply 互いに cancel しない)
- fork PR ガード
- `id-token` なし最小権限

## Test plan

- [ ] Pavo が初回 review を走らせる
- [ ] 1 Review にバンドルされる（split しない）
- [ ] inline コメントへ返信 → 会話 path 動作