### PR TITLE
chore(deps)!: peerDeps を TypeScript >=6 / zod >=4.4 に引き上げ (v10 #1/4)

### DIFF
--- a/.changeset/v10-deps-config.md
+++ b/.changeset/v10-deps-config.md
@@ -1,0 +1,11 @@
+---
+"@k8o/arte-odyssey": major
+---
+
+依存・設定の前提を更新（v10 の締め）。
+
+**BREAKING**: `peerDependencies.typescript` を `>=5.9.0` → `>=6.0.0` に引き上げ。型定義は TypeScript 6 系を前提とする。
+
+- `peerDependencies.zod`（optional）を `>=4.0.0` → `>=4.4.0` に引き上げ（内部利用 API に合わせて SoT を統一）。
+- ルート `tsconfig.json` に `forceConsistentCasingInFileNames: true` を追加（非破壊）。
+- `engines.node` は `>=24.13.0` を維持。

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A modern, TypeScript-first React UI component library built with performance and
 
 ## Features
 
-- **Modern Stack**: Built with React 19, TypeScript 5.9+, and Tailwind CSS 4+
+- **Modern Stack**: Built with React 19, TypeScript 6+, and Tailwind CSS 4+
 - **Accessible**: WCAG compliant components with full keyboard navigation
 - **Performant**: Optimized bundle size with tree-shakeable components
 - **Developer Friendly**: Comprehensive TypeScript support and Storybook documentation

--- a/apps/docs/src/pages/get-started.tsx
+++ b/apps/docs/src/pages/get-started.tsx
@@ -112,7 +112,7 @@ function MyComponent() {
           <li className="list-disc">React &gt;= 19.0.0</li>
           <li className="list-disc">React DOM &gt;= 19.0.0</li>
           <li className="list-disc">Tailwind CSS &gt;= 4.0.0</li>
-          <li className="list-disc">TypeScript &gt;= 5.9.0</li>
+          <li className="list-disc">TypeScript &gt;= 6.0.0</li>
         </ul>
       </section>
 

--- a/packages/arte-odyssey/README.md
+++ b/packages/arte-odyssey/README.md
@@ -23,7 +23,7 @@ npm install react react-dom typescript tailwindcss
 Required versions:
 
 - React ≥19.0.0
-- TypeScript ≥5.9.0
+- TypeScript ≥6.0.0
 - Tailwind CSS ≥4.0.0
 
 ## Quick Start

--- a/packages/arte-odyssey/package.json
+++ b/packages/arte-odyssey/package.json
@@ -125,8 +125,8 @@
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0",
     "tailwindcss": ">=4.0.0",
-    "typescript": ">=5.9.0",
-    "zod": ">=4.0.0"
+    "typescript": ">=6.0.0",
+    "zod": ">=4.4.0"
   },
   "peerDependenciesMeta": {
     "@json-render/core": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,7 +240,7 @@ importers:
         specifier: 3.6.0
         version: 3.6.0
       typescript:
-        specifier: '>=5.9.0'
+        specifier: '>=6.0.0'
         version: 6.0.3
     devDependencies:
       '@chromatic-com/storybook':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
 
     // Best practices
     "strict": true,
+    "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
## 概要

v10.0.0 メジャーリリースの一環。依存・設定の前提を更新する。**スタックPRの 1/4（先頭）**。

## 破壊的変更

- \`peerDependencies.typescript\`: \`>=5.9.0\` → **\`>=6.0.0\`**（型定義は TS6 系前提）

## その他

- \`peerDependencies.zod\`(optional): \`>=4.0.0\` → \`>=4.4.0\`（内部利用 API に合わせ SoT 統一）
- ルート \`tsconfig.json\` に \`forceConsistentCasingInFileNames: true\` を追加（非破壊）
- \`engines.node\` は \`>=24.13.0\` を維持

changeset: \`v10-deps-config.md\`（major）

## v10 スタック（マージ順）

1. **#この PR** deps/config ← main
2. form onChange 値型統一
3. variant/tone 語彙統一
4. overlay controllable 化

すべて major changeset。最終的に 10.0.0 へ集約。