### PR TITLE
refactor(arte-odyssey): dogfood createSafeContext across compound components

### DIFF
--- a/.changeset/dogfood-create-safe-context.md
+++ b/.changeset/dogfood-create-safe-context.md
@@ -1,0 +1,7 @@
+---
+'@k8o/arte-odyssey': patch
+---
+
+`createSafeContext` ヘルパーを内部のCompoundコンポーネントで dogfood 適用した。`createContext` + `use` + null チェックの定型コードを削減し、Provider外で利用された際のエラーメッセージを統一した。
+
+対象: `FileField` / `Dialog` / `DropdownMenu` / `ListBox` / `Popover` / `Tabs` / `Toast` / `Accordion`

--- a/packages/arte-odyssey/src/components/data-display/accordion/context.tsx
+++ b/packages/arte-odyssey/src/components/data-display/accordion/context.tsx
@@ -2,31 +2,22 @@
 
 import { createContext, type FC, type PropsWithChildren, use } from 'react';
 
+import { createSafeContext } from '../../../helpers/create-safe-context';
 import { useDisclosure } from '../../../hooks/disclosure';
 
 const OpenContext = createContext(false);
 
 type ToggleOpen = () => void;
-const ToggleOpenContext = createContext<ToggleOpen | undefined>(undefined);
-const ItemIdContext = createContext<string | undefined>(undefined);
+const [ToggleOpenContext, useToggleOpen] = createSafeContext<ToggleOpen>(
+  'useToggleOpen must be used within AccordionProvider',
+);
+const [ItemIdContext, useItemId] = createSafeContext<string>(
+  'useItemId must be used within AccordionProvider',
+);
+
+export { useItemId, useToggleOpen };
 
 export const useOpen = (): boolean => use(OpenContext);
-
-export const useToggleOpen = (): ToggleOpen => {
-  const toggleOpen = use(ToggleOpenContext);
-  if (!toggleOpen) {
-    throw new Error('useToggleOpen must be used within AccordionProvider');
-  }
-  return toggleOpen;
-};
-
-export const useItemId = (): string => {
-  const id = use(ItemIdContext);
-  if (id === undefined || id === '') {
-    throw new Error('useItemId must be used within AccordionProvider');
-  }
-  return id;
-};
 
 export const AccordionItemProvider: FC<
   PropsWithChildren<{

--- a/packages/arte-odyssey/src/components/feedback/toast/context.ts
+++ b/packages/arte-odyssey/src/components/feedback/toast/context.ts
@@ -1,13 +1,8 @@
 'use client';
 
-import {
-  createContext,
-  type Dispatch,
-  type SetStateAction,
-  use,
-  useCallback,
-} from 'react';
+import { type Dispatch, type SetStateAction, useCallback } from 'react';
 
+import { createSafeContext } from './../../../helpers/create-safe-context';
 import type { Status } from './../../../types/variables';
 
 const MAX_TOAST_COUNT = 5;
@@ -18,15 +13,12 @@ export type ToastType = {
   message: string;
 };
 
-export const SetToastContext = createContext<
-  Dispatch<SetStateAction<ToastType[]>> | undefined
->(undefined);
+export const [SetToastContext, useSetToast] = createSafeContext<
+  Dispatch<SetStateAction<ToastType[]>>
+>('useToast must be used within a ToastProvider');
 
 export const useToast = () => {
-  const setToasts = use(SetToastContext);
-  if (!setToasts) {
-    throw new Error('useToast must be used within a ToastProvider');
-  }
+  const setToasts = useSetToast();
 
   const onOpen = useCallback(
     (status: Status, message: string) => {

--- a/packages/arte-odyssey/src/components/form/file-field/file-field.tsx
+++ b/packages/arte-odyssey/src/components/form/file-field/file-field.tsx
@@ -8,19 +8,12 @@ import type {
   PropsWithChildren,
   ReactElement,
 } from 'react';
-import {
-  createContext,
-  use,
-  useCallback,
-  useId,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { useCallback, useId, useMemo, useRef, useState } from 'react';
 import { useFormStatus } from 'react-dom';
 
 import { IconButton } from '../../buttons/icon-button';
 import { CloseIcon } from '../../icons';
+import { createSafeContext } from './../../../helpers/create-safe-context';
 
 type AcceptedFile = {
   file: File;
@@ -35,18 +28,10 @@ type FileFieldContext = {
   openFilePicker: () => void;
 };
 
-const FileFieldContext = createContext<FileFieldContext | null>(null);
-
-const FileFieldProvider = FileFieldContext;
-
-const useFileFieldContext = (): FileFieldContext => {
-  const fileField = use(FileFieldContext);
-  if (!fileField) {
-    throw new Error('useFileFieldContext must be used within a FileField.Root');
-  }
-
-  return fileField;
-};
+const [FileFieldProvider, useFileFieldContext] =
+  createSafeContext<FileFieldContext>(
+    'useFileFieldContext must be used within a FileField.Root',
+  );
 
 type RootProps = PropsWithChildren<
   {

--- a/packages/arte-odyssey/src/components/navigation/tabs/tabs.tsx
+++ b/packages/arte-odyssey/src/components/navigation/tabs/tabs.tsx
@@ -2,12 +2,10 @@
 
 import * as motion from 'motion/react-client';
 import {
-  createContext,
   type FC,
   type KeyboardEvent,
   type PropsWithChildren,
   type RefObject,
-  use,
   useEffect,
   useId,
   useMemo,
@@ -16,6 +14,7 @@ import {
 } from 'react';
 
 import { cn } from './../../../helpers/cn';
+import { createSafeContext } from './../../../helpers/create-safe-context';
 
 type TabsContext = {
   rootId: string;
@@ -24,15 +23,9 @@ type TabsContext = {
   setSelectedId: (id: string) => void;
 };
 
-const TabsProvider = createContext<TabsContext | undefined>(undefined);
-
-const useTabsState = (): TabsContext => {
-  const context = use(TabsProvider);
-  if (!context) {
-    throw new Error('useTabsState must be used within a TabsProvider');
-  }
-  return context;
-};
+const [TabsProvider, useTabsState] = createSafeContext<TabsContext>(
+  'useTabsState must be used within a TabsProvider',
+);
 
 const Root: FC<
   PropsWithChildren<{
@@ -68,22 +61,9 @@ const Root: FC<
   );
 };
 
-const TabsListProvider = createContext<
-  | {
-      setFocusRef: RefObject<boolean>;
-    }
-  | undefined
->(undefined);
-
-const useTabsListState = (): {
+const [TabsListProvider, useTabsListState] = createSafeContext<{
   setFocusRef: RefObject<boolean>;
-} => {
-  const context = use(TabsListProvider);
-  if (!context) {
-    throw new Error('useTabListState must be used within a TabListProvider');
-  }
-  return context;
-};
+}>('useTabListState must be used within a TabListProvider');
 
 const List: FC<
   PropsWithChildren<{

--- a/packages/arte-odyssey/src/components/overlays/dialog/dialog.tsx
+++ b/packages/arte-odyssey/src/components/overlays/dialog/dialog.tsx
@@ -1,11 +1,9 @@
 'use client';
 
 import {
-  createContext,
   type FC,
   type PropsWithChildren,
   type Ref,
-  use,
   useId,
   useMemo,
 } from 'react';
@@ -13,18 +11,11 @@ import {
 import { IconButton } from '../../buttons/icon-button';
 import { Heading } from '../../data-display/heading';
 import { CloseIcon } from '../../icons';
+import { createSafeContext } from './../../../helpers/create-safe-context';
 
-const DialogContext = createContext<{
+const [DialogContext, useDialogContext] = createSafeContext<{
   rootId: string;
-} | null>(null);
-
-const useDialogContext = () => {
-  const context = use(DialogContext);
-  if (context === null) {
-    throw new Error('useDialogContext must be used within a DialogProvider');
-  }
-  return context;
-};
+}>('useDialogContext must be used within a DialogProvider');
 
 const Root: FC<
   PropsWithChildren<{

--- a/packages/arte-odyssey/src/components/overlays/dropdown-menu/hooks.ts
+++ b/packages/arte-odyssey/src/components/overlays/dropdown-menu/hooks.ts
@@ -2,15 +2,14 @@
 
 import { useListItem } from '@floating-ui/react';
 import {
-  createContext,
   type HTMLAttributes,
   type HTMLProps,
   type MouseEventHandler,
   type RefObject,
-  use,
   useMemo,
 } from 'react';
 
+import { createSafeContext } from '../../../helpers/create-safe-context';
 import { useOpenContext } from '../popover/hooks';
 
 type MenuContext = {
@@ -27,18 +26,10 @@ type MenuContext = {
   ) => HTMLAttributes<HTMLElement>;
 };
 
-const MenuContext = createContext<MenuContext | null>(null);
-
-export const MenuContextProvider = MenuContext;
-
-const useMenuContext = (): MenuContext => {
-  const menu = use(MenuContext);
-  if (!menu) {
-    throw new Error('useMenuContext must be used within a DropdownMenu.Root');
-  }
-
-  return menu;
-};
+export const [MenuContextProvider, useMenuContext] =
+  createSafeContext<MenuContext>(
+    'useMenuContext must be used within a DropdownMenu.Root',
+  );
 
 export const useMenuContent = () => {
   const menu = useMenuContext();

--- a/packages/arte-odyssey/src/components/overlays/list-box/hooks.ts
+++ b/packages/arte-odyssey/src/components/overlays/list-box/hooks.ts
@@ -2,14 +2,13 @@
 
 import { useListItem } from '@floating-ui/react';
 import {
-  createContext,
   type HTMLAttributes,
   type HTMLProps,
   type RefObject,
-  use,
   useMemo,
 } from 'react';
 
+import { createSafeContext } from '../../../helpers/create-safe-context';
 import { useOpenContext } from '../popover/hooks';
 
 export type Option = {
@@ -34,18 +33,11 @@ type MenuContext = {
   ) => HTMLAttributes<HTMLElement>;
 };
 
-const MenuContext = createContext<MenuContext | null>(null);
+const [MenuContextProvider, useMenuContext] = createSafeContext<MenuContext>(
+  'useMenuContext must be used within a ListBox.Root',
+);
 
-export const MenuContextProvider = MenuContext;
-
-const useMenuContext = (): MenuContext => {
-  const menu = use(MenuContext);
-  if (!menu) {
-    throw new Error('useMenuContext must be used within a DropdownMenu.Root');
-  }
-
-  return menu;
-};
+export { MenuContextProvider };
 
 export const useMenuContent = () => {
   const menu = useMenuContext();

--- a/packages/arte-odyssey/src/components/overlays/popover/hooks.ts
+++ b/packages/arte-odyssey/src/components/overlays/popover/hooks.ts
@@ -7,17 +7,16 @@ import type {
 } from '@floating-ui/react';
 import {
   type CSSProperties,
-  createContext,
   type KeyboardEvent,
   type KeyboardEventHandler,
   type MouseEventHandler,
   type RefCallback,
   type RefObject,
-  use,
   useMemo,
   useRef,
 } from 'react';
 
+import { createSafeContext } from './../../../helpers/create-safe-context';
 import { useClickAway } from './../../../hooks/click-away';
 
 type PopoverContext = {
@@ -38,18 +37,10 @@ type PopoverContext = {
   contentStyles: CSSProperties;
 };
 
-const PopoverContext = createContext<PopoverContext | null>(null);
-
-export const PopoverProvider = PopoverContext;
-
-export const usePopoverContext = (): PopoverContext => {
-  const popover = use(PopoverContext);
-  if (!popover) {
-    throw new Error('usePopoverContext must be used within a Popover.Root');
-  }
-
-  return popover;
-};
+export const [PopoverProvider, usePopoverContext] =
+  createSafeContext<PopoverContext>(
+    'usePopoverContext must be used within a Popover.Root',
+  );
 
 export const useFloatingUIContext = () => {
   const popover = usePopoverContext();


### PR DESCRIPTION
## Summary

公開済みヘルパー \`createSafeContext\` を内部のCompoundコンポーネントで適用 (dogfooding)。\`createContext\` + \`use\` + null チェックの定型コードを統一した。

### 対象

8コンポーネント・9コンテキストを移行:

- \`FileField\` (FileFieldContext)
- \`Dialog\` (DialogContext)
- \`DropdownMenu\` (MenuContext)
- \`ListBox\` (MenuContext)
- \`Popover\` (PopoverContext)
- \`Tabs\` (TabsContext + TabsListContext の2つ)
- \`Toast\` (SetToastContext)
- \`Accordion\` (ToggleOpenContext + ItemIdContext の2つ、OpenContextはデフォルトbool値があるので非対象)

### 効果

- 132行 → 52行に削減 (-80行)
- Provider外利用時のエラー処理が一貫
- 公開ヘルパーが内部でも使われていることで品質保証になる

### 既存挙動への影響なし

- Context の値・型は同一
- エラーメッセージも基本的に同一 (ListBoxのMenuContextだけ \"DropdownMenu.Root\" → \"ListBox.Root\" にエラー文言を実態に合わせて修正)

## Test plan

- [x] \`pnpm --filter @k8o/arte-odyssey typecheck\` 通過
- [x] \`pnpm --filter @k8o/arte-odyssey check\` 通過
- [x] \`pnpm --filter @k8o/arte-odyssey build\` 成功
- [x] \`pnpm --filter @k8o/arte-odyssey test --project=helpers\` 29/29 passing
- [ ] Storybook component testsが既存どおり通る (CI側で確認)