### PR TITLE
feat(arte-odyssey): add horizontal and vertical writing icons

### DIFF
--- a/packages/arte-odyssey/src/components/icons/icons.stories.tsx
+++ b/packages/arte-odyssey/src/components/icons/icons.stories.tsx
@@ -23,6 +23,7 @@ import {
   FormIcon,
   GoodIcon,
   HistoryIcon,
+  HorizontalWritingIcon,
   InformativeIcon,
   InterestingIcon,
   LightModeIcon,
@@ -49,6 +50,7 @@ import {
 } from './lucide';
 import { QiitaIcon } from './qiita';
 import { TwitterIcon } from './twitter';
+import { VerticalWritingIcon } from './vertical-writing';
 
 const meta: Meta<typeof SVGAElement> = {
   title: 'components/icons',
@@ -130,6 +132,14 @@ export const Primary: Story = {
       <div className="flex flex-col items-center justify-center">
         <BlogIcon />
         <p className="text-center">Blog</p>
+      </div>
+      <div className="flex flex-col items-center justify-center">
+        <HorizontalWritingIcon />
+        <p className="text-center">横書き</p>
+      </div>
+      <div className="flex flex-col items-center justify-center">
+        <VerticalWritingIcon />
+        <p className="text-center">縦書き</p>
       </div>
       <div className="flex flex-col items-center justify-center">
         <SlideIcon />

--- a/packages/arte-odyssey/src/components/icons/index.ts
+++ b/packages/arte-odyssey/src/components/icons/index.ts
@@ -22,6 +22,7 @@ export {
   FormIcon,
   GoodIcon,
   HistoryIcon,
+  HorizontalWritingIcon,
   InformativeIcon,
   InterestingIcon,
   LightModeIcon,
@@ -52,3 +53,4 @@ export {
 } from './lucide';
 export { QiitaIcon } from './qiita';
 export { TwitterIcon } from './twitter';
+export { VerticalWritingIcon } from './vertical-writing';

--- a/packages/arte-odyssey/src/components/icons/lucide.tsx
+++ b/packages/arte-odyssey/src/components/icons/lucide.tsx
@@ -7,6 +7,7 @@ import {
   Bell,
   Blend,
   Bookmark,
+  BookOpenText,
   BookText,
   Bot,
   Calendar,
@@ -273,4 +274,8 @@ export const AccessibilityIcon: FC<IconProps> = ({ size = 'md' }) => (
 
 export const SparklesIcon: FC<IconProps> = ({ size = 'md' }) => (
   <BaseIcon renderItem={(props) => <Sparkles {...props} />} size={size} />
+);
+
+export const HorizontalWritingIcon: FC<IconProps> = ({ size = 'md' }) => (
+  <BaseIcon renderItem={(props) => <BookOpenText {...props} />} size={size} />
 );

--- a/packages/arte-odyssey/src/components/icons/vertical-writing.tsx
+++ b/packages/arte-odyssey/src/components/icons/vertical-writing.tsx
@@ -14,11 +14,9 @@ const VerticalWriting: FC<{ className: string }> = ({ className }) => (
     xmlns="http://www.w3.org/2000/svg"
   >
     <path d="M12 7v14" />
-    <path d="M15 8v4" />
-    <path d="M19 8v4" />
+    <path d="M17 8v4" />
     <path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z" />
-    <path d="M5 8v4" />
-    <path d="M9 8v4" />
+    <path d="M7 8v4" />
   </svg>
 );
 

--- a/packages/arte-odyssey/src/components/icons/vertical-writing.tsx
+++ b/packages/arte-odyssey/src/components/icons/vertical-writing.tsx
@@ -1,0 +1,32 @@
+import type { FC } from 'react';
+
+import { BaseIcon, type BaseIconProps } from './base';
+
+const VerticalWriting: FC<{ className: string }> = ({ className }) => (
+  <svg
+    className={className}
+    fill="none"
+    stroke="currentColor"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    strokeWidth="2"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path d="M12 7v14" />
+    <path d="M15 8v4" />
+    <path d="M19 8v4" />
+    <path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z" />
+    <path d="M5 8v4" />
+    <path d="M9 8v4" />
+  </svg>
+);
+
+export const VerticalWritingIcon: FC<Partial<BaseIconProps>> = ({
+  size = 'md',
+}) => (
+  <BaseIcon
+    renderItem={(props) => <VerticalWriting {...props} />}
+    size={size}
+  />
+);


### PR DESCRIPTION
## 概要

横書き（`HorizontalWritingIcon`）と縦書き（`VerticalWritingIcon`）の 2 種類のアイコンを追加。

## 詳細

- `HorizontalWritingIcon` — lucide-react の `BookOpenText` をラップ。
- `VerticalWritingIcon` — `BookOpenText` をベースに、ページ内側の文字線を縦にしたカスタム SVG（`packages/arte-odyssey/src/components/icons/vertical-writing.tsx`）。
  - 本の輪郭・背骨はそのまま流用。
  - 左右ページに 2 本ずつの縦線（左ページ x=5,9 / 右ページ x=15,19、長さ 4）でテキスト列を表現。
- `index.ts` から両方をエクスポートし、Storybook の Primary ストーリーに「横書き」「縦書き」として追加。