### PR TITLE
fix(icon-button): default tooltip placement to top

### DIFF
--- a/.changeset/icon-button-tooltip-top.md
+++ b/.changeset/icon-button-tooltip-top.md
@@ -1,0 +1,7 @@
+---
+'@k8o/arte-odyssey': patch
+---
+
+`IconButton` の `tooltipPlacement` のデフォルト値を `'bottom'` から `'top'` に変更した。
+
+ツールチップがボタンの上に表示されることで、下部のコンテンツが隠れにくくなる。`tooltipPlacement` を明示的に指定しているコードに影響はない。

--- a/apps/docs/src/pages/components/icon-button-page.tsx
+++ b/apps/docs/src/pages/components/icon-button-page.tsx
@@ -30,7 +30,7 @@ const iconButtonProps: PropItem[] = [
   {
     name: 'tooltipPlacement',
     types: ['Placement'],
-    defaultValue: "'bottom'",
+    defaultValue: "'top'",
   },
   { name: 'tooltipDisabled', types: ['boolean'], defaultValue: 'false' },
   {

--- a/packages/arte-odyssey/src/components/buttons/icon-button/icon-button.tsx
+++ b/packages/arte-odyssey/src/components/buttons/icon-button/icon-button.tsx
@@ -38,7 +38,7 @@ export const IconButton: FC<Props> = ({
   size = 'md',
   bg = 'transparent',
   label,
-  tooltipPlacement = 'bottom',
+  tooltipPlacement = 'top',
   tooltipDisabled = false,
   children,
   onAction,


### PR DESCRIPTION
## 概要

`IconButton` の `tooltipPlacement` のデフォルト値を `'bottom'` から `'top'` に変更した。ボタン下部にツールチップが出るとボタン直下のコンテンツに被るケースがあるため、上方向をデフォルトにする。

## 詳細

- [packages/arte-odyssey/src/components/buttons/icon-button/icon-button.tsx](packages/arte-odyssey/src/components/buttons/icon-button/icon-button.tsx) の `tooltipPlacement` デフォルト値を `'top'` に変更
- [apps/docs/src/pages/components/icon-button-page.tsx](apps/docs/src/pages/components/icon-button-page.tsx) の Props テーブルのデフォルト値表記を `'top'` に同期
- `@k8o/arte-odyssey: patch` の changeset を追加

## 気をつけるポイント

- `tooltipPlacement` を明示的に指定している呼び出し側には影響なし
- デフォルトに依存している呼び出し側では、ツールチップの表示位置が下→上に変わる（視覚的な変更）
- `IconButton` のロジック・公開 API シグネチャは変更なし

## 影響範囲

- ライブラリ利用側で `tooltipPlacement` を指定していない `IconButton` の見た目
- docs の `IconButton` ページの Props 表記