### PR TITLE
feat(arte-odyssey): add z-index design tokens for overlay stacking

### DIFF
--- a/.changeset/modal-portal-root.md
+++ b/.changeset/modal-portal-root.md
@@ -1,0 +1,9 @@
+---
+'@k8o/arte-odyssey': patch
+---
+
+`Modal` 内で `Popover` / `DropdownMenu` / `ListBox` / `Tooltip` を使うと、それらの `FloatingPortal` が `document.body` 直下に portal されるため `<dialog>` の top-layer に隠れて見えない問題を修正した。
+
+`Modal` が children を `PortalRootProvider` で自動ラップし、dialog 要素を portal root として配信するようにした。これにより `Modal` 内の Popover 系コンポーネントは何も書かずとも dialog の top-layer に乗って表示される。
+
+これまで動作させるには手動で `<PortalRootProvider value={dialogRef}>` を書く必要があったが、その workaround は不要になる(残してあっても上書きされるだけで害はない)。

--- a/.changeset/overlay-stacking-tokens.md
+++ b/.changeset/overlay-stacking-tokens.md
@@ -1,0 +1,16 @@
+---
+'@k8o/arte-odyssey': minor
+---
+
+オーバーレイ系コンポーネントの重なり順を司る z-index デザイントークンを追加した。これまで `Toast` が `z-50` を直接指定していたほかは z-index の管理が無く、複数のオーバーレイを混在させた際の重なり順が暗黙的だった。
+
+3 層スケールで整理した:
+
+- `z-overlay` (1000) — `Popover` / `DropdownMenu` / `ListBox` / `Tooltip` (trigger に紐付く浮遊 UI)
+- `z-modal` (1300) — `Modal` / `Drawer` (`<dialog>` top-layer により実質はネイティブ制御だが、stacking context を持つ非ネイティブ実装に切り替えても破綻しないよう明示)
+- `z-toast` (1500) — `Toast` (モーダルや浮遊 UI より上に必ず表示される)
+
+公開 API:
+
+- `@k8o/arte-odyssey/tokens` から `Z_INDICES` を export
+- スタイルシートに CSS 変数 `--z-overlay` / `--z-modal` / `--z-toast` と Tailwind ユーティリティ `z-overlay` / `z-modal` / `z-toast` を追加

--- a/apps/docs/src/i18n/messages/en.ts
+++ b/apps/docs/src/i18n/messages/en.ts
@@ -360,6 +360,9 @@ export const en = {
     'The spacing scale. The base unit is 0.25rem (4px), and p-{n} or gap-{n} computes to n × 0.25rem.',
   'theming.breakpointsTitle': 'Breakpoints',
   'theming.breakpointsDescription': 'Responsive breakpoints.',
+  'theming.zIndexTitle': 'Z-Index Layers',
+  'theming.zIndexDescription':
+    'A three-tier scale that defines stacking order for overlay components. Anchored floating UI (Popover / DropdownMenu / ListBox / Tooltip) sits on overlay, Modal / Drawer on modal, and Toast on toast.',
   'sideNav.openNavigation': 'Open navigation',
   'common.switchToDarkMode': 'Switch to dark mode',
   'common.switchToLightMode': 'Switch to light mode',

--- a/apps/docs/src/i18n/messages/ja.ts
+++ b/apps/docs/src/i18n/messages/ja.ts
@@ -361,6 +361,9 @@ export const ja = {
     'スペーシングスケールです。基本単位は0.25rem（4px）で、p-{n}やgap-{n}はn × 0.25remに計算されます。',
   'theming.breakpointsTitle': 'ブレイクポイント',
   'theming.breakpointsDescription': 'レスポンシブブレイクポイントです。',
+  'theming.zIndexTitle': 'Z-Index レイヤ',
+  'theming.zIndexDescription':
+    'オーバーレイ系コンポーネントの重なり順を定義する 3 層スケールです。trigger に紐付く浮遊 UI（Popover / DropdownMenu / ListBox / Tooltip）はoverlay、Modal / Drawer はmodal、Toast はtoastに配置されます。',
   'sideNav.openNavigation': 'ナビゲーションを開く',
   'common.switchToDarkMode': 'ダークモードに切り替え',
   'common.switchToLightMode': 'ライトモードに切り替え',

--- a/apps/docs/src/i18n/types.ts
+++ b/apps/docs/src/i18n/types.ts
@@ -290,6 +290,8 @@ export const MESSAGE_KEYS = [
   'theming.spacingDescription',
   'theming.breakpointsTitle',
   'theming.breakpointsDescription',
+  'theming.zIndexTitle',
+  'theming.zIndexDescription',
   'sideNav.openNavigation',
   'common.switchToDarkMode',
   'common.switchToLightMode',

--- a/apps/docs/src/pages/theming.tsx
+++ b/apps/docs/src/pages/theming.tsx
@@ -16,12 +16,19 @@ import {
   SHADOWS,
   SPACING_SCALE,
   TEXT_SIZES,
+  Z_INDICES,
   lineHeightToNumber,
 } from '@k8o/arte-odyssey/tokens';
 
 import { CodeBlock } from '../components/code-block';
 import { T } from '../components/t';
 import { TokenCard } from '../components/token-card';
+
+const Z_INDEX_USAGE = {
+  overlay: 'Popover, DropdownMenu, ListBox, Tooltip',
+  modal: 'Modal, Drawer',
+  toast: 'Toast',
+} as const;
 
 export function Theming() {
   return (
@@ -388,6 +395,34 @@ export function Theming() {
                 </code>
                 <span className="text-fg-subtle text-xs">
                   ≥ {bp.px} ({bp.rem})
+                </span>
+              </div>
+            ))}
+          </div>
+        </Card>
+      </section>
+      <Separator color="mute" />
+
+      {/* Z-Index */}
+      <section className="flex flex-col gap-4">
+        <Heading type="h2">
+          <T k="theming.zIndexTitle" />
+        </Heading>
+        <p className="text-fg-mute">
+          <T k="theming.zIndexDescription" />
+        </p>
+        <Card appearance="bordered">
+          <div className="flex flex-col gap-2 p-4">
+            {Z_INDICES.map((z) => (
+              <div className="flex items-center gap-4" key={z.name}>
+                <code className="w-24 shrink-0 text-sm font-medium">
+                  z-{z.name}
+                </code>
+                <span className="text-fg-mute flex-1 text-sm">
+                  {Z_INDEX_USAGE[z.name as keyof typeof Z_INDEX_USAGE]}
+                </span>
+                <span className="text-fg-subtle shrink-0 text-xs">
+                  {z.value}
                 </span>
               </div>
             ))}

--- a/packages/arte-odyssey/scripts/generate-css.ts
+++ b/packages/arte-odyssey/scripts/generate-css.ts
@@ -32,6 +32,7 @@ import {
   SPACING_BASE,
   TEXT_SIZES,
   WHITE,
+  Z_INDICES,
   type SemanticToken,
   type ShadeRef,
 } from '../src/styles/tokens.ts';
@@ -66,6 +67,9 @@ const renderPalette = (): string =>
         .join('\n')}`,
   ).join('\n\n');
 
+const renderZRootBlock = (): string =>
+  Z_INDICES.map((z) => `  --z-${z.name}: ${z.value};`).join('\n');
+
 const renderRoot = (): string => {
   const palette = renderPalette();
   const fg = renderSemanticBlock(FG_TOKENS, 'light');
@@ -74,6 +78,7 @@ const renderRoot = (): string => {
   const primary = renderSemanticBlock(PRIMARY_TOKENS, 'light');
   const secondary = renderSemanticBlock(SECONDARY_TOKENS, 'light');
   const group = renderSemanticBlock(GROUP_TOKENS, 'light');
+  const zIndices = renderZRootBlock();
 
   return `:root {
   --white: ${WHITE};
@@ -91,6 +96,8 @@ ${primary}
 ${secondary}
 
   --back-drop: ${BACK_DROP};
+
+${zIndices}
 
   /* TODO: 上の変数の一環として使えるようにする */
 ${group}
@@ -214,6 +221,11 @@ ${renderInsetShadows()}
 ${renderBreakpoints()}
 }`;
 
+const renderZUtilities = (): string =>
+  Z_INDICES.map(
+    (z) => `@utility z-${z.name} {\n  z-index: var(--z-${z.name});\n}`,
+  ).join('\n\n');
+
 const renderTokensCss = (): string => `${renderRoot()}
 
 ${renderDark()}
@@ -236,6 +248,8 @@ ${base}
 ${renderTokensCss()}
 
 ${utilities}
+
+${renderZUtilities()}
 `;
 
 const outputPath = resolve(stylesDir, 'index.css');

--- a/packages/arte-odyssey/src/components/feedback/toast/provider.tsx
+++ b/packages/arte-odyssey/src/components/feedback/toast/provider.tsx
@@ -65,7 +65,7 @@ export const ToastProvider: FC<
               aria-label="通知"
               aria-live="polite"
               className={cn(
-                'absolute bottom-3 z-50 flex w-full flex-col items-center justify-center gap-4',
+                'absolute bottom-3 z-toast flex w-full flex-col items-center justify-center gap-4',
                 position === 'fixed' && 'fixed',
                 position === 'absolute' && 'absolute',
               )}

--- a/packages/arte-odyssey/src/components/overlays/modal/modal.tsx
+++ b/packages/arte-odyssey/src/components/overlays/modal/modal.tsx
@@ -13,6 +13,7 @@ import {
 } from 'react';
 
 import { ToastProvider } from '../../feedback/toast';
+import { PortalRootProvider } from '../../providers';
 import { cn } from './../../../helpers/cn';
 
 const centerVariants: Variants = {
@@ -170,9 +171,11 @@ export const Modal: FC<
               : rightVariants
       }
     >
-      <ToastProvider portalRef={realRef} position="absolute">
-        {children}
-      </ToastProvider>
+      <PortalRootProvider value={realRef}>
+        <ToastProvider portalRef={realRef} position="absolute">
+          {children}
+        </ToastProvider>
+      </PortalRootProvider>
     </motion.dialog>
   );
 };

--- a/packages/arte-odyssey/src/components/overlays/modal/modal.tsx
+++ b/packages/arte-odyssey/src/components/overlays/modal/modal.tsx
@@ -142,7 +142,7 @@ export const Modal: FC<
     <motion.dialog
       animate={realDialogOpen ? 'open' : 'closed'}
       className={cn(
-        'bg-bg-raised text-fg-base shadow-md backdrop:bg-back-drop',
+        'bg-bg-raised text-fg-base z-modal shadow-md backdrop:bg-back-drop',
         type === 'center' &&
           'm-auto max-h-lg w-5/6 max-w-2xl rounded-lg vertical:h-5/6 vertical:max-h-2xl vertical:w-auto vertical:max-w-lg',
         type === 'bottom' && 'mt-auto w-screen max-w-screen rounded-t-lg',

--- a/packages/arte-odyssey/src/components/overlays/popover/popover.tsx
+++ b/packages/arte-odyssey/src/components/overlays/popover/popover.tsx
@@ -19,6 +19,7 @@ import {
   useId,
 } from 'react';
 
+import { cn } from '../../../helpers/cn';
 import { useDisclosure } from '../../../hooks/disclosure';
 import { useWritingMode } from '../../../hooks/writing-mode';
 import { usePortalRoot } from '../../providers';
@@ -165,7 +166,7 @@ const Content: FC<{
             modal={false}
           >
             <div
-              className={writingClass}
+              className={cn('z-overlay', writingClass)}
               ref={setContentRef}
               style={contentStyles}
             >

--- a/packages/arte-odyssey/src/styles/tokens.ts
+++ b/packages/arte-odyssey/src/styles/tokens.ts
@@ -472,3 +472,23 @@ export const BREAKPOINTS: readonly Breakpoint[] = [
   { name: 'xl', rem: '80rem', px: '1280px' },
   { name: '2xl', rem: '96rem', px: '1536px' },
 ];
+
+// ---------------------------------------------------------------------------
+// Overlay z-index layers
+// ---------------------------------------------------------------------------
+
+/**
+ * オーバーレイ系コンポーネントの重なり順を定義する 3 層スケール。
+ *
+ *   overlay (1000) — trigger に紐付く浮遊 UI (Popover / DropdownMenu / ListBox / Tooltip)
+ *   modal   (1300) — Modal / Drawer。`<dialog>` top-layer により実質はネイティブ制御だが、
+ *                     stacking context を持つ非ネイティブ実装に切り替えても破綻しないよう明示
+ *   toast   (1500) — Toast。モーダルや浮遊 UI より上に必ず表示される
+ *
+ * 同層内の同時表示はサポート外。新たな層が必要になったら間に挿入する。
+ */
+export const Z_INDICES: readonly NamedScale[] = [
+  { name: 'overlay', value: '1000' },
+  { name: 'modal', value: '1300' },
+  { name: 'toast', value: '1500' },
+];


### PR DESCRIPTION
## Summary

オーバーレイ系コンポーネントの stacking 周りを整備するまとめ PR。

- **feat**: 3 層 z-index トークン (`z-overlay` / `z-modal` / `z-toast`) を追加。Toast の `z-50` 直書きを置き換え、Popover 系の浮遊 UI と Modal にも明示的なレイヤを割り当てた
- **fix**: `Modal` 内で `Popover` / `DropdownMenu` / `ListBox` / `Tooltip` を使うと top-layer に隠れて見えない問題を修正。`Modal` が children を `PortalRootProvider` で自動ラップして dialog を portal root に配信
- **docs**: Theming ページに Z-Index レイヤの一覧セクションを追加 (ja/en)

### z-index 設計

| トークン | 値 | 適用 |
|---|---|---|
| `z-overlay` | 1000 | Popover / DropdownMenu / ListBox / Tooltip(trigger 紐付き浮遊 UI) |
| `z-modal` | 1300 | Modal / Drawer (`<dialog>` top-layer により実質はネイティブ制御だが、stacking context を持つ非ネイティブ実装に切り替えても破綻しないよう明示) |
| `z-toast` | 1500 | Toast |

### 公開 API

- `@k8o/arte-odyssey/tokens` から `Z_INDICES` を export
- スタイルシートに CSS 変数 `--z-overlay` / `--z-modal` / `--z-toast` と Tailwind ユーティリティ `z-overlay` / `z-modal` / `z-toast` を追加

### Modal portal root の挙動変更

これまで Modal 内で `DropdownMenu` などを使うと、それらの `FloatingPortal` が `document.body` 直下に portal されるため `<dialog>` の top-layer に隠れて見えなかった。手動で `<PortalRootProvider value={dialogRef}>` を書く workaround が必要だったが、Modal が自動でラップするようにしたためその workaround は不要になる(残してあっても上書きされるだけで害はない)。

## Test plan

- [x] `pnpm typecheck` が通る
- [x] `pnpm check` (Oxlint/Oxfmt) が通る
- [x] `pnpm test` で 291 件すべて pass
- [x] `pnpm build`(apps/docs 含む) が通る
- [ ] docs サイトの `/theming` ページに Z-Index セクションが表示される (ja/en 両方)
- [ ] Modal を開いた状態で Toast を出すと Toast が上に表示される
- [ ] Modal の中で `DropdownMenu` を開くと、Modal の上に正しく表示される(これまで隠れていた)
- [ ] Modal の中で `Tooltip` をホバーすると、Modal の上に正しく表示される