### PR TITLE
refactor(arte-odyssey): dogfood useDisclosure and chain helpers

### DIFF
--- a/.changeset/dogfood-disclosure-chain.md
+++ b/.changeset/dogfood-disclosure-chain.md
@@ -1,0 +1,7 @@
+---
+'@k8o/arte-odyssey': patch
+---
+
+`useDisclosure` フックを `Autocomplete` で適用した。`useState(false)` + `setOpen(true)`/`setOpen(false)` の手動open/close管理を `useDisclosure` の `isOpen`/`open`/`close` に置き換えた。
+
+`chain` ヘルパーを `IconButton` の Tooltip トリガープロップ統合で適用した。`(e) => { triggerProps.onFoo(e); userOnFoo?.(e); }` の手動チェイニングを `chain(triggerProps.onFoo, userOnFoo)` で簡潔にした。

--- a/packages/arte-odyssey/src/components/buttons/icon-button/icon-button.tsx
+++ b/packages/arte-odyssey/src/components/buttons/icon-button/icon-button.tsx
@@ -6,6 +6,7 @@ import { useTransition } from 'react';
 import { useFormStatus } from 'react-dom';
 
 import { Tooltip, type TooltipTriggerProps } from '../../overlays/tooltip';
+import { chain } from './../../../helpers/chain';
 import { cn } from './../../../helpers/cn';
 import { mergeRefs } from './../../../helpers/merge-refs';
 
@@ -157,23 +158,11 @@ export const IconButton: FC<Props> = ({
               aria-label={label}
               className={className}
               disabled={isDisabled}
-              onBlur={(e) => {
-                triggerProps.onBlur(e);
-                onBlur?.(e);
-              }}
+              onBlur={chain(triggerProps.onBlur, onBlur)}
               onClick={handleClick}
-              onFocus={(e) => {
-                triggerProps.onFocus(e);
-                onFocus?.(e);
-              }}
-              onMouseEnter={(e) => {
-                triggerProps.onMouseEnter(e);
-                onMouseEnter?.(e);
-              }}
-              onMouseLeave={(e) => {
-                triggerProps.onMouseLeave(e);
-                onMouseLeave?.(e);
-              }}
+              onFocus={chain(triggerProps.onFocus, onFocus)}
+              onMouseEnter={chain(triggerProps.onMouseEnter, onMouseEnter)}
+              onMouseLeave={chain(triggerProps.onMouseLeave, onMouseLeave)}
               ref={mergeRefs(ref, triggerProps.ref)}
               type="button"
             >

--- a/packages/arte-odyssey/src/components/form/autocomplete/autocomplete.tsx
+++ b/packages/arte-odyssey/src/components/form/autocomplete/autocomplete.tsx
@@ -12,6 +12,7 @@ import { useFormStatus } from 'react-dom';
 
 import { useControllableState } from '../../../hooks/controllable-state';
 import { useDeferredDebounce } from '../../../hooks/deferred-debounce';
+import { useDisclosure } from '../../../hooks/disclosure';
 import type { Option } from '../../../types/variables';
 import { IconButton } from '../../buttons/icon-button';
 import { CloseIcon } from '../../icons';
@@ -70,7 +71,7 @@ export const Autocomplete: FC<Props> = ({
   });
 
   const ref = useRef<HTMLDivElement>(null);
-  const [open, setOpen] = useState(false);
+  const { isOpen, open, close } = useDisclosure();
   const [text, setText] = useState('');
   const [selectIndex, setSelectIndex] = useState<number>();
 
@@ -83,9 +84,9 @@ export const Autocomplete: FC<Props> = ({
 
   const reset = useCallback(() => {
     setText('');
-    setOpen(false);
+    close();
     setSelectIndex(undefined);
-  }, []);
+  }, [close]);
 
   useEffect(() => {
     const handleClick = (e: MouseEvent) => {
@@ -151,8 +152,8 @@ export const Autocomplete: FC<Props> = ({
           <input
             {...rest}
             aria-autocomplete="list"
-            aria-controls={open ? `${id}_listbox` : undefined}
-            aria-expanded={open}
+            aria-controls={isOpen ? `${id}_listbox` : undefined}
+            aria-expanded={isOpen}
             aria-invalid={invalid}
             aria-required={required}
             autoComplete="off"
@@ -166,19 +167,19 @@ export const Autocomplete: FC<Props> = ({
               if (e.relatedTarget?.id.startsWith(`${id}_option_`) === true) {
                 return;
               }
-              setOpen(false);
+              close();
             }}
             onChange={(e) => {
-              setOpen(true);
+              open();
               setText(e.target.value);
               setSelectIndex(undefined);
             }}
             onClick={() => {
-              if (open && text.length === 0) {
-                setOpen(false);
+              if (isOpen && text.length === 0) {
+                close();
                 return;
               }
-              setOpen(true);
+              open();
               setSelectIndex(undefined);
             }}
             onKeyDown={(e) => {
@@ -188,7 +189,7 @@ export const Autocomplete: FC<Props> = ({
                 return;
               }
               if (e.key === 'ArrowDown') {
-                setOpen(true);
+                open();
                 setSelectIndex((prev) => {
                   if (prev === undefined) {
                     return 0;
@@ -198,7 +199,7 @@ export const Autocomplete: FC<Props> = ({
                 return;
               }
               if (e.key === 'ArrowUp') {
-                setOpen(true);
+                open();
                 setSelectIndex((prev) => {
                   if (prev === undefined) {
                     return 0;
@@ -251,7 +252,7 @@ export const Autocomplete: FC<Props> = ({
         )}
       </div>
       <div className="relative w-full">
-        {open && (
+        {isOpen && (
           <div
             className="bg-bg-raised absolute top-1 z-10 w-full rounded-xl shadow-md"
             role="presentation"


### PR DESCRIPTION
## Summary

未使用だった既存の \`useDisclosure\` フックと \`chain\` ヘルパーを内部で適用 (dogfooding)。

### 対象

- **Autocomplete**: \`useState(false)\` + \`setOpen(true)\`/\`setOpen(false)\` の手動 open/close 管理を \`useDisclosure\` の \`isOpen\`/\`open\`/\`close\` に置き換え
- **IconButton**: Tooltip トリガープロップとユーザーハンドラの手動チェイニング (\`(e) => { triggerProps.onFoo(e); userOnFoo?.(e); }\`) を \`chain(triggerProps.onFoo, userOnFoo)\` で簡潔に

### 既存挙動への影響なし

- 状態遷移は完全に同等
- IconButton のハンドラ実行順序も同じ (triggerProps → user)

## Test plan

- [x] \`pnpm --filter @k8o/arte-odyssey typecheck\` 通過
- [x] \`pnpm --filter @k8o/arte-odyssey check\` 通過
- [x] \`pnpm --filter @k8o/arte-odyssey build\` 成功
- [ ] Storybook component testsが既存どおり通る (CI側で確認)