### PR TITLE
fix: oxlint の require-unicode-regexp / no-underscore-dangle に準拠

### DIFF
--- a/packages/arte-odyssey/scripts/generate-css.ts
+++ b/packages/arte-odyssey/scripts/generate-css.ts
@@ -232,8 +232,8 @@ ${renderDark()}
 
 ${renderTheme()}`;
 
-const __dirname = import.meta.dirname;
-const stylesDir = resolve(__dirname, '../src/styles');
+const scriptDir = import.meta.dirname;
+const stylesDir = resolve(scriptDir, '../src/styles');
 
 const base = readFileSync(resolve(stylesDir, 'base.css'), 'utf8').trimEnd();
 const utilities = readFileSync(

--- a/packages/arte-odyssey/src/components/data-display/avatar/avatar.tsx
+++ b/packages/arte-odyssey/src/components/data-display/avatar/avatar.tsx
@@ -23,7 +23,7 @@ const getInitials = (name?: string) => {
 
   const initials = name
     .trim()
-    .split(/\s+/)
+    .split(/\s+/u)
     .slice(0, 2)
     .map((part) => part.charAt(0).toUpperCase())
     .join('');

--- a/packages/arte-odyssey/src/components/data-display/code/find-all-colors.ts
+++ b/packages/arte-odyssey/src/components/data-display/code/find-all-colors.ts
@@ -4,7 +4,7 @@ const extractFunctionContent = (
   source: string,
   funcName: string,
 ): ColorMatch[] => {
-  const funcPattern = new RegExp(`${funcName}\\s*\\(`, 'gi');
+  const funcPattern = new RegExp(`${funcName}\\s*\\(`, 'giu');
   const matches: ColorMatch[] = [];
   let match = funcPattern.exec(source);
 
@@ -58,7 +58,7 @@ export function findAllColors(text: string): ColorMatch[] {
   }
 
   // HEX色を見つける
-  const hexPattern = /#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})(?=\s|;|,|$|\)|]|})/g;
+  const hexPattern = /#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})(?=\s|;|,|$|\)|\]|\})/gu;
   let hexMatch = hexPattern.exec(text);
   while (hexMatch !== null) {
     results.push({
@@ -111,7 +111,7 @@ export function findAllColors(text: string): ColorMatch[] {
 
       // 前後が英数字でないことを確認（完全一致のみ）
       const isWordBoundary = !(
-        /[a-zA-Z0-9]/.test(beforeChar) || /[a-zA-Z0-9]/.test(afterChar)
+        /[a-zA-Z0-9]/u.test(beforeChar) || /[a-zA-Z0-9]/u.test(afterChar)
       );
 
       if (isWordBoundary) {

--- a/packages/arte-odyssey/src/components/form/number-field/cast.ts
+++ b/packages/arte-odyssey/src/components/form/number-field/cast.ts
@@ -1,6 +1,6 @@
 import { toPrecision } from '../../../internal/to-precision';
 
-const FLOATING_POINT_REGEX = /^[Ee0-9+\-.]$/;
+const FLOATING_POINT_REGEX = /^[Ee0-9+\-.]$/u;
 
 const isInvalidCharacter = (value: string): boolean =>
   FLOATING_POINT_REGEX.test(value);
@@ -12,7 +12,7 @@ const sanitize = (value: string): string =>
     .join('');
 
 const parse = (value: string | number): number =>
-  Number.parseFloat(value.toString().replaceAll(/[^\w.-]+/g, ''));
+  Number.parseFloat(value.toString().replaceAll(/[^\w.-]+/gu, ''));
 
 const countDecimalPlaces = (value: number): number => {
   if (!Number.isFinite(value)) return 0;

--- a/packages/arte-odyssey/src/components/navigation/breadcrumb/breadcrumb.tsx
+++ b/packages/arte-odyssey/src/components/navigation/breadcrumb/breadcrumb.tsx
@@ -32,7 +32,7 @@ const Separator: FC = () => (
   </li>
 );
 
-const _Link = <T extends string>({
+const Link = <T extends string>({
   href,
   current = false,
   children,
@@ -42,16 +42,16 @@ const _Link = <T extends string>({
   current?: boolean;
   component?: FC<{ href: T; className: string }>;
 }>) => {
-  const Link = component ?? 'a';
+  const Component = component ?? 'a';
   return current ? (
     <span className="text-fg-base">{children}</span>
   ) : (
-    <Link
+    <Component
       className="hover:text-fg-base focus-visible:ring-border-info underline transition-colors focus-visible:rounded-sm focus-visible:ring-2 focus-visible:outline-none"
       href={href}
     >
       {children}
-    </Link>
+    </Component>
   );
 };
 
@@ -59,5 +59,5 @@ export const Breadcrumb = {
   List,
   Item,
   Separator,
-  Link: _Link,
+  Link,
 } as const;

--- a/packages/arte-odyssey/src/components/overlays/popover/hooks.ts
+++ b/packages/arte-odyssey/src/components/overlays/popover/hooks.ts
@@ -107,8 +107,8 @@ export const usePopoverContent = () => {
       case 'listbox':
         return { id, ref, role: 'listbox' };
       default: {
-        const _exhaustive: never = popover.type;
-        return _exhaustive;
+        const exhaustive: never = popover.type;
+        return exhaustive;
       }
     }
   }, [popover.rootId, popover.type, ref]);
@@ -212,8 +212,8 @@ export const usePopoverTrigger = (): PopoverTriggerProps => {
           ref: popover.setTriggerRef,
         };
       default: {
-        const _exhaustive: never = popover.type;
-        return _exhaustive;
+        const exhaustive: never = popover.type;
+        return exhaustive;
       }
     }
   }, [popover]);


### PR DESCRIPTION
## Summary

- 次期 oxlint バージョンで有効化される 2 つのルール違反を解消する
  - `require-unicode-regexp`: 全ての正規表現に `u` フラグを付与
  - `no-underscore-dangle`: dangling underscore を持つ識別子 (`_Link`, `_exhaustive`, `__dirname`) をリネーム
- [#483](https://github.com/k35o/arte-odyssey/pull/483) で oxlint が更新された際に発生する Lint 失敗を、main 側で先回りして解消するための修正
- マージ後に Renovate が #483 を rebase することで、依存更新側の CI も通るようになる

## 変更内容

| ファイル | 修正内容 |
|---|---|
| `packages/arte-odyssey/scripts/generate-css.ts` | `__dirname` → `scriptDir` |
| `packages/arte-odyssey/src/components/data-display/avatar/avatar.tsx` | `/\s+/` → `/\s+/u` |
| `packages/arte-odyssey/src/components/data-display/code/find-all-colors.ts` | 4 つの正規表現に `u` フラグを付与（合わせて `]` `}` を `\]` `\}` にエスケープ） |
| `packages/arte-odyssey/src/components/form/number-field/cast.ts` | 2 つの正規表現に `u` フラグを付与 |
| `packages/arte-odyssey/src/components/navigation/breadcrumb/breadcrumb.tsx` | `_Link` → `Link`、内側の `Link` 変数 (`component ?? 'a'`) は名前衝突を避けて `Component` に |
| `packages/arte-odyssey/src/components/overlays/popover/hooks.ts` | `_exhaustive` → `exhaustive` (2 箇所) |

## Test plan

- [x] `pnpm build`
- [x] `pnpm check` (ルート, all packages)
- [x] `pnpm typecheck`
- [x] `pnpm test` (`packages/arte-odyssey`: 295/295 passed)