### PR TITLE
docs: sync stale documentation with current package surface

### DIFF
--- a/.changeset/sync-stale-docs.md
+++ b/.changeset/sync-stale-docs.md
@@ -1,0 +1,11 @@
+---
+'@k8o/arte-odyssey': patch
+---
+
+npm パッケージに同梱されるドキュメントを実装に追従させた。
+
+`packages/arte-odyssey/docs/GUIDE.md` および `references/components.md` から、すでに削除済みの `LinkButton` / `IconLink` の記述を除去し、代わりに `Button` / `IconButton` の `renderItem` prop でリンク化するパターンを記載した。`references/hooks.md` には `useWritingMode` の説明を追加した。
+
+`README.md` のコンポーネント一覧・カスタムフック一覧も、実際の export と一致するよう全面的に書き直した（`Pagination` / `Switch` / `CheckboxGroup` / `PasswordInput` / `Badge` / `Spinner` / `Skeleton` / `Table` / `Avatar` / `Heading` / `PortalRootProvider` などを追加、`useBreakpoint` / `useControllableState` / `useDebouncedTransition` / `useDeferredDebounce` / `useDisclosure` / `useHover` / `useIntersectionObserver` / `useInView` / `useScrollLock` / `useSessionStorage` / `useWritingMode` を追加）。
+
+実装変更は含まないが、AI コーディングアシスタント向けのガイドが npm パッケージに同梱されているため patch として扱う。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ArteOdyssey is a monorepo containing a React UI library (`@k8o/arte-odyssey`) and its documentation site, built with:
 
 - **Vite+** (`vp`) as unified toolchain (dev, build, test, lint, format, task runner)
-- **pnpm** for package management (v10.32.1, Node.js >=24.13.0)
+- **pnpm** for package management (v11.1.3, Node.js >=24.13.0)
 - **TypeScript** (strict mode, `noUncheckedIndexedAccess: true`)
 - **Oxlint/Oxfmt** for linting and formatting (via `vp check`)
 - **Tailwind CSS 4** with semantic design tokens

--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ ArteOdyssey includes design system documentation in the published npm package. W
 
 ## Development
 
-This is a monorepo managed with Turborepo and pnpm.
+This is a monorepo managed with [Vite+](https://vite.plus) (`vp`) and pnpm.
 
 ### Prerequisites
 
 - Node.js ≥24.13.0
-- pnpm 10.30.3
+- pnpm 11.1.3
 
 ### Setup
 
@@ -55,6 +55,8 @@ pnpm check:write
 ### Project Structure
 
 ```
+apps/
+  docs/                  # Documentation site (Vite + @funstack/router)
 packages/
   arte-odyssey/          # Main UI library package
 examples/

--- a/apps/docs/src/app.tsx
+++ b/apps/docs/src/app.tsx
@@ -79,6 +79,7 @@ import { UseStepPage } from './pages/hooks/use-step-page';
 import { UseTimeoutPage } from './pages/hooks/use-timeout-page';
 import { UseWindowResizePage } from './pages/hooks/use-window-resize-page';
 import { UseWindowSizePage } from './pages/hooks/use-window-size-page';
+import { UseWritingModePage } from './pages/hooks/use-writing-mode-page';
 import { RootRedirect } from './pages/root-redirect';
 import { Theming } from './pages/theming';
 import { Router } from './router';
@@ -375,6 +376,10 @@ const routes: RouteDefinition[] = [
       route({
         path: '/hooks/use-window-size',
         component: <UseWindowSizePage />,
+      }),
+      route({
+        path: '/hooks/use-writing-mode',
+        component: <UseWritingModePage />,
       }),
       route({
         path: '/helpers',

--- a/apps/docs/src/data/hooks-nav.ts
+++ b/apps/docs/src/data/hooks-nav.ts
@@ -10,6 +10,7 @@ export const hookCategories: NavCategory[] = [
       { name: 'useScrollDirection', path: '/hooks/use-scroll-direction' },
       { name: 'useScrollLock', path: '/hooks/use-scroll-lock' },
       { name: 'useWindowResize', path: '/hooks/use-window-resize' },
+      { name: 'useWritingMode', path: '/hooks/use-writing-mode' },
     ],
   },
   {

--- a/apps/docs/src/i18n/messages/en.ts
+++ b/apps/docs/src/i18n/messages/en.ts
@@ -308,6 +308,8 @@ export const en = {
     'A hook that detects hover state of an element.',
   'hooks.useControllableState.description':
     'A hook that manages controlled/uncontrolled component state.',
+  'hooks.useWritingMode.description':
+    "A hook that observes an element's writing-mode and returns either horizontal or vertical.",
   'helpers.description':
     'A catalog of helper functions provided by ArteOdyssey.',
   'helpers.categoryStyling': 'Styling',

--- a/apps/docs/src/i18n/messages/ja.ts
+++ b/apps/docs/src/i18n/messages/ja.ts
@@ -310,6 +310,8 @@ export const ja = {
   'hooks.useHover.description': '要素のホバー状態を検出するフックです。',
   'hooks.useControllableState.description':
     'controlled/uncontrolledコンポーネントの状態を管理するフックです。',
+  'hooks.useWritingMode.description':
+    '要素のwriting-modeを監視し、horizontalかverticalを返すフックです。',
   'helpers.description': 'ArteOdysseyが提供するヘルパー関数の一覧です。',
   'helpers.categoryStyling': 'スタイリング',
   'helpers.categoryReact': 'React',

--- a/apps/docs/src/i18n/types.ts
+++ b/apps/docs/src/i18n/types.ts
@@ -251,6 +251,7 @@ export const MESSAGE_KEYS = [
   'hooks.useScrollLock.bodyNotScrollableNote',
   'hooks.useHover.description',
   'hooks.useControllableState.description',
+  'hooks.useWritingMode.description',
   'helpers.description',
   'helpers.categoryStyling',
   'helpers.categoryReact',

--- a/apps/docs/src/pages/hooks/use-writing-mode-page.tsx
+++ b/apps/docs/src/pages/hooks/use-writing-mode-page.tsx
@@ -15,8 +15,8 @@ const parameters: PropItem[] = [
 
 const returnValue: PropItem[] = [
   {
-    name: "'horizontal' | 'vertical'",
-    types: ['WritingMode'],
+    name: 'writingMode',
+    types: ["'horizontal'", "'vertical'"],
     defaultValue: null,
   },
 ];

--- a/apps/docs/src/pages/hooks/use-writing-mode-page.tsx
+++ b/apps/docs/src/pages/hooks/use-writing-mode-page.tsx
@@ -1,0 +1,88 @@
+import { Heading, Separator } from '@k8o/arte-odyssey';
+
+import { CodeBlock } from '../../components/code-block';
+import type { PropItem } from '../../components/props-table';
+import { PropsTable } from '../../components/props-table';
+import { T } from '../../components/t';
+
+const parameters: PropItem[] = [
+  {
+    name: 'ref',
+    types: ['RefObject<Element | null>'],
+    defaultValue: null,
+  },
+];
+
+const returnValue: PropItem[] = [
+  {
+    name: "'horizontal' | 'vertical'",
+    types: ['WritingMode'],
+    defaultValue: null,
+  },
+];
+
+export function UseWritingModePage() {
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
+      {/* Header */}
+      <div className="flex flex-col gap-4">
+        <Heading type="h1">useWritingMode</Heading>
+        <p className="text-fg-mute text-lg">
+          <T k="hooks.useWritingMode.description" />
+        </p>
+      </div>
+      <Separator color="mute" />
+
+      {/* Import */}
+      <section className="flex flex-col gap-4">
+        <Heading type="h2">
+          <T k="hooks.common.importTitle" />
+        </Heading>
+        <CodeBlock
+          code="import { useWritingMode } from '@k8o/arte-odyssey';"
+          lang="ts"
+        />
+      </section>
+      <Separator color="mute" />
+
+      {/* Usage */}
+      <section className="flex flex-col gap-8">
+        <Heading type="h2">
+          <T k="hooks.common.usageTitle" />
+        </Heading>
+        <div className="flex flex-col gap-4">
+          <Heading type="h3">
+            <T k="hooks.common.basicUsageTitle" />
+          </Heading>
+          <CodeBlock
+            code={`const ref = useRef<HTMLDivElement>(null);
+const writingMode = useWritingMode(ref);
+
+return (
+  <div ref={ref}>
+    {writingMode === 'vertical' ? '縦書き' : '横書き'}
+  </div>
+);`}
+            lang="tsx"
+          />
+        </div>
+      </section>
+      <Separator color="mute" />
+
+      {/* API */}
+      <section className="flex flex-col gap-4">
+        <Heading type="h2">
+          <T k="hooks.common.parametersTitle" />
+        </Heading>
+        <PropsTable items={parameters} />
+      </section>
+      <Separator color="mute" />
+      <section className="flex flex-col gap-4">
+        <Heading type="h2">
+          <T k="hooks.common.returnValueTitle" />
+        </Heading>
+        <PropsTable items={returnValue} />
+      </section>
+    </div>
+  );
+}

--- a/packages/arte-odyssey/README.md
+++ b/packages/arte-odyssey/README.md
@@ -76,61 +76,71 @@ ArteOdyssey includes design system documentation in `docs/` directory. When inst
 
 ## Component Categories
 
-### Layout & Navigation
+### Buttons
 
-- **Accordion** - Collapsible content panels
+- **Button** - Primary action button (use `renderItem` to render as a link)
+- **IconButton** - Button with icon only (use `renderItem` to render as a link)
+
+### Navigation
+
+- **Anchor** - Text link with external-link awareness
 - **Breadcrumb** - Navigation path indicator
-- **Card** / **InteractiveCard** - Flexible content container (with hover interaction)
-- **Separator** - Visual content divider
+- **Pagination** - Page navigation controls
 - **Tabs** - Tab-based content organization
-- **ScrollLinked** - Scroll progress indicator
 
 ### Form Controls
 
 - **Autocomplete** - Search with suggestions
-- **Checkbox** - Binary selection input
+- **Checkbox** / **CheckboxCard** / **CheckboxGroup** - Multi-selection inputs
 - **FileField** - File upload with composite pattern
-- **FormControl** - Form field wrapper with label and validation
+- **Form** / **FormControl** - Form wrapper and field with label/validation
 - **NumberField** - Numeric input with controls
-- **Radio** - Single selection from options
-- **Slider** - Slider input control
+- **PasswordInput** - Password input with show/hide toggle
+- **Radio** / **RadioCard** - Single-selection inputs
 - **Select** - Dropdown selection
+- **Slider** - Slider input control
+- **Switch** - Toggle switch
 - **TextField** - Single-line text input
 - **Textarea** - Multi-line text input
 
-### Buttons & Links
+### Data Display
 
-- **Button** - Primary action button
-- **IconButton** - Button with icon only
-- **LinkButton** - Button styled as link
-- **Anchor** - External link component
-- **IconLink** - Link with icon
+- **Accordion** - Collapsible content panels
+- **Avatar** - User/entity avatar
+- **Badge** - Status/label indicator
+- **BaselineStatus** - Web standard support indicator
+- **Card** / **InteractiveCard** - Flexible content container (with hover interaction)
+- **Code** - Formatted code display
+- **Heading** - Typography heading component
+- **Table** - Tabular data display
 
-### Feedback & Status
+### Feedback
 
 - **Alert** - Important messages and notifications
-- **Toast** - Temporary notification messages
 - **Progress** - Progress indication
-- **BaselineStatus** - Web standard support indicator
+- **Skeleton** - Content loading placeholder
+- **Spinner** - Loading indicator
+- **ToastProvider** / **useToast** - Temporary notification messages
 
-### Overlays & Modals
+### Overlays
 
 - **Dialog** - Modal dialog boxes
 - **Drawer** - Slide-out panel
+- **DropdownMenu** - Action menu component
+- **ListBox** - Selectable list component
 - **Modal** - Overlay modal component
 - **Popover** - Floating content container
 - **Tooltip** - Contextual help text
-- **DropdownMenu** - Action menu component
 
-### Data Display
+### Layout
 
-- **Code** - Formatted code display
-- **Heading** - Typography heading component
-- **ListBox** - Selectable list component
+- **ScrollLinked** - Scroll progress indicator
+- **Separator** - Visual content divider
 
 ### Utilities
 
-- **ArteOdysseyProvider** - Context providers for the library
+- **ArteOdysseyProvider** - Root provider for the library
+- **PortalRootProvider** / **usePortalRoot** - Customize the portal mount root
 - **Icons** - Icon component collection
 
 ## Usage Examples
@@ -224,18 +234,27 @@ import { useLocalStorage } from '@k8o/arte-odyssey';
 
 The library includes several useful hooks:
 
+- **useBreakpoint** - Tailwind breakpoint matcher
 - **useClickAway** - Detect clicks outside an element
 - **useClient** - Client-side rendering detection
 - **useClipboard** - Clipboard operations
+- **useControllableState** - Controlled/uncontrolled state pattern
+- **useDebouncedTransition** - Rate-limited transition with `AbortSignal`
+- **useDeferredDebounce** - `useDeferredValue` with pending flag
+- **useDisclosure** - Open/close/toggle disclosure state
 - **useHash** - URL hash management
+- **useHover** - Element hover detection
+- **useIntersectionObserver** / **useInView** - Element visibility
 - **useInterval** - Interval timer management
-- **useLocalStorage** - Local storage with React state
-- **useResize** - Element resize detection
+- **useLocalStorage** / **useSessionStorage** - Web Storage with React state
+- **useResize** - Element resize detection (ResizeObserver)
 - **useScrollDirection** - Scroll direction detection
+- **useScrollLock** - Body/element scroll lock
 - **useStep** - Step-based state management
 - **useTimeout** - Timeout management
 - **useWindowResize** - Window resize events
 - **useWindowSize** - Window size tracking
+- **useWritingMode** - Detect horizontal/vertical `writing-mode`
 
 ## Accessibility
 

--- a/packages/arte-odyssey/docs/GUIDE.md
+++ b/packages/arte-odyssey/docs/GUIDE.md
@@ -137,12 +137,12 @@ import { Button, Card } from '@k8o/arte-odyssey';
 
 ## コンポーネント使用の原則
 
-### Button / LinkButton
+### Button
 
 `color` と `variant` で統一されたスタイル。ピル型（`rounded-full`）。
 
 ```tsx
-import { Button, LinkButton } from '@k8o/arte-odyssey';
+import { Button } from '@k8o/arte-odyssey';
 
 // プライマリアクション
 <Button color="primary" variant="contained">保存する</Button>
@@ -153,20 +153,39 @@ import { Button, LinkButton } from '@k8o/arte-odyssey';
 // テキストのみ
 <Button variant="skeleton">詳細を見る</Button>
 
-// リンクボタン（同じ props）
-<LinkButton href="/settings" color="gray">設定へ</LinkButton>
+// リンクとしてレンダーする（renderItem prop）
+<Button
+  color="gray"
+  renderItem={({ className, children }) => (
+    <a className={className} href="/settings">{children}</a>
+  )}
+>
+  設定へ
+</Button>
 ```
 
-### IconButton / IconLink
+### IconButton
 
 `bg` prop でスタイルを制御（`variant` ではない）。
 
 ```tsx
-import { IconButton, IconLink } from '@k8o/arte-odyssey';
+import { IconButton } from '@k8o/arte-odyssey';
 
 <IconButton bg="transparent" label="コピー"><CopyIcon /></IconButton>
 <IconButton bg="primary" label="送信"><SendIcon /></IconButton>
-<IconLink href="/home" bg="base" label="ホーム"><HomeIcon /></IconLink>
+
+// リンクとしてレンダーする（renderItem prop）
+<IconButton
+  bg="base"
+  label="ホーム"
+  renderItem={({ className, children, 'aria-label': ariaLabel, triggerProps }) => (
+    <a aria-label={ariaLabel} className={className} href="/home" {...triggerProps}>
+      {children}
+    </a>
+  )}
+>
+  <HomeIcon />
+</IconButton>
 ```
 
 ### Card / InteractiveCard

--- a/packages/arte-odyssey/docs/references/components.md
+++ b/packages/arte-odyssey/docs/references/components.md
@@ -28,8 +28,25 @@ import { Button } from '@k8o/arte-odyssey';
   startIcon={<Icon />}
   endIcon={<Icon />}
   disabled={false}
+  active={false}
 >
   ボタン
+</Button>
+```
+
+リンクとしてレンダーする場合は `renderItem` prop を使う。Next.js の `<Link>` などにも応用できる。
+
+```tsx
+<Button
+  color="gray"
+  variant="outlined"
+  renderItem={({ className, children }) => (
+    <a className={className} href="/page">
+      {children}
+    </a>
+  )}
+>
+  リンク
 </Button>
 ```
 
@@ -51,28 +68,30 @@ Props:
 - `size`: `'sm'` | `'md'` | `'lg'`
 - `label`: string（必須、aria-label として使用）
 
-### LinkButton
-
-リンクスタイルのボタン。Button と同じ `color` / `variant` props。
+リンクとしてレンダーする場合は `renderItem` prop を使う。`triggerProps` を `<a>` にスプレッドすると hover/focus 時に `label` が Tooltip として表示される。
 
 ```tsx
-import { LinkButton } from '@k8o/arte-odyssey';
-
-<LinkButton href="/page" color="gray" variant="outlined">
-  リンク
-</LinkButton>;
-```
-
-### IconLink
-
-アイコンのみのリンク。IconButton と同じ `bg` prop。
-
-```tsx
-import { IconLink } from '@k8o/arte-odyssey';
-
-<IconLink href="/home" bg="base" label="ホーム">
+<IconButton
+  bg="base"
+  label="ホーム"
+  renderItem={({
+    className,
+    children,
+    'aria-label': ariaLabel,
+    triggerProps,
+  }) => (
+    <a
+      aria-label={ariaLabel}
+      className={className}
+      href="/home"
+      {...triggerProps}
+    >
+      {children}
+    </a>
+  )}
+>
   <HomeIcon />
-</IconLink>;
+</IconButton>
 ```
 
 ### Anchor

--- a/packages/arte-odyssey/docs/references/hooks.md
+++ b/packages/arte-odyssey/docs/references/hooks.md
@@ -267,6 +267,23 @@ lock();
 unlock();
 ```
 
+### useWritingMode
+
+要素の `writing-mode` を検知し、`'horizontal'` または `'vertical'` を返す。`vertical-*` / `sideways-*` はすべて `'vertical'` として正規化される。ResizeObserver で監視し、SSR では `'horizontal'` を返す。
+
+```tsx
+const ref = useRef<HTMLDivElement>(null);
+const writingMode = useWritingMode(ref); // 'horizontal' | 'vertical'
+```
+
+引数:
+
+- `ref`: `RefObject<Element | null>`
+
+戻り値:
+
+- `'horizontal' | 'vertical'`
+
 ### useBreakpoint
 
 Tailwind ブレークポイントの判定。


### PR DESCRIPTION
## Summary

ドキュメント類が実装に追従できていない箇所を一括で反映しました。

### AI Agent Documentation (npm に同梱される `packages/arte-odyssey/docs/`)

- `GUIDE.md` / `references/components.md`: 既に削除済みの **`LinkButton` / `IconLink`** への参照を除去し、現行の `Button` / `IconButton` の **`renderItem` prop** によるリンク化パターンを記載
- `references/hooks.md`: 追加済みの **`useWritingMode`** フックの説明を追加

### packages/arte-odyssey/README.md

- Component Categories を実際の export と一致するよう全面改訂（`Pagination` / `Switch` / `CheckboxGroup` / `PasswordInput` / `Badge` / `Spinner` / `Skeleton` / `Table` / `Avatar` / `Heading` / `PortalRootProvider` などを追加、存在しない `LinkButton` / `IconLink` を削除）
- Custom Hooks 一覧を実際の export と一致するよう更新（`useBreakpoint` / `useControllableState` / `useDebouncedTransition` / `useDeferredDebounce` / `useDisclosure` / `useHover` / `useIntersectionObserver` / `useInView` / `useScrollLock` / `useSessionStorage` / `useWritingMode` を追加）

### 直下 `README.md`

- "Turborepo" との記述を **Vite+ (`vp`)** に修正
- pnpm のバージョンを **11.1.3** に更新
- プロジェクト構造に `apps/docs/` を追加

### 直下 `CLAUDE.md`

- pnpm のバージョンを **11.1.3** に更新

### apps/docs

- 未ドキュメントだった **`useWritingMode`** フックのページを追加
  - `src/pages/hooks/use-writing-mode-page.tsx` 新規作成
  - `src/app.tsx` にルート登録
  - `src/data/hooks-nav.ts` のサイドバーに追加
  - `src/i18n/types.ts` / `src/i18n/messages/{ja,en}.ts` に description キーを追加

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm check` (oxlint / oxfmt) — passes
- [x] `pnpm --filter docs build` — passes（新しい route が SSR バンドルに含まれることを確認）
- [ ] `pnpm dev` で `/hooks/use-writing-mode` を表示し、レイアウト・i18n が他のフックページと同じ見え方であることを目視確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01L1JEpeR9QxACvkLZRbrPJY)_