### PR TITLE
refactor(arte-odyssey): dogfood useControllableState across form components

### DIFF
--- a/.changeset/dogfood-controllable-state.md
+++ b/.changeset/dogfood-controllable-state.md
@@ -1,0 +1,7 @@
+---
+'@k8o/arte-odyssey': patch
+---
+
+`useControllableState` フックを内部のフォーム系コンポーネントで dogfood 適用した。各コンポーネントが手書きで持っていた `isControlled = value !== undefined` + `useState` + 条件分岐 + `onChange` 呼び出しの定型コードを削減した。
+
+対象: `Switch` / `Checkbox` / `Radio` / `RadioCard` / `CheckboxCard` / `NumberField`

--- a/packages/arte-odyssey/src/components/form/checkbox-card/checkbox-card.tsx
+++ b/packages/arte-odyssey/src/components/form/checkbox-card/checkbox-card.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import type { FC, FieldsetHTMLAttributes, ReactNode } from 'react';
-import { useId, useState } from 'react';
+import { useId } from 'react';
 
 import { cn } from '../../../helpers/cn';
+import { useControllableState } from '../../../hooks/controllable-state';
 import { CheckIcon } from '../../icons';
 
 export type CheckboxCardOption = Readonly<{
@@ -47,19 +48,17 @@ export const CheckboxCard: FC<Props> = ({
   ...rest
 }) => {
   const groupId = useId();
-  const [internalValue, setInternalValue] = useState(defaultValue ?? []);
-  const isControlled = value !== undefined;
-  const selectedValues = isControlled ? value : internalValue;
+  const [selectedValues, setSelectedValues] = useControllableState<string[]>({
+    value,
+    defaultValue: defaultValue ?? [],
+    onChange,
+  });
 
   const handleToggle = (nextValue: string, checked: boolean) => {
     const nextValues = checked
       ? [...selectedValues, nextValue]
       : selectedValues.filter((item) => item !== nextValue);
-
-    if (!isControlled) {
-      setInternalValue(nextValues);
-    }
-    onChange?.(nextValues);
+    setSelectedValues(nextValues);
   };
 
   return (

--- a/packages/arte-odyssey/src/components/form/checkbox/checkbox.tsx
+++ b/packages/arte-odyssey/src/components/form/checkbox/checkbox.tsx
@@ -6,12 +6,12 @@ import type {
   FC,
   InputHTMLAttributes,
 } from 'react';
-import { useState } from 'react';
 import { useFormStatus } from 'react-dom';
 
 import { CheckIcon } from '../../icons';
 import { useCheckboxGroupContext } from '../checkbox-group/checkbox-group';
 import { cn } from './../../../helpers/cn';
+import { useControllableState } from './../../../hooks/controllable-state';
 
 type BaseProps = {
   itemValue?: string;
@@ -53,9 +53,10 @@ export const Checkbox: FC<Props> = ({
 }) => {
   const groupContext = useCheckboxGroupContext();
   const { pending } = useFormStatus();
-  const [internalChecked, setInternalChecked] = useState(
-    defaultChecked ?? false,
-  );
+  const [internalChecked, setInternalChecked] = useControllableState({
+    value,
+    defaultValue: defaultChecked ?? false,
+  });
   const groupItemValue = itemValue ?? '';
 
   if (groupContext && (itemValue === undefined || itemValue === '')) {
@@ -67,14 +68,10 @@ export const Checkbox: FC<Props> = ({
     disabled || groupContext?.disabled === true || pending;
   const checked = groupContext
     ? groupContext.currentValue.includes(groupItemValue)
-    : isControlled
-      ? value
-      : internalChecked;
+    : internalChecked;
 
   const setChecked = (nextChecked: boolean) => {
-    if (!isControlled) {
-      setInternalChecked(nextChecked);
-    }
+    setInternalChecked(nextChecked);
     onChange?.({
       target: { checked: nextChecked },
     } as ChangeEvent<HTMLInputElement>);

--- a/packages/arte-odyssey/src/components/form/number-field/number-field.tsx
+++ b/packages/arte-odyssey/src/components/form/number-field/number-field.tsx
@@ -5,6 +5,7 @@ import { useFormStatus } from 'react-dom';
 
 import { ChevronIcon } from '../../icons';
 import { cn } from './../../../helpers/cn';
+import { useControllableState } from './../../../hooks/controllable-state';
 import { clamp } from './../../../internal/clamp';
 import { toPrecision } from './../../../internal/to-precision';
 import { cast } from './cast';
@@ -57,28 +58,24 @@ export const NumberField: FC<Props> = ({
   min = -9_007_199_254_740_991,
   ...rest
 }) => {
-  const isControlled = value !== undefined;
-  const initialValue = defaultValue ?? value ?? 0;
-
-  const [internalValue, setInternalValue] = useState(initialValue);
+  const [currentValue, setCurrentValue] = useControllableState<number>({
+    value,
+    defaultValue: defaultValue ?? 0,
+    onChange,
+  });
   const [displayValue, setDisplayValue] = useState(
-    initialValue.toFixed(precision),
+    currentValue.toFixed(precision),
   );
-  const [prevValue, setPrevValue] = useState(initialValue);
+  const [prevValue, setPrevValue] = useState(currentValue);
   const { pending } = useFormStatus();
 
-  const currentValue = isControlled ? value : internalValue;
-
-  if (isControlled && value !== prevValue) {
-    setDisplayValue(value.toFixed(precision));
-    setPrevValue(value);
+  if (currentValue !== prevValue) {
+    setDisplayValue(currentValue.toFixed(precision));
+    setPrevValue(currentValue);
   }
 
   const handleChange = (newValue: number) => {
-    if (!isControlled) {
-      setInternalValue(newValue);
-    }
-    onChange?.(newValue);
+    setCurrentValue(newValue);
   };
 
   return (

--- a/packages/arte-odyssey/src/components/form/radio-card/radio-card.tsx
+++ b/packages/arte-odyssey/src/components/form/radio-card/radio-card.tsx
@@ -8,9 +8,10 @@ import type {
   KeyboardEvent,
   ReactNode,
 } from 'react';
-import { useId, useRef, useState } from 'react';
+import { useId, useRef } from 'react';
 
 import { cn } from '../../../helpers/cn';
+import { useControllableState } from '../../../hooks/controllable-state';
 
 export type RadioCardOption = Readonly<{
   value: string;
@@ -56,16 +57,15 @@ export const RadioCard: FC<Props> = ({
 }) => {
   const groupId = useId();
   const buttonRefs = useRef<Array<HTMLButtonElement | null>>([]);
-  const [internalValue, setInternalValue] = useState(
-    defaultValue ?? options[0]?.value,
-  );
-  const isControlled = value !== undefined;
-  const currentValue = isControlled ? value : internalValue;
+  const [currentValue, setCurrentValue] = useControllableState<
+    string | undefined
+  >({
+    value,
+    defaultValue: defaultValue ?? options[0]?.value,
+  });
 
   const selectValue = (nextValue: string) => {
-    if (!isControlled) {
-      setInternalValue(nextValue);
-    }
+    setCurrentValue(nextValue);
     onChange?.({
       target: { value: nextValue },
     } as ChangeEvent<HTMLInputElement>);

--- a/packages/arte-odyssey/src/components/form/radio/radio.tsx
+++ b/packages/arte-odyssey/src/components/form/radio/radio.tsx
@@ -6,11 +6,11 @@ import type {
   FC,
   HTMLAttributes,
 } from 'react';
-import { useState } from 'react';
 import { useFormStatus } from 'react-dom';
 
 import type { Option } from '../../../types/variables';
 import { cn } from './../../../helpers/cn';
+import { useControllableState } from './../../../hooks/controllable-state';
 
 type BaseProps = {
   'aria-labelledby': string;
@@ -46,16 +46,18 @@ export const Radio: FC<Props> = ({
   options,
   ...rest
 }) => {
-  const [internalValue, setInternalValue] = useState(defaultValue);
+  const [selectedValue, setSelectedValue] = useControllableState<
+    string | undefined
+  >({
+    value,
+    defaultValue,
+  });
   const { pending } = useFormStatus();
   const isControlled = value !== undefined;
-  const selectedValue = isControlled ? value : internalValue;
   const disabledResolved = disabled || pending;
 
   const selectValue = (nextValue: string) => {
-    if (!isControlled) {
-      setInternalValue(nextValue);
-    }
+    setSelectedValue(nextValue);
     onChange?.({
       target: { value: nextValue },
     } as ChangeEvent<HTMLInputElement>);

--- a/packages/arte-odyssey/src/components/form/switch/switch.tsx
+++ b/packages/arte-odyssey/src/components/form/switch/switch.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import type { ChangeEventHandler, FC, InputHTMLAttributes } from 'react';
-import { useId, useState } from 'react';
+import { useId } from 'react';
 import { useFormStatus } from 'react-dom';
 
 import { cn } from '../../../helpers/cn';
+import { useControllableState } from '../../../hooks/controllable-state';
 
 type BaseProps = {
   invalid?: boolean;
@@ -48,13 +49,13 @@ export const Switch: FC<Props> = ({
 }) => {
   const generatedId = useId();
   const inputId = id ?? generatedId;
-  const [internalChecked, setInternalChecked] = useState(
-    defaultChecked ?? false,
-  );
+  const [isSelected, setSelected] = useControllableState({
+    value,
+    defaultValue: defaultChecked ?? false,
+  });
   const { pending } = useFormStatus();
 
   const isControlled = value !== undefined;
-  const isSelected = isControlled ? value : internalChecked;
   const disabledResolved = disabled || pending;
 
   return (
@@ -76,9 +77,7 @@ export const Switch: FC<Props> = ({
           disabled={disabledResolved}
           id={inputId}
           onChange={(event) => {
-            if (!isControlled) {
-              setInternalChecked(event.target.checked);
-            }
+            setSelected(event.target.checked);
             onChange?.(event);
           }}
           required={required}


### PR DESCRIPTION
## Summary

公開済みフック \`useControllableState\` を内部のフォーム系コンポーネントで適用 (dogfooding)。各コンポーネントが手書きで持っていた controlled/uncontrolled パターンを統一した。

### 対象

6コンポーネントを移行:

- \`Switch\`
- \`Checkbox\`
- \`Radio\`
- \`RadioCard\`
- \`CheckboxCard\`
- \`NumberField\`

### 既存挙動への影響なし

- 全コンポーネントで以下のパターンを集約:
  - \`isControlled = value !== undefined\`
  - \`useState\` で内部値を保持
  - controlled 時は外部 value、uncontrolled 時は内部値を表示
  - \`onChange\` を必要に応じて呼ぶ
- DOM入力の \`checked\` / \`defaultChecked\` の切り替えロジック (\`isControlled\` を参照) は引き続き残している

## Test plan

- [x] \`pnpm --filter @k8o/arte-odyssey typecheck\` 通過
- [x] \`pnpm --filter @k8o/arte-odyssey check\` 通過
- [x] \`pnpm --filter @k8o/arte-odyssey build\` 成功
- [ ] Storybook component testsが既存どおり通る (CI側で確認)