### PR TITLE
refactor(arte-odyssey): disallow className/style props on components

### DIFF
--- a/.changeset/disallow-classname-style-props.md
+++ b/.changeset/disallow-classname-style-props.md
@@ -1,0 +1,18 @@
+---
+'@k8o/arte-odyssey': major
+---
+
+全コンポーネントで `className` と `style` プロップを受け取れないようにした。
+
+スタイルはコンポーネント内部の実装に閉じ、外部からのオーバーライド経路を廃止する。Tailwind の utility class を渡してデザインを上書きする使い方ができなくなるため、利用側の影響範囲は大きい。
+
+対象コンポーネント:
+
+- Buttons: `Button`, `IconButton`
+- Data Display: `Card`, `InteractiveCard`, `Badge`, `Avatar`, `Heading`, `Code`, `Table.*`
+- Feedback: `Alert`, `Progress`, `Skeleton`, `Spinner`
+- Form: `Form`, `TextField`, `Textarea`, `Select`, `PasswordInput`, `Checkbox`, `Radio`, `Switch`, `NumberField`, `Slider`, `Autocomplete`, `FileField`, `CheckboxCard`, `RadioCard`, `CheckboxGroup`
+- Layout: `Separator`
+- Navigation: `Anchor`
+
+`Table.Root` の `className` / `containerClassName` プロップも併せて削除した。

--- a/.changeset/disallow-classname-style-props.md
+++ b/.changeset/disallow-classname-style-props.md
@@ -1,5 +1,5 @@
 ---
-'@k8o/arte-odyssey': major
+'@k8o/arte-odyssey': patch
 ---
 
 全コンポーネントで `className` と `style` プロップを受け取れないようにした。

--- a/packages/arte-odyssey/src/components/buttons/button/button.tsx
+++ b/packages/arte-odyssey/src/components/buttons/button/button.tsx
@@ -18,7 +18,7 @@ type Props = {
   endIcon?: ReactNode;
   onAction?: () => void | Promise<void>;
   renderItem?: (props: { className: string; children: ReactNode }) => ReactNode;
-} & Omit<HTMLProps<HTMLButtonElement>, 'size' | 'type'>;
+} & Omit<HTMLProps<HTMLButtonElement>, 'size' | 'type' | 'className' | 'style'>;
 
 export const Button: FC<Props> = ({
   ref,

--- a/packages/arte-odyssey/src/components/buttons/icon-button/icon-button.tsx
+++ b/packages/arte-odyssey/src/components/buttons/icon-button/icon-button.tsx
@@ -25,7 +25,7 @@ type Props = {
     'aria-label': string;
     triggerProps: IconButtonTriggerProps;
   }) => ReactNode;
-} & Omit<HTMLProps<HTMLButtonElement>, 'size' | 'type'>;
+} & Omit<HTMLProps<HTMLButtonElement>, 'size' | 'type' | 'className' | 'style'>;
 
 const joinIds = (
   ...ids: ReadonlyArray<string | undefined>

--- a/packages/arte-odyssey/src/components/data-display/avatar/avatar.tsx
+++ b/packages/arte-odyssey/src/components/data-display/avatar/avatar.tsx
@@ -11,7 +11,10 @@ type Props = {
   name?: string;
   size?: 'sm' | 'md' | 'lg';
   src?: string;
-} & Omit<HTMLAttributes<HTMLSpanElement>, 'role' | 'aria-label'>;
+} & Omit<
+  HTMLAttributes<HTMLSpanElement>,
+  'role' | 'aria-label' | 'className' | 'style'
+>;
 
 const getInitials = (name?: string) => {
   if (name === undefined || name === '') {
@@ -34,7 +37,6 @@ export const Avatar: FC<Props> = ({
   name,
   size = 'md',
   src,
-  className,
   ...rest
 }) => {
   const [failedSrc, setFailedSrc] = useState<string | null>(null);
@@ -51,7 +53,6 @@ export const Avatar: FC<Props> = ({
         size === 'sm' && 'size-8 text-xs',
         size === 'md' && 'size-10 text-sm',
         size === 'lg' && 'size-14 text-lg',
-        className,
       )}
       role="img"
     >

--- a/packages/arte-odyssey/src/components/data-display/badge/badge.tsx
+++ b/packages/arte-odyssey/src/components/data-display/badge/badge.tsx
@@ -8,7 +8,7 @@ type Props = {
   interactive?: boolean;
   tone?: 'neutral' | 'info' | 'success' | 'warning' | 'error';
   variant?: 'solid' | 'outline';
-} & Omit<HTMLAttributes<HTMLElement>, 'children'>;
+} & Omit<HTMLAttributes<HTMLElement>, 'children' | 'className' | 'style'>;
 
 export const Badge: FC<Props> = ({
   interactive = false,
@@ -16,7 +16,6 @@ export const Badge: FC<Props> = ({
   text,
   tone = 'neutral',
   variant = 'solid',
-  className,
   ...rest
 }) => {
   const interactiveClassName = cn(
@@ -103,14 +102,14 @@ export const Badge: FC<Props> = ({
 
   if (interactive) {
     return (
-      <button {...rest} className={cn(badgeClassName, className)} type="button">
+      <button {...rest} className={badgeClassName} type="button">
         {text}
       </button>
     );
   }
 
   return (
-    <span {...rest} className={cn(badgeClassName, className)}>
+    <span {...rest} className={badgeClassName}>
       {text}
     </span>
   );

--- a/packages/arte-odyssey/src/components/data-display/card/card.tsx
+++ b/packages/arte-odyssey/src/components/data-display/card/card.tsx
@@ -7,7 +7,6 @@ export const Card: FC<CardProps> = ({
   children,
   width = 'full',
   appearance = 'shadow',
-  className,
   ...rest
 }) => (
   <div
@@ -19,7 +18,6 @@ export const Card: FC<CardProps> = ({
       width === 'full' && 'w-full',
       width === 'fit' && 'w-fit',
       'bg-bg-base',
-      className,
     )}
   >
     {children}

--- a/packages/arte-odyssey/src/components/data-display/card/interactive-card.tsx
+++ b/packages/arte-odyssey/src/components/data-display/card/interactive-card.tsx
@@ -7,7 +7,6 @@ export const InteractiveCard: FC<CardProps> = ({
   children,
   width = 'full',
   appearance = 'shadow',
-  className,
   ...rest
 }) => (
   <div
@@ -19,7 +18,6 @@ export const InteractiveCard: FC<CardProps> = ({
       width === 'full' && 'w-full',
       width === 'fit' && 'w-fit',
       'bg-bg-base',
-      className,
     )}
   >
     {children}

--- a/packages/arte-odyssey/src/components/data-display/card/type.ts
+++ b/packages/arte-odyssey/src/components/data-display/card/type.ts
@@ -3,4 +3,4 @@ import type { HTMLAttributes } from 'react';
 export type CardProps = {
   width?: 'full' | 'fit';
   appearance?: 'shadow' | 'bordered';
-} & HTMLAttributes<HTMLDivElement>;
+} & Omit<HTMLAttributes<HTMLDivElement>, 'className' | 'style'>;

--- a/packages/arte-odyssey/src/components/data-display/code/code.tsx
+++ b/packages/arte-odyssey/src/components/data-display/code/code.tsx
@@ -1,24 +1,17 @@
 import { type FC, Fragment, type HTMLAttributes } from 'react';
 
-import { cn } from './../../../helpers/cn';
 import { findAllColors } from './find-all-colors';
 
 type Props = {
   children: string;
-} & Omit<HTMLAttributes<HTMLElement>, 'children'>;
+} & Omit<HTMLAttributes<HTMLElement>, 'children' | 'className' | 'style'>;
 
-export const Code: FC<Props> = ({ children, className, ...rest }) => {
+export const Code: FC<Props> = ({ children, ...rest }) => {
   const colors = findAllColors(children);
 
   if (colors.length === 0) {
     return (
-      <code
-        {...rest}
-        className={cn(
-          'bg-bg-mute m-0.5 rounded-md px-1.5 sm:py-0.5',
-          className,
-        )}
-      >
+      <code {...rest} className="bg-bg-mute m-0.5 rounded-md px-1.5 sm:py-0.5">
         {children}
       </code>
     );
@@ -58,10 +51,7 @@ export const Code: FC<Props> = ({ children, className, ...rest }) => {
   return (
     <code
       {...rest}
-      className={cn(
-        'bg-bg-mute m-0.5 inline-flex items-center gap-1 rounded-md px-1.5 sm:py-0.5',
-        className,
-      )}
+      className="bg-bg-mute m-0.5 inline-flex items-center gap-1 rounded-md px-1.5 sm:py-0.5"
     >
       {parts}
     </code>

--- a/packages/arte-odyssey/src/components/data-display/heading/heading.tsx
+++ b/packages/arte-odyssey/src/components/data-display/heading/heading.tsx
@@ -5,15 +5,9 @@ import { cn } from './../../../helpers/cn';
 type Props = {
   type: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
   lineClamp?: number;
-} & HTMLAttributes<HTMLHeadingElement>;
+} & Omit<HTMLAttributes<HTMLHeadingElement>, 'className' | 'style'>;
 
-export const Heading: FC<Props> = ({
-  children,
-  type,
-  lineClamp,
-  className,
-  ...rest
-}) => {
+export const Heading: FC<Props> = ({ children, type, lineClamp, ...rest }) => {
   const lineClampClass = {
     [`line-clamp-${lineClamp?.toString() ?? ''}`]: lineClamp,
   };
@@ -21,11 +15,7 @@ export const Heading: FC<Props> = ({
     return (
       <h1
         {...rest}
-        className={cn(
-          'font-bold text-2xl md:text-3xl',
-          lineClampClass,
-          className,
-        )}
+        className={cn('font-bold text-2xl md:text-3xl', lineClampClass)}
       >
         {children}
       </h1>
@@ -35,11 +25,7 @@ export const Heading: FC<Props> = ({
     return (
       <h2
         {...rest}
-        className={cn(
-          'font-bold text-xl md:text-2xl',
-          lineClampClass,
-          className,
-        )}
+        className={cn('font-bold text-xl md:text-2xl', lineClampClass)}
       >
         {children}
       </h2>
@@ -49,11 +35,7 @@ export const Heading: FC<Props> = ({
     return (
       <h3
         {...rest}
-        className={cn(
-          'font-bold text-lg md:text-xl',
-          lineClampClass,
-          className,
-        )}
+        className={cn('font-bold text-lg md:text-xl', lineClampClass)}
       >
         {children}
       </h3>
@@ -63,11 +45,7 @@ export const Heading: FC<Props> = ({
     return (
       <h4
         {...rest}
-        className={cn(
-          'font-bold text-md md:text-lg',
-          lineClampClass,
-          className,
-        )}
+        className={cn('font-bold text-md md:text-lg', lineClampClass)}
       >
         {children}
       </h4>
@@ -77,11 +55,7 @@ export const Heading: FC<Props> = ({
     return (
       <h5
         {...rest}
-        className={cn(
-          'font-bold text-sm md:text-md',
-          lineClampClass,
-          className,
-        )}
+        className={cn('font-bold text-sm md:text-md', lineClampClass)}
       >
         {children}
       </h5>
@@ -90,7 +64,7 @@ export const Heading: FC<Props> = ({
   return (
     <h6
       {...rest}
-      className={cn('font-bold text-xs md:text-sm', lineClampClass, className)}
+      className={cn('font-bold text-xs md:text-sm', lineClampClass)}
     >
       {children}
     </h6>

--- a/packages/arte-odyssey/src/components/data-display/table/table.tsx
+++ b/packages/arte-odyssey/src/components/data-display/table/table.tsx
@@ -2,13 +2,9 @@ import type { FC, PropsWithChildren, ReactNode } from 'react';
 
 import { cn } from '../../../helpers/cn';
 
-type RootProps = PropsWithChildren<{
-  className?: string;
-  containerClassName?: string;
-}>;
+type RootProps = PropsWithChildren;
 
 type RowProps = PropsWithChildren<{
-  className?: string;
   interactive?: boolean;
 }>;
 
@@ -16,77 +12,56 @@ type CellAlign = 'left' | 'center' | 'right';
 
 type HeaderCellProps = PropsWithChildren<{
   align?: CellAlign;
-  className?: string;
 }>;
 
 type CellProps = PropsWithChildren<{
   align?: CellAlign;
-  className?: string;
   colSpan?: number;
   tone?: 'default' | 'muted';
 }>;
 
-type SectionProps = PropsWithChildren<{
-  className?: string;
-}>;
+type SectionProps = PropsWithChildren;
 
-type CaptionProps = PropsWithChildren<{
-  className?: string;
-}>;
+type CaptionProps = PropsWithChildren;
 
 type EmptyStateProps = {
   colSpan: number;
   children: ReactNode;
 };
 
-const Root: FC<RootProps> = ({ children, className, containerClassName }) => (
-  <div
-    className={cn(
-      'w-full overflow-x-auto rounded-lg border border-border-mute bg-bg-base',
-      containerClassName,
-    )}
-  >
-    <table
-      className={cn('min-w-full border-collapse text-left text-sm', className)}
-    >
+const Root: FC<RootProps> = ({ children }) => (
+  <div className="border-border-mute bg-bg-base w-full overflow-x-auto rounded-lg border">
+    <table className="min-w-full border-collapse text-left text-sm">
       {children}
     </table>
   </div>
 );
 
-const Head: FC<SectionProps> = ({ children, className }) => (
-  <thead className={cn('bg-bg-subtle', className)}>{children}</thead>
+const Head: FC<SectionProps> = ({ children }) => (
+  <thead className="bg-bg-subtle">{children}</thead>
 );
 
-const Body: FC<SectionProps> = ({ children, className }) => (
-  <tbody className={cn('[&_tr:last-child]:border-b-0', className)}>
-    {children}
-  </tbody>
+const Body: FC<SectionProps> = ({ children }) => (
+  <tbody className="[&_tr:last-child]:border-b-0">{children}</tbody>
 );
 
-const Row: FC<RowProps> = ({ children, className, interactive = false }) => (
+const Row: FC<RowProps> = ({ children, interactive = false }) => (
   <tr
     className={cn(
       'border-border-mute border-b transition-colors',
       interactive && 'hover:bg-bg-mute',
-      className,
     )}
   >
     {children}
   </tr>
 );
 
-const HeaderCell: FC<HeaderCellProps> = ({
-  align = 'left',
-  children,
-  className,
-}) => (
+const HeaderCell: FC<HeaderCellProps> = ({ align = 'left', children }) => (
   <th
     className={cn(
       'px-4 py-3 font-medium text-fg-base',
       align === 'center' && 'text-center',
       align === 'right' && 'text-right',
-      className,
     )}
     scope="col"
   >
@@ -97,7 +72,6 @@ const HeaderCell: FC<HeaderCellProps> = ({
 const Cell: FC<CellProps> = ({
   align = 'left',
   children,
-  className,
   colSpan,
   tone = 'default',
 }) => (
@@ -107,7 +81,6 @@ const Cell: FC<CellProps> = ({
       tone === 'muted' ? 'text-fg-mute' : 'text-fg-base',
       align === 'center' && 'text-center',
       align === 'right' && 'text-right',
-      className,
     )}
     colSpan={colSpan}
   >
@@ -115,20 +88,21 @@ const Cell: FC<CellProps> = ({
   </td>
 );
 
-const Caption: FC<CaptionProps> = ({ children, className }) => (
-  <caption
-    className={cn('caption-bottom px-4 py-3 text-fg-mute text-sm', className)}
-  >
+const Caption: FC<CaptionProps> = ({ children }) => (
+  <caption className="text-fg-mute caption-bottom px-4 py-3 text-sm">
     {children}
   </caption>
 );
 
 const EmptyState: FC<EmptyStateProps> = ({ children, colSpan }) => (
-  <Row>
-    <Cell align="center" className="text-fg-mute py-10" colSpan={colSpan}>
+  <tr className="border-border-mute border-b transition-colors">
+    <td
+      className="text-fg-mute px-4 py-10 text-center align-middle"
+      colSpan={colSpan}
+    >
       {children}
-    </Cell>
-  </Row>
+    </td>
+  </tr>
 );
 
 export const Table = {

--- a/packages/arte-odyssey/src/components/feedback/alert/alert.tsx
+++ b/packages/arte-odyssey/src/components/feedback/alert/alert.tsx
@@ -7,7 +7,10 @@ import type { Status } from './../../../types/variables';
 type Props = {
   status: Status;
   message: string | string[];
-} & Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'role'>;
+} & Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'children' | 'role' | 'className' | 'style'
+>;
 
 const STATUS_LABEL = {
   success: '成功',
@@ -16,7 +19,7 @@ const STATUS_LABEL = {
   error: 'エラー',
 } as const satisfies Record<Status, string>;
 
-export const Alert: FC<Props> = ({ status, message, className, ...rest }) => (
+export const Alert: FC<Props> = ({ status, message, ...rest }) => (
   <div
     {...rest}
     className={cn(
@@ -25,7 +28,6 @@ export const Alert: FC<Props> = ({ status, message, className, ...rest }) => (
       status === 'info' && 'bg-bg-info',
       status === 'warning' && 'bg-bg-warning',
       status === 'error' && 'bg-bg-error',
-      className,
     )}
     role={status === 'error' || status === 'warning' ? 'alert' : 'status'}
   >

--- a/packages/arte-odyssey/src/components/feedback/progress/progress.tsx
+++ b/packages/arte-odyssey/src/components/feedback/progress/progress.tsx
@@ -1,6 +1,5 @@
 import type { FC, HTMLAttributes } from 'react';
 
-import { cn } from './../../../helpers/cn';
 import { toPrecision } from './../../../internal/to-precision';
 
 type Props = {
@@ -8,20 +7,16 @@ type Props = {
   maxProgress: number;
   minProgress?: number;
   label?: string;
-} & Omit<HTMLAttributes<HTMLDivElement>, 'children'>;
+} & Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'className' | 'style'>;
 
 export const Progress: FC<Props> = ({
   progress,
   maxProgress,
   minProgress = 0,
   label,
-  className,
   ...rest
 }) => (
-  <div
-    {...rest}
-    className={cn('bg-bg-emphasize w-full rounded-full', className)}
-  >
+  <div {...rest} className="bg-bg-emphasize w-full rounded-full">
     <div
       aria-label={label ?? `${toPrecision(progress / maxProgress).toString()}%`}
       aria-valuemax={maxProgress}

--- a/packages/arte-odyssey/src/components/feedback/skeleton/skeleton.tsx
+++ b/packages/arte-odyssey/src/components/feedback/skeleton/skeleton.tsx
@@ -6,13 +6,12 @@ type Props = {
   animate?: boolean;
   shape?: 'rect' | 'circle';
   size?: 'sm' | 'md' | 'lg';
-} & Omit<HTMLAttributes<HTMLDivElement>, 'children'>;
+} & Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'className' | 'style'>;
 
 export const Skeleton: FC<Props> = ({
   animate = true,
   shape = 'rect',
   size = 'md',
-  className,
   ...rest
 }) => (
   <div
@@ -29,7 +28,6 @@ export const Skeleton: FC<Props> = ({
       shape === 'circle' && size === 'sm' && 'size-8',
       shape === 'circle' && size === 'md' && 'size-12',
       shape === 'circle' && size === 'lg' && 'size-16',
-      className,
     )}
   />
 );

--- a/packages/arte-odyssey/src/components/feedback/spinner/spinner.tsx
+++ b/packages/arte-odyssey/src/components/feedback/spinner/spinner.tsx
@@ -5,19 +5,21 @@ import { cn } from '../../../helpers/cn';
 type Props = {
   label?: string;
   size?: 'sm' | 'md' | 'lg';
-} & Omit<OutputHTMLAttributes<HTMLOutputElement>, 'children' | 'aria-label'>;
+} & Omit<
+  OutputHTMLAttributes<HTMLOutputElement>,
+  'children' | 'aria-label' | 'className' | 'style'
+>;
 
 export const Spinner: FC<Props> = ({
   label = 'Loading',
   size = 'md',
-  className,
   ...rest
 }) => (
   <output
     {...rest}
     aria-label={label}
     aria-live="polite"
-    className={cn('inline-flex items-center justify-center', className)}
+    className="inline-flex items-center justify-center"
   >
     <span
       aria-hidden

--- a/packages/arte-odyssey/src/components/form/autocomplete/autocomplete.tsx
+++ b/packages/arte-odyssey/src/components/form/autocomplete/autocomplete.tsx
@@ -27,6 +27,7 @@ type BaseProps = {
   | 'type'
   | 'role'
   | 'className'
+  | 'style'
   | 'value'
   | 'onChange'
   | 'defaultValue'

--- a/packages/arte-odyssey/src/components/form/checkbox-card/checkbox-card.tsx
+++ b/packages/arte-odyssey/src/components/form/checkbox-card/checkbox-card.tsx
@@ -20,7 +20,7 @@ type BaseProps = {
   options: readonly CheckboxCardOption[];
 } & Omit<
   FieldsetHTMLAttributes<HTMLFieldSetElement>,
-  'className' | 'children' | 'onChange' | 'defaultValue'
+  'className' | 'style' | 'children' | 'onChange' | 'defaultValue'
 >;
 
 type ControlledProps = {

--- a/packages/arte-odyssey/src/components/form/checkbox-group/checkbox-group.tsx
+++ b/packages/arte-odyssey/src/components/form/checkbox-group/checkbox-group.tsx
@@ -33,7 +33,7 @@ type RootBaseProps = PropsWithChildren<
     name: string;
   } & Omit<
     FieldsetHTMLAttributes<HTMLFieldSetElement>,
-    'className' | 'onChange' | 'defaultValue' | 'name'
+    'className' | 'style' | 'onChange' | 'defaultValue' | 'name'
   >
 >;
 

--- a/packages/arte-odyssey/src/components/form/checkbox/checkbox.tsx
+++ b/packages/arte-odyssey/src/components/form/checkbox/checkbox.tsx
@@ -20,6 +20,7 @@ type BaseProps = {
   InputHTMLAttributes<HTMLInputElement>,
   | 'type'
   | 'className'
+  | 'style'
   | 'value'
   | 'onChange'
   | 'defaultChecked'

--- a/packages/arte-odyssey/src/components/form/file-field/file-field.tsx
+++ b/packages/arte-odyssey/src/components/form/file-field/file-field.tsx
@@ -42,7 +42,13 @@ type RootProps = PropsWithChildren<
     webkitDirectory?: boolean;
   } & Omit<
     InputHTMLAttributes<HTMLInputElement>,
-    'type' | 'className' | 'onChange' | 'defaultValue' | 'value' | 'children'
+    | 'type'
+    | 'className'
+    | 'style'
+    | 'onChange'
+    | 'defaultValue'
+    | 'value'
+    | 'children'
   >
 >;
 

--- a/packages/arte-odyssey/src/components/form/form/form.tsx
+++ b/packages/arte-odyssey/src/components/form/form/form.tsx
@@ -2,19 +2,16 @@
 
 import type { FC, FormHTMLAttributes, ReactNode } from 'react';
 
-import { cn } from '../../../helpers/cn';
-
 type Props = {
   action?: ((formData: FormData) => void | Promise<void>) | string;
   children: ReactNode;
-} & Omit<FormHTMLAttributes<HTMLFormElement>, 'action' | 'children'>;
+} & Omit<
+  FormHTMLAttributes<HTMLFormElement>,
+  'action' | 'children' | 'className' | 'style'
+>;
 
-export const Form: FC<Props> = ({ action, className, children, ...rest }) => (
-  <form
-    action={action}
-    className={cn('flex flex-col gap-6', className)}
-    {...rest}
-  >
+export const Form: FC<Props> = ({ action, children, ...rest }) => (
+  <form action={action} className="flex flex-col gap-6" {...rest}>
     {children}
   </form>
 );

--- a/packages/arte-odyssey/src/components/form/number-field/number-field.tsx
+++ b/packages/arte-odyssey/src/components/form/number-field/number-field.tsx
@@ -18,6 +18,7 @@ type BaseProps = {
   | 'type'
   | 'role'
   | 'className'
+  | 'style'
   | 'value'
   | 'onChange'
   | 'defaultValue'

--- a/packages/arte-odyssey/src/components/form/password-input/password-input.tsx
+++ b/packages/arte-odyssey/src/components/form/password-input/password-input.tsx
@@ -11,7 +11,7 @@ type Props = {
   invalid?: boolean;
   showLabel?: string;
   hideLabel?: string;
-} & Omit<InputHTMLAttributes<HTMLInputElement>, 'type' | 'className'>;
+} & Omit<InputHTMLAttributes<HTMLInputElement>, 'type' | 'className' | 'style'>;
 
 export const PasswordInput: FC<Props> = ({
   invalid = false,

--- a/packages/arte-odyssey/src/components/form/radio-card/radio-card.tsx
+++ b/packages/arte-odyssey/src/components/form/radio-card/radio-card.tsx
@@ -27,7 +27,12 @@ type BaseProps = {
   options: readonly RadioCardOption[];
 } & Omit<
   FieldsetHTMLAttributes<HTMLFieldSetElement>,
-  'className' | 'children' | 'onChange' | 'defaultValue' | 'aria-labelledby'
+  | 'className'
+  | 'style'
+  | 'children'
+  | 'onChange'
+  | 'defaultValue'
+  | 'aria-labelledby'
 >;
 
 type ControlledProps = {

--- a/packages/arte-odyssey/src/components/form/radio/radio.tsx
+++ b/packages/arte-odyssey/src/components/form/radio/radio.tsx
@@ -19,7 +19,7 @@ type BaseProps = {
   options: readonly Option[];
 } & Omit<
   HTMLAttributes<HTMLDivElement>,
-  'role' | 'className' | 'children' | 'aria-labelledby' | 'onChange'
+  'role' | 'className' | 'style' | 'children' | 'aria-labelledby' | 'onChange'
 >;
 
 type ControlledProps = {

--- a/packages/arte-odyssey/src/components/form/select/select.tsx
+++ b/packages/arte-odyssey/src/components/form/select/select.tsx
@@ -10,7 +10,7 @@ import { cn } from './../../../helpers/cn';
 type Props = {
   invalid?: boolean;
   options: readonly Option[];
-} & Omit<SelectHTMLAttributes<HTMLSelectElement>, 'className'>;
+} & Omit<SelectHTMLAttributes<HTMLSelectElement>, 'className' | 'style'>;
 
 export const Select: FC<Props> = ({
   invalid = false,

--- a/packages/arte-odyssey/src/components/form/slider/slider.tsx
+++ b/packages/arte-odyssey/src/components/form/slider/slider.tsx
@@ -15,6 +15,7 @@ type BaseProps = {
   InputHTMLAttributes<HTMLInputElement>,
   | 'type'
   | 'className'
+  | 'style'
   | 'value'
   | 'onChange'
   | 'defaultValue'

--- a/packages/arte-odyssey/src/components/form/switch/switch.tsx
+++ b/packages/arte-odyssey/src/components/form/switch/switch.tsx
@@ -15,6 +15,7 @@ type BaseProps = {
   | 'type'
   | 'role'
   | 'className'
+  | 'style'
   | 'value'
   | 'onChange'
   | 'defaultChecked'

--- a/packages/arte-odyssey/src/components/form/text-field/text-field.tsx
+++ b/packages/arte-odyssey/src/components/form/text-field/text-field.tsx
@@ -7,7 +7,7 @@ import { cn } from './../../../helpers/cn';
 
 type Props = {
   invalid?: boolean;
-} & Omit<InputHTMLAttributes<HTMLInputElement>, 'type' | 'className'>;
+} & Omit<InputHTMLAttributes<HTMLInputElement>, 'type' | 'className' | 'style'>;
 
 export const TextField: FC<Props> = ({
   invalid = false,

--- a/packages/arte-odyssey/src/components/form/textarea/textarea.tsx
+++ b/packages/arte-odyssey/src/components/form/textarea/textarea.tsx
@@ -9,7 +9,7 @@ type Props = {
   invalid?: boolean;
   fullHeight?: boolean;
   autoResize?: boolean;
-} & Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'className'>;
+} & Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'className' | 'style'>;
 
 const resizeToContent = (el: HTMLTextAreaElement) => {
   el.style.height = 'auto';

--- a/packages/arte-odyssey/src/components/layout/separator/separator.tsx
+++ b/packages/arte-odyssey/src/components/layout/separator/separator.tsx
@@ -7,13 +7,12 @@ type Props = {
   color?: 'base' | 'mute' | 'subtle';
 } & Omit<
   HTMLAttributes<HTMLSpanElement>,
-  'children' | 'role' | 'aria-orientation'
+  'children' | 'role' | 'aria-orientation' | 'className' | 'style'
 >;
 
 export const Separator: FC<Props> = ({
   orientation = 'horizontal',
   color = 'base',
-  className,
   ...rest
 }) => {
   const isVertical = orientation === 'vertical';
@@ -30,7 +29,6 @@ export const Separator: FC<Props> = ({
         color === 'base' && 'bg-border-base',
         color === 'mute' && 'bg-border-mute',
         color === 'subtle' && 'bg-border-subtle',
-        className,
       )}
       role="separator"
     />

--- a/packages/arte-odyssey/src/components/navigation/anchor/anchor.tsx
+++ b/packages/arte-odyssey/src/components/navigation/anchor/anchor.tsx
@@ -4,7 +4,7 @@ import { ExternalLinkIcon } from '../../icons';
 
 type RestProps = Omit<
   AnchorHTMLAttributes<HTMLAnchorElement>,
-  'href' | 'children' | 'target' | 'rel' | 'className'
+  'href' | 'children' | 'target' | 'rel' | 'className' | 'style'
 >;
 
 type Props<T extends string> = {


### PR DESCRIPTION
外部から className と style を受け取れないようにし、コンポーネントの
スタイリング API を内部実装のみに限定する。