### PR TITLE
chore(ci): commit release PRs as k8o-bot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,27 @@ jobs:
           client-id: ${{ secrets.K35O_BOT_CLIENT_ID }}
           private-key: ${{ secrets.K35O_BOT_PRIVATE_KEY }}
 
+      - name: Resolve GitHub App user id
+        id: app-user
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          APP_SLUG: ${{ steps.generate-token.outputs.app-slug }}
+        run: |
+          user_id=$(gh api "users/${APP_SLUG}[bot]" --jq .id)
+          echo "id=${user_id}" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Configure git user as GitHub App
+        env:
+          APP_SLUG: ${{ steps.generate-token.outputs.app-slug }}
+          APP_USER_ID: ${{ steps.app-user.outputs.id }}
+        run: |
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
 
       - name: Install
         uses: ./.github/composite-actions/install
@@ -36,5 +53,6 @@ jobs:
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           publish: pnpm release
+          setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
## 概要

`changesets/action` が作成するリリース PR (#461 など) のコミット author が `github-actions[bot]` になっていたのを、トークン発行元の k8o-bot に揃える。

## 動機

リリースワークフローは `actions/create-github-app-token` で k8o-bot のトークンを発行しているため、PR の作成者は k8o-bot になっていた。一方、PR 内のコミット author は `github-actions[bot]` のままで、見た目がちぐはぐだった。

原因は `changesets/action` が内部で `git config user.{name,email}` を `github-actions[bot]` にハードコードしていること。git のコミット author/committer は commit object 自体に書き込まれる値なので、push に使うトークンとは独立に決まる。

## 詳細

- `Resolve GitHub App user id` ステップを追加。`gh api users/<app-slug>[bot]` で App ユーザーの数値 ID を実行時に取得する（ID をハードコードしない）。
- `Configure git user as GitHub App` ステップを checkout 後に追加し、`<id>+<app-slug>[bot]@users.noreply.github.com` 形式で `user.name` / `user.email` を設定する。
- `changesets/action` に `setupGitUser: false` を渡し、action 側のハードコード設定を抑止する。

## 気をつけるポイント

- マージ後に次のリリース PR が作成・更新されたタイミングで初めて挙動が確認できる。マージ直後は既存の #461 を一度閉じる、もしくは新しい changeset で再生成させて差分を見るのが確実。
- App slug が変わると email の形式も変わるため、Secrets で別の App に切り替える際は同じ仕組みで自動追従する。

## 影響範囲

- `.github/workflows/release.yml` のみ。リリースワークフロー以外には影響しない。