### PR TITLE
fix(docs): reorder theming nav and fix border-radius layout

### DIFF
--- a/apps/docs/src/components/navigation.tsx
+++ b/apps/docs/src/components/navigation.tsx
@@ -11,8 +11,8 @@ import { ThemeSwitcher } from './theme-switcher';
 const NAV_ITEMS: Array<{ path: string; labelKey: MessageKey }> = [
   { path: '/', labelKey: 'nav.home' },
   { path: '/get-started', labelKey: 'nav.getStarted' },
-  { path: '/components', labelKey: 'nav.components' },
   { path: '/theming', labelKey: 'nav.theming' },
+  { path: '/components', labelKey: 'nav.components' },
   { path: '/hooks', labelKey: 'nav.hooks' },
   { path: '/helpers', labelKey: 'nav.helpers' },
 ];

--- a/apps/docs/src/pages/theming.tsx
+++ b/apps/docs/src/pages/theming.tsx
@@ -300,7 +300,7 @@ export function Theming() {
         <p className="text-fg-mute">
           <T k="theming.borderRadiusDescription" />
         </p>
-        <div className="flex items-end gap-6">
+        <div className="grid grid-cols-3 gap-4 sm:grid-cols-5 sm:gap-6">
           {RADII.map((radius) => (
             <div className="flex flex-col items-center gap-2" key={radius.name}>
               <div


### PR DESCRIPTION
## Summary

- ナビ順序を変更: Theming を「はじめに」(Get Started) の直後に表示するようにした
- borderRadius プレビューが小さい画面で横に溢れていたのを `grid-cols-3 sm:grid-cols-5` のレスポンシブグリッドに変更して修正

## Test plan

- [x] `pnpm --filter docs typecheck` 通過
- [x] `pnpm --filter docs check` 通過
- [x] `pnpm --filter docs build` 成功
- [ ] dev server で実際の表示を確認（モバイル幅でborderRadiusが折り返すこと）
- [ ] ナビ表示順がHome → Get Started → Theming → Components → Hooks → Helpers になっていること