### PR TITLE
refactor(docs): derive design-token view from extractor refs

### DIFF
--- a/apps/docs/src/theme/design-tokens.ts
+++ b/apps/docs/src/theme/design-tokens.ts
@@ -1,44 +1,29 @@
 /**
  * Docs-only design-token view.
  *
- * The token VALUES come from `@k8o/arte-odyssey/tokens` (extracted from the
- * design system's CSS by `tailwind-token-extractor`). Presentation metadata that
- * does NOT exist in CSS — palette hue/description, the semantic ShadeRef tables,
- * and the spacing display scale — lives here, since it is a documentation
- * concern rather than part of the library's public token API.
+ * Everything derivable comes from `@k8o/arte-odyssey/tokens` (extracted from the
+ * design system's CSS by `tailwind-token-extractor`):
+ *   - palette families / shades / hue ← `tokens.vars` (`teal-500` keys, oklch hue)
+ *   - semantic → palette mappings     ← `tokens.refs` (the symbolic var() targets)
+ *   - typography / scales / z-index   ← `tokens.theme` / `tokens.vars`
+ *
+ * Only genuinely authored knowledge is hand-written here: the palette
+ * descriptions (design rationale, not in CSS) and the spacing display scale
+ * (a multiplicative view of the single `--spacing` unit).
  */
 import { tokens } from '@k8o/arte-odyssey/tokens';
 
-export const SHADES = [
-  50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950,
-] as const;
-export type Shade = (typeof SHADES)[number];
-
-export const PALETTE_PREFIXES = [
-  'gray',
-  'red',
-  'pink',
-  'purple',
-  'cyan',
-  'blue',
-  'teal',
-  'green',
-  'yellow',
-  'orange',
-] as const;
-export type PalettePrefix = (typeof PALETTE_PREFIXES)[number];
-
-export type ShadeRef = `${PalettePrefix}-${Shade}` | 'white';
+export type Shade = number;
 
 export type PaletteFamily = {
   name: string;
-  prefix: PalettePrefix;
+  prefix: string;
   hue: number;
   description: string;
   shades: Record<Shade, string>;
 };
 
-export type SemanticToken = { name: string; light: ShadeRef; dark: ShadeRef };
+export type SemanticToken = { name: string; light: string; dark: string };
 export type TextSize = { name: string; fontSize: string; lineHeight: number };
 export type NamedScale = { name: string; value: string };
 export type SpacingStep = { step: number; rem: string; px: string };
@@ -52,6 +37,7 @@ const THEME = tokens.theme as unknown as Record<
   string,
   Record<string, unknown>
 >;
+const REFS = tokens.refs as Record<string, { light: string; dark: string }>;
 
 const scalarVar = (key: string): string => {
   const value = VARS.get(key);
@@ -69,97 +55,74 @@ const namedScale = (group: Record<string, unknown> | undefined): NamedScale[] =>
     value: String(value),
   }));
 
-// --- palette (hue/description = metadata, shade values = extracted) -----------
-const PALETTE_META: ReadonlyArray<Omit<PaletteFamily, 'shades'>> = [
-  {
-    name: 'Gray',
-    prefix: 'gray',
-    hue: 235,
-    description: 'H: 235 (sky blue tint), minimal chroma for branded neutral',
-  },
-  { name: 'Red', prefix: 'red', hue: 25, description: 'H: 25' },
-  { name: 'Pink', prefix: 'pink', hue: 350, description: 'H: 350' },
-  { name: 'Purple', prefix: 'purple', hue: 305, description: 'H: 305' },
-  { name: 'Cyan', prefix: 'cyan', hue: 210, description: 'H: 210 (Secondary)' },
-  { name: 'Blue', prefix: 'blue', hue: 260, description: 'H: 260' },
-  { name: 'Teal', prefix: 'teal', hue: 180, description: 'H: 180 (Primary)' },
-  { name: 'Green', prefix: 'green', hue: 150, description: 'H: 150' },
-  { name: 'Yellow', prefix: 'yellow', hue: 90, description: 'H: 90' },
-  { name: 'Orange', prefix: 'orange', hue: 55, description: 'H: 55' },
-];
+// --- palette (families/shades/hue derived; descriptions authored) -------------
+/** Design rationale that does not exist in CSS; keyed by palette prefix. */
+const PALETTE_DESCRIPTIONS: Record<string, string> = {
+  gray: 'sky blue tint, minimal chroma for branded neutral',
+  cyan: 'Secondary',
+  teal: 'Primary',
+};
 
-export const PALETTE: readonly PaletteFamily[] = PALETTE_META.map((family) => ({
-  name: family.name,
-  prefix: family.prefix,
-  hue: family.hue,
-  description: family.description,
-  shades: Object.fromEntries(
-    SHADES.map((shade) => [shade, scalarVar(`${family.prefix}-${shade}`)]),
-  ) as Record<Shade, string>,
-}));
+const valueOf = (v: VarValue): string =>
+  typeof v === 'object' ? String(v.light) : String(v);
+const isColor = (s: string): boolean => /^(oklch|rgb|hsl|#)/iu.test(s);
+const hueOf = (oklch: string): number => {
+  const m = /^oklch\(\s*\S+\s+\S+\s+(-?[\d.]+)/iu.exec(oklch.trim());
+  return m?.[1] === undefined ? Number.NaN : Number(m[1]);
+};
+const capitalize = (s: string): string =>
+  s.charAt(0).toUpperCase() + s.slice(1);
 
-// --- semantic tokens (ShadeRef labels = metadata; swatch uses live CSS var) ---
-export const FG_TOKENS: readonly SemanticToken[] = [
-  { name: 'fg-base', light: 'gray-900', dark: 'gray-50' },
-  { name: 'fg-subtle', light: 'gray-400', dark: 'gray-500' },
-  { name: 'fg-mute', light: 'gray-700', dark: 'gray-300' },
-  { name: 'fg-inverse', light: 'gray-50', dark: 'gray-900' },
-  { name: 'fg-info', light: 'blue-800', dark: 'blue-200' },
-  { name: 'fg-success', light: 'green-800', dark: 'green-200' },
-  { name: 'fg-warning', light: 'yellow-800', dark: 'yellow-200' },
-  { name: 'fg-error', light: 'red-800', dark: 'red-200' },
-];
+// Scan the raw var layer for `<prefix>-<shade>` color entries (e.g. `teal-500`),
+// preserving CSS source order for families/shades. Hue is constant within a
+// family, so it is read from the first shade encountered.
+const PALETTE_SHADE_RE = /^([a-z]+)-(\d+)$/u;
+const shadeSet = new Set<number>();
+const prefixOrder: string[] = [];
+const hueByPrefix = new Map<string, number>();
+for (const [name, value] of VARS) {
+  const m = PALETTE_SHADE_RE.exec(name);
+  const prefix = m?.[1];
+  const shade = m?.[2];
+  if (prefix === undefined || shade === undefined) continue;
+  const color = valueOf(value);
+  if (!isColor(color)) continue;
+  shadeSet.add(Number(shade));
+  if (!prefixOrder.includes(prefix)) {
+    prefixOrder.push(prefix);
+    hueByPrefix.set(prefix, hueOf(color));
+  }
+}
 
-export const BG_TOKENS: readonly SemanticToken[] = [
-  { name: 'bg-base', light: 'white', dark: 'gray-800' },
-  { name: 'bg-raised', light: 'white', dark: 'gray-700' },
-  { name: 'bg-surface', light: 'gray-50', dark: 'gray-900' },
-  { name: 'bg-subtle', light: 'gray-100', dark: 'gray-800' },
-  { name: 'bg-mute', light: 'gray-200', dark: 'gray-700' },
-  { name: 'bg-emphasize', light: 'gray-300', dark: 'gray-600' },
-  { name: 'bg-inverse', light: 'gray-900', dark: 'white' },
-  { name: 'bg-info', light: 'blue-100', dark: 'blue-900' },
-  { name: 'bg-success', light: 'green-100', dark: 'green-900' },
-  { name: 'bg-warning', light: 'yellow-100', dark: 'yellow-900' },
-  { name: 'bg-error', light: 'red-100', dark: 'red-900' },
-];
+export const SHADES: readonly Shade[] = [...shadeSet].toSorted((a, b) => a - b);
+export const PALETTE_PREFIXES: readonly string[] = prefixOrder;
 
-export const BORDER_TOKENS: readonly SemanticToken[] = [
-  { name: 'border-base', light: 'gray-400', dark: 'gray-600' },
-  { name: 'border-subtle', light: 'gray-100', dark: 'gray-700' },
-  { name: 'border-mute', light: 'gray-200', dark: 'gray-600' },
-  { name: 'border-emphasize', light: 'gray-500', dark: 'gray-500' },
-  { name: 'border-inverse', light: 'gray-700', dark: 'gray-300' },
-  { name: 'border-info', light: 'blue-500', dark: 'blue-400' },
-  { name: 'border-success', light: 'green-500', dark: 'green-400' },
-  { name: 'border-warning', light: 'yellow-500', dark: 'yellow-400' },
-  { name: 'border-error', light: 'red-500', dark: 'red-400' },
-];
+export const PALETTE: readonly PaletteFamily[] = PALETTE_PREFIXES.map(
+  (prefix) => ({
+    name: capitalize(prefix),
+    prefix,
+    hue: hueByPrefix.get(prefix) ?? Number.NaN,
+    description: PALETTE_DESCRIPTIONS[prefix] ?? '',
+    shades: Object.fromEntries(
+      SHADES.map((shade) => [shade, scalarVar(`${prefix}-${shade}`)]),
+    ) as Record<Shade, string>,
+  }),
+);
 
-export const PRIMARY_TOKENS: readonly SemanticToken[] = [
-  { name: 'primary-fg', light: 'teal-800', dark: 'teal-300' },
-  { name: 'primary-bg', light: 'teal-200', dark: 'teal-800' },
-  { name: 'primary-bg-subtle', light: 'teal-50', dark: 'teal-950' },
-  { name: 'primary-bg-mute', light: 'teal-100', dark: 'teal-900' },
-  { name: 'primary-bg-emphasize', light: 'teal-300', dark: 'teal-700' },
-  { name: 'primary-border', light: 'teal-500', dark: 'teal-500' },
-];
+// --- semantic tokens (mapping derived from tokens.refs) -----------------------
+// Each entry is `{ name, light, dark }` where light/dark are the palette shade
+// the semantic var aliases in that mode — recovered from the CSS, not hand-kept.
+const semanticTokens = (prefix: string): readonly SemanticToken[] =>
+  Object.entries(REFS)
+    .filter(([name]) => name.startsWith(prefix))
+    .map(([name, ref]) => ({ name, light: ref.light, dark: ref.dark }));
 
-export const SECONDARY_TOKENS: readonly SemanticToken[] = [
-  { name: 'secondary-fg', light: 'cyan-800', dark: 'cyan-300' },
-  { name: 'secondary-bg', light: 'cyan-200', dark: 'cyan-800' },
-  { name: 'secondary-bg-subtle', light: 'cyan-50', dark: 'cyan-950' },
-  { name: 'secondary-bg-mute', light: 'cyan-100', dark: 'cyan-900' },
-  { name: 'secondary-bg-emphasize', light: 'cyan-300', dark: 'cyan-700' },
-  { name: 'secondary-border', light: 'cyan-500', dark: 'cyan-500' },
-];
-
-export const GROUP_TOKENS: readonly SemanticToken[] = [
-  { name: 'group-primary', light: 'teal-800', dark: 'teal-200' },
-  { name: 'group-secondary', light: 'cyan-800', dark: 'cyan-200' },
-  { name: 'group-tertiary', light: 'pink-800', dark: 'pink-200' },
-  { name: 'group-quaternary', light: 'purple-800', dark: 'purple-200' },
-];
+export const FG_TOKENS = semanticTokens('fg-');
+export const BG_TOKENS = semanticTokens('bg-');
+export const BORDER_TOKENS = semanticTokens('border-');
+export const PRIMARY_TOKENS = semanticTokens('primary-');
+export const SECONDARY_TOKENS = semanticTokens('secondary-');
+export const GROUP_TOKENS = semanticTokens('group-');
 
 // --- typography / scales (values extracted) -----------------------------------
 type GeneratedText = {
@@ -203,11 +166,9 @@ export const BREAKPOINTS: readonly Breakpoint[] = Object.entries(
   THEME['breakpoint'] ?? {},
 ).map(([name, rem]) => ({ name, rem: String(rem), px: remToPx(String(rem)) }));
 
-const Z_ORDER = ['overlay', 'modal', 'toast'] as const;
-export const Z_INDICES: readonly NamedScale[] = Z_ORDER.map((name) => ({
-  name,
-  value: scalarVar(`z-${name}`),
-}));
+export const Z_INDICES: readonly NamedScale[] = Object.keys(tokens.vars)
+  .filter((name) => name.startsWith('z-'))
+  .map((name) => ({ name: name.slice(2), value: scalarVar(name) }));
 
 /** Display scale for docs — not derivable from CSS. */
 export const SPACING_SCALE: readonly SpacingStep[] = [

--- a/packages/arte-odyssey/package.json
+++ b/packages/arte-odyssey/package.json
@@ -108,7 +108,7 @@
     "react-dom": "catalog:",
     "storybook": "10.4.1",
     "storybook-addon-mock-date": "3.0.2",
-    "tailwind-token-extractor": "0.1.1",
+    "tailwind-token-extractor": "0.2.0",
     "tailwindcss": "catalog:",
     "vite": "catalog:",
     "vite-plus": "catalog:",

--- a/packages/arte-odyssey/src/styles/tokens.generated.ts
+++ b/packages/arte-odyssey/src/styles/tokens.generated.ts
@@ -630,6 +630,184 @@ export const tokens = {
       dark: 'oklch(0.9 0.082 305)',
     },
   },
+  refs: {
+    'fg-base': {
+      light: 'gray-900',
+      dark: 'gray-50',
+    },
+    'fg-subtle': {
+      light: 'gray-400',
+      dark: 'gray-500',
+    },
+    'fg-mute': {
+      light: 'gray-700',
+      dark: 'gray-300',
+    },
+    'fg-inverse': {
+      light: 'gray-50',
+      dark: 'gray-900',
+    },
+    'fg-info': {
+      light: 'blue-800',
+      dark: 'blue-200',
+    },
+    'fg-success': {
+      light: 'green-800',
+      dark: 'green-200',
+    },
+    'fg-warning': {
+      light: 'yellow-800',
+      dark: 'yellow-200',
+    },
+    'fg-error': {
+      light: 'red-800',
+      dark: 'red-200',
+    },
+    'bg-base': {
+      light: 'white',
+      dark: 'gray-800',
+    },
+    'bg-raised': {
+      light: 'white',
+      dark: 'gray-700',
+    },
+    'bg-surface': {
+      light: 'gray-50',
+      dark: 'gray-900',
+    },
+    'bg-subtle': {
+      light: 'gray-100',
+      dark: 'gray-800',
+    },
+    'bg-mute': {
+      light: 'gray-200',
+      dark: 'gray-700',
+    },
+    'bg-emphasize': {
+      light: 'gray-300',
+      dark: 'gray-600',
+    },
+    'bg-inverse': {
+      light: 'gray-900',
+      dark: 'white',
+    },
+    'bg-info': {
+      light: 'blue-100',
+      dark: 'blue-900',
+    },
+    'bg-success': {
+      light: 'green-100',
+      dark: 'green-900',
+    },
+    'bg-warning': {
+      light: 'yellow-100',
+      dark: 'yellow-900',
+    },
+    'bg-error': {
+      light: 'red-100',
+      dark: 'red-900',
+    },
+    'border-base': {
+      light: 'gray-400',
+      dark: 'gray-600',
+    },
+    'border-subtle': {
+      light: 'gray-100',
+      dark: 'gray-700',
+    },
+    'border-mute': {
+      light: 'gray-200',
+      dark: 'gray-600',
+    },
+    'border-emphasize': {
+      light: 'gray-500',
+      dark: 'gray-500',
+    },
+    'border-inverse': {
+      light: 'gray-700',
+      dark: 'gray-300',
+    },
+    'border-info': {
+      light: 'blue-500',
+      dark: 'blue-400',
+    },
+    'border-success': {
+      light: 'green-500',
+      dark: 'green-400',
+    },
+    'border-warning': {
+      light: 'yellow-500',
+      dark: 'yellow-400',
+    },
+    'border-error': {
+      light: 'red-500',
+      dark: 'red-400',
+    },
+    'primary-fg': {
+      light: 'teal-800',
+      dark: 'teal-300',
+    },
+    'primary-bg': {
+      light: 'teal-200',
+      dark: 'teal-800',
+    },
+    'primary-bg-subtle': {
+      light: 'teal-50',
+      dark: 'teal-950',
+    },
+    'primary-bg-mute': {
+      light: 'teal-100',
+      dark: 'teal-900',
+    },
+    'primary-bg-emphasize': {
+      light: 'teal-300',
+      dark: 'teal-700',
+    },
+    'primary-border': {
+      light: 'teal-500',
+      dark: 'teal-500',
+    },
+    'secondary-fg': {
+      light: 'cyan-800',
+      dark: 'cyan-300',
+    },
+    'secondary-bg': {
+      light: 'cyan-200',
+      dark: 'cyan-800',
+    },
+    'secondary-bg-subtle': {
+      light: 'cyan-50',
+      dark: 'cyan-950',
+    },
+    'secondary-bg-mute': {
+      light: 'cyan-100',
+      dark: 'cyan-900',
+    },
+    'secondary-bg-emphasize': {
+      light: 'cyan-300',
+      dark: 'cyan-700',
+    },
+    'secondary-border': {
+      light: 'cyan-500',
+      dark: 'cyan-500',
+    },
+    'group-primary': {
+      light: 'teal-800',
+      dark: 'teal-200',
+    },
+    'group-secondary': {
+      light: 'cyan-800',
+      dark: 'cyan-200',
+    },
+    'group-tertiary': {
+      light: 'pink-800',
+      dark: 'pink-200',
+    },
+    'group-quaternary': {
+      light: 'purple-800',
+      dark: 'purple-200',
+    },
+  },
 } as const;
 
 export const meta = {
@@ -643,6 +821,7 @@ export const meta = {
 
 export type ThemeNamespace = keyof typeof tokens.theme;
 export type VarName = keyof typeof tokens.vars;
+export type RefName = keyof typeof tokens.refs;
 export type AnimateToken = keyof typeof tokens.theme.animate;
 export type AspectToken = keyof typeof tokens.theme.aspect;
 export type BlurToken = keyof typeof tokens.theme.blur;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,8 +307,8 @@ importers:
         specifier: 3.0.2
         version: 3.0.2(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@2.8.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plus@0.1.22(@types/node@24.12.4)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.7)(jiti@2.7.0)(typescript@6.0.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0))))
       tailwind-token-extractor:
-        specifier: 0.1.1
-        version: 0.1.1(@tailwindcss/node@4.3.0)(tailwindcss@4.3.0)
+        specifier: 0.2.0
+        version: 0.2.0(@tailwindcss/node@4.3.0)(tailwindcss@4.3.0)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.3.0
@@ -3620,8 +3620,8 @@ packages:
   tailwind-merge@3.6.0:
     resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
-  tailwind-token-extractor@0.1.1:
-    resolution: {integrity: sha512-wQnMO6d95+gfbEUGisaoGGlkj22+PqGPiXSKXa9psIhNVQGytppn8H8crwrRgCSjFWGAOuweRsDZLGIt7hSQiw==}
+  tailwind-token-extractor@0.2.0:
+    resolution: {integrity: sha512-KIsdGIiveTwLyg0VO1G47vXCO4OiMkypcBIZUf/uro+BtzloGgH6E/clPuNnupoCsaZoLb0BzolbN3HkIMeGzQ==}
     engines: {node: '>=24.14.1'}
     hasBin: true
     peerDependencies:
@@ -6929,7 +6929,7 @@ snapshots:
 
   tailwind-merge@3.6.0: {}
 
-  tailwind-token-extractor@0.1.1(@tailwindcss/node@4.3.0)(tailwindcss@4.3.0):
+  tailwind-token-extractor@0.2.0(@tailwindcss/node@4.3.0)(tailwindcss@4.3.0):
     dependencies:
       '@tailwindcss/node': 4.3.0
       cac: 7.0.0


### PR DESCRIPTION
## 概要

docs のデザイントークン表示（`apps/docs/src/theme/design-tokens.ts`）を、手書きの並行マッピングから **抽出器由来の自動派生**へ切り替えた。これにより「CSS のトークンを変えたら docs の手書き表も直す」という暗黙の同期作業がなくなる。

`tailwind-token-extractor` を **0.2.0** に上げて再生成。生成物に新しい `tokens.refs`（`var()` の参照先を light/dark 別に保持）が入る。

## 動機

#499 で CSS をトークンの単一の真実の源にしたが、抽出器は `var()` を最終値まで解決して**シンボリックな関係を捨てて**いた。そのため docs は「`fg-base` → `gray-900`/`gray-50`」のような対応表を手書きで持つしかなく、CSS を変えても**ラベルが静かにドリフト**する状態だった（スウォッチはライブ変数なので正しく、ラベルだけ嘘になる）。`tokens.refs` がこの関係を復元するので、docs 側で派生できる。

## 詳細

- `tailwind-token-extractor` 0.1.1 → 0.2.0、`pnpm generate:tokens` で再生成（`tokens.generated.ts` は `refs` 追加の**純粋な addition**、既存値の変化なし）
- `design-tokens.ts` で派生に変更：
  - セマンティック表（`FG/BG/BORDER/PRIMARY/SECONDARY/GROUP_TOKENS`）← `tokens.refs`
  - パレットの家族・シェード・hue ← `tokens.vars`（hue は oklch 第3成分をパース、CSS ソース順を維持）
  - z-index 一覧 ← `tokens.vars`
- 手書きで残すのは CSS から導けないものだけ：パレットの**説明文**（設計意図）と `SPACING_SCALE`（`--spacing` 単位の倍数表示）
- 欠損トークンは従来どおり throw（loud failure）。これで「無検証の値の複製」が消える

## 気をつけるポイント

- **挙動非破壊**：派生した全テーブル（セマンティック表・prefixes・shades・hue）が旧手書き値と**完全一致**することをスクリプトで確認済み。`SemanticToken` 型は `light/dark: ShadeRef` → `string` に緩めた（参照名は生成物側で型付け）。`token-card.tsx` は `name`/`light`/`dark` を文字列として使うだけなので影響なし。
- 公開順は `tokens.vars`/`tokens.refs` の生成順（＝CSS ソース順）に依存。現状は旧テーブルと同順。

## テスト

- 派生値 vs 旧手書きテーブルの全件一致を検証（fg/bg/border/primary/secondary/group、prefixes、shades、hue）
- `pnpm typecheck`（docs）/ `pnpm check`(lint/format) パス
- `pnpm build`(docs SSG) 成功 — theming ページが `design-tokens.ts` を実行してレンダリングされることを確認

## 関連

- 抽出器側の対応 PR: k35o/tailwind-token-extractor#5（`tokens.refs` 追加、0.2.0 で公開）
- スタイル分割 PR: #504
