### PR TITLE
feat(form)!: onChange を値型シグネチャに統一 (v10 #2/4)

### DIFF
--- a/.changeset/v10-form-onchange-value.md
+++ b/.changeset/v10-form-onchange-value.md
@@ -1,0 +1,30 @@
+---
+"@k8o/arte-odyssey": major
+---
+
+フォームコンポーネントの `onChange` を値型シグネチャに統一。イベント型と値型の混在、`ListBox` の `onSelect` 別名を解消した。第1引数を「その要素の意味的な値」とし、実 `<input>` を持つコンポーネントは第2引数で本物の DOM イベントも渡す。
+
+**BREAKING**:
+
+- `Checkbox` / `Switch`: `ChangeEventHandler<HTMLInputElement>` → `(checked: boolean, event: ChangeEvent<HTMLInputElement>) => void`
+- `Radio`: `ChangeEventHandler<HTMLInputElement>` → `(value: string, event: ChangeEvent<HTMLInputElement>) => void`
+- `RadioCard`: `ChangeEventHandler<HTMLInputElement>` → `(value: string) => void`（`<button>` 駆動で change イベントが存在しないため値のみ）
+- `FileField`: `ChangeEventHandler<HTMLInputElement>` → `(files: FileList | null, event?: ChangeEvent<HTMLInputElement>) => void`（プログラム的なファイル削除時は `event` が `undefined`）
+- `ListBox.Root`: `onSelect` を `onChange: (key: string) => void` にリネーム
+
+`Slider` / `NumberField` / `Autocomplete` / `CheckboxCard` / `CheckboxGroup` / `Tabs` は既に値型のため変更なし。`TextField` / `Textarea` / `Select` / `PasswordInput` はネイティブ `<input>` 互換のため従来どおりイベント型 `onChange` を維持する。
+
+> 値だけ使う場合は第1引数のみ受け取れば良い（`(value) => void` は `(value, event) => void` に代入可能）。`preventDefault` や `currentTarget` 等が必要なときは第2引数の本物の DOM イベントを使う。
+
+```tsx
+// v9
+<Checkbox onChange={(e) => setChecked(e.target.checked)} />
+// v10（値だけ / イベントも）
+<Checkbox onChange={(checked) => setChecked(checked)} />
+<Checkbox onChange={(checked, event) => { event.stopPropagation(); setChecked(checked); }} />
+
+// v9
+<ListBox.Root onSelect={(key) => setKey(key)} options={options} value={value}>
+// v10
+<ListBox.Root onChange={(key) => setKey(key)} options={options} value={value}>
+```

--- a/apps/docs/src/components/component-previews.tsx
+++ b/apps/docs/src/components/component-previews.tsx
@@ -331,7 +331,7 @@ export const componentPreviews: Record<string, ReactNode> = {
   ListBox: (
     <div className="w-56">
       <ListBox.Root
-        onSelect={() => undefined}
+        onChange={() => undefined}
         options={listBoxOptions}
         value="apple"
       >

--- a/apps/docs/src/pages/components/_previews/checkbox-previews.tsx
+++ b/apps/docs/src/pages/components/_previews/checkbox-previews.tsx
@@ -8,8 +8,8 @@ export function CheckboxControlledPreview() {
   return (
     <Checkbox
       label="Controlled checkbox"
-      onChange={(e) => {
-        setChecked(e.target.checked);
+      onChange={(nextChecked) => {
+        setChecked(nextChecked);
       }}
       value={checked}
     />

--- a/apps/docs/src/pages/components/_previews/list-box-previews.tsx
+++ b/apps/docs/src/pages/components/_previews/list-box-previews.tsx
@@ -16,7 +16,7 @@ export function ListBoxBasicPreview() {
   return (
     <div className="w-56">
       <ListBox.Root
-        onSelect={(key: string) => {
+        onChange={(key: string) => {
           setSelected(key);
         }}
         options={OPTIONS}
@@ -37,7 +37,7 @@ export function ListBoxSizesPreview() {
     <div className="flex flex-wrap items-start gap-4">
       <div className="w-44">
         <ListBox.Root
-          onSelect={(key: string) => {
+          onChange={(key: string) => {
             setSm(key);
           }}
           options={OPTIONS}
@@ -49,7 +49,7 @@ export function ListBoxSizesPreview() {
       </div>
       <div className="w-48">
         <ListBox.Root
-          onSelect={(key: string) => {
+          onChange={(key: string) => {
             setMd(key);
           }}
           options={OPTIONS}
@@ -61,7 +61,7 @@ export function ListBoxSizesPreview() {
       </div>
       <div className="w-56">
         <ListBox.Root
-          onSelect={(key: string) => {
+          onChange={(key: string) => {
             setLg(key);
           }}
           options={OPTIONS}
@@ -79,7 +79,7 @@ export function ListBoxTriggerIconPreview() {
   const [selected, setSelected] = useState<string>();
   return (
     <ListBox.Root
-      onSelect={(key: string) => {
+      onChange={(key: string) => {
         setSelected(key);
       }}
       options={OPTIONS}

--- a/apps/docs/src/pages/components/_previews/radio-card-previews.tsx
+++ b/apps/docs/src/pages/components/_previews/radio-card-previews.tsx
@@ -36,8 +36,8 @@ export function RadioCardControlledPreview() {
         disabled={false}
         invalid={false}
         aria-labelledby="radio-card-preview-label"
-        onChange={(event) => {
-          setValue(event.target.value);
+        onChange={(nextValue) => {
+          setValue(nextValue);
         }}
         options={options}
         value={value}

--- a/apps/docs/src/pages/components/_previews/radio-previews.tsx
+++ b/apps/docs/src/pages/components/_previews/radio-previews.tsx
@@ -21,8 +21,8 @@ export function RadioControlledPreview() {
         defaultValue={undefined}
         disabled={false}
         aria-labelledby="radio-controlled-label"
-        onChange={(event) => {
-          setValue(event.target.value);
+        onChange={(nextValue) => {
+          setValue(nextValue);
         }}
         options={options}
         value={value}

--- a/apps/docs/src/pages/components/_previews/switch-previews.tsx
+++ b/apps/docs/src/pages/components/_previews/switch-previews.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { Switch } from '@k8o/arte-odyssey';
-import type { ChangeEvent } from 'react';
 import { useState } from 'react';
 
 export function SwitchControlledPreview() {
@@ -13,8 +12,8 @@ export function SwitchControlledPreview() {
       invalid={false}
       required={false}
       label="Controlled switch"
-      onChange={(event: ChangeEvent<HTMLInputElement>) => {
-        setValue(event.target.checked);
+      onChange={(checked) => {
+        setValue(checked);
       }}
       value={value}
     />

--- a/apps/docs/src/pages/components/checkbox-page.tsx
+++ b/apps/docs/src/pages/components/checkbox-page.tsx
@@ -19,7 +19,7 @@ const checkboxProps: PropItem[] = [
   { name: 'value', types: ['boolean'], defaultValue: null },
   {
     name: 'onChange',
-    types: ['ChangeEventHandler'],
+    types: ['(checked: boolean) => void'],
     defaultValue: null,
   },
   { name: 'defaultChecked', types: ['boolean'], defaultValue: null },
@@ -104,7 +104,7 @@ export function CheckboxPage() {
 
 <Checkbox
   label="Controlled checkbox"
-  onChange={(e) => setChecked(e.target.checked)}
+  onChange={(checked) => setChecked(checked)}
   value={checked}
 />`}
           >

--- a/apps/docs/src/pages/components/file-field-page.tsx
+++ b/apps/docs/src/pages/components/file-field-page.tsx
@@ -23,7 +23,9 @@ const fileFieldProps: PropItem[] = [
   { name: 'maxFiles', types: ['number'], defaultValue: null },
   {
     name: 'onChange',
-    types: ['ChangeEventHandler'],
+    types: [
+      '(files: FileList | null, event?: ChangeEvent<HTMLInputElement>) => void',
+    ],
     defaultValue: null,
   },
 ];

--- a/apps/docs/src/pages/components/list-box-page.tsx
+++ b/apps/docs/src/pages/components/list-box-page.tsx
@@ -21,7 +21,7 @@ const listBoxRootProps: PropItem[] = [
   { name: 'options', types: ['Option[]'], defaultValue: null },
   { name: 'value', types: ['string', 'undefined'], defaultValue: null },
   {
-    name: 'onSelect',
+    name: 'onChange',
     types: ['(key: string) => void'],
     defaultValue: null,
   },
@@ -99,7 +99,7 @@ export function ListBoxPage() {
 const [selected, setSelected] = useState<string>();
 
 <ListBox.Root
-  onSelect={(key) => setSelected(key)}
+  onChange={(key) => setSelected(key)}
   options={OPTIONS}
   value={selected}
 >
@@ -117,17 +117,17 @@ const [selected, setSelected] = useState<string>();
             <T k="components.listBox.sizesTitle" />
           </Heading>
           <ComponentPreview
-            code={`<ListBox.Root onSelect={onSelect} options={OPTIONS} value={value}>
+            code={`<ListBox.Root onChange={onChange} options={OPTIONS} value={value}>
   <ListBox.Trigger size="sm" />
   <ListBox.Content />
 </ListBox.Root>
 
-<ListBox.Root onSelect={onSelect} options={OPTIONS} value={value}>
+<ListBox.Root onChange={onChange} options={OPTIONS} value={value}>
   <ListBox.Trigger size="md" />
   <ListBox.Content />
 </ListBox.Root>
 
-<ListBox.Root onSelect={onSelect} options={OPTIONS} value={value}>
+<ListBox.Root onChange={onChange} options={OPTIONS} value={value}>
   <ListBox.Trigger size="lg" />
   <ListBox.Content />
 </ListBox.Root>`}
@@ -144,7 +144,7 @@ const [selected, setSelected] = useState<string>();
           <ComponentPreview
             code={`import { ListIcon } from '@k8o/arte-odyssey';
 
-<ListBox.Root onSelect={onSelect} options={OPTIONS} value={value}>
+<ListBox.Root onChange={onChange} options={OPTIONS} value={value}>
   <ListBox.TriggerIcon icon={<ListIcon />} />
   <ListBox.Content />
 </ListBox.Root>`}

--- a/apps/docs/src/pages/components/radio-card-page.tsx
+++ b/apps/docs/src/pages/components/radio-card-page.tsx
@@ -16,7 +16,7 @@ const radioCardProps: PropItem[] = [
   { name: 'value', types: ['string'], defaultValue: null },
   {
     name: 'onChange',
-    types: ['ChangeEventHandler<HTMLInputElement>'],
+    types: ['(value: string) => void'],
     defaultValue: null,
   },
   { name: 'defaultValue', types: ['string'], defaultValue: null },
@@ -92,7 +92,7 @@ const [value, setValue] = useState('pro');
   disabled={false}
   invalid={false}
   aria-labelledby="plan-label"
-  onChange={(event) => setValue(event.target.value)}
+  onChange={(value) => setValue(value)}
   options={options}
   value={value}
 />`}

--- a/apps/docs/src/pages/components/radio-page.tsx
+++ b/apps/docs/src/pages/components/radio-page.tsx
@@ -15,7 +15,7 @@ const radioProps: PropItem[] = [
   { name: 'value', types: ['string'], defaultValue: null },
   {
     name: 'onChange',
-    types: ['ChangeEventHandler<HTMLInputElement>'],
+    types: ['(value: string) => void'],
     defaultValue: null,
   },
   { name: 'defaultValue', types: ['string'], defaultValue: null },
@@ -104,7 +104,7 @@ const options = [
 <Radio
   disabled={false}
   aria-labelledby="radio-controlled-label"
-  onChange={(event) => setValue(event.target.value)}
+  onChange={(value) => setValue(value)}
   options={options}
   value={value}
 />`}

--- a/apps/docs/src/pages/components/switch-page.tsx
+++ b/apps/docs/src/pages/components/switch-page.tsx
@@ -17,7 +17,7 @@ const switchProps: PropItem[] = [
   { name: 'value', types: ['boolean'], defaultValue: null },
   {
     name: 'onChange',
-    types: ['ChangeEventHandler<HTMLInputElement>'],
+    types: ['(checked: boolean) => void'],
     defaultValue: null,
   },
   { name: 'defaultChecked', types: ['boolean'], defaultValue: null },
@@ -112,7 +112,7 @@ export function SwitchPage() {
   invalid={false}
   required={false}
   label="Controlled switch"
-  onChange={(event) => setValue(event.target.checked)}
+  onChange={(checked) => setValue(checked)}
   value={value}
 />`}
           >

--- a/packages/arte-odyssey/CLAUDE.md
+++ b/packages/arte-odyssey/CLAUDE.md
@@ -40,6 +40,17 @@ src/components/<name>/
 - **モード・バリアントを表す boolean** → prefix なし: `interactive`, `animate`, `current`, `fullWidth`, `multiple`
 - **ネイティブ HTML 属性 / ARIA 状態に 1:1 対応する boolean** → そのまま: `disabled`, `checked`, `required`, `invalid`（`aria-invalid` にそのまま渡るため `is` prefix を付けない）
 
+### イベントハンドラの値型
+
+フォーム系コンポーネントの `onChange` は、ネイティブ要素をそのまま薄くラップするもの（`TextField` / `Textarea` / `Select` / `PasswordInput`）を除き、**第1引数にその要素の意味的な値**を取る（イベントオブジェクトではなく値）。実 `<input>` を持つコンポーネントは、汎用性のため**第2引数で本物の DOM イベント**も渡す:
+
+- `Checkbox` / `Switch`: `(checked: boolean, event: ChangeEvent<HTMLInputElement>) => void`
+- `Radio`: `(value: string, event: ChangeEvent<HTMLInputElement>) => void`
+- `FileField`: `(files: FileList | null, event?: ChangeEvent<HTMLInputElement>) => void`（プログラム的削除時は `event` 無し）
+- `RadioCard`（`<button>` 駆動で change イベントが無い）/ `ListBox`: 値のみ（`(value) => void` / `(key) => void`）
+
+第2引数は後方互換に追加でき（`(value) => void` は `(value, event) => void` に代入可能）、利用側は値だけ使うなら第1引数のみ受け取れば良い。
+
 ## Component Authoring Patterns
 
 ### Standard Component

--- a/packages/arte-odyssey/src/components/form/checkbox/checkbox.stories.tsx
+++ b/packages/arte-odyssey/src/components/form/checkbox/checkbox.stories.tsx
@@ -22,8 +22,8 @@ const DefaultRender = (props: ComponentProps<typeof Checkbox>) => {
     <Checkbox
       disabled={props.disabled}
       label={props.label}
-      onChange={(e) => {
-        setValue(e.target.checked);
+      onChange={(checked) => {
+        setValue(checked);
       }}
       value={value}
     />

--- a/packages/arte-odyssey/src/components/form/checkbox/checkbox.tsx
+++ b/packages/arte-odyssey/src/components/form/checkbox/checkbox.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import type {
-  ChangeEvent,
-  ChangeEventHandler,
-  FC,
-  InputHTMLAttributes,
-} from 'react';
+import type { ChangeEvent, FC, InputHTMLAttributes } from 'react';
 import { useFormStatus } from 'react-dom';
 
 import { FOCUS_RING_PEER } from '../../_internal/focus-ring';
@@ -31,14 +26,14 @@ type BaseProps = {
 
 type ControlledProps = {
   value: boolean;
-  onChange: ChangeEventHandler<HTMLInputElement>;
+  onChange: (checked: boolean, event: ChangeEvent<HTMLInputElement>) => void;
   defaultChecked?: never;
 };
 
 type UncontrolledProps = {
   defaultChecked?: boolean;
   value?: never;
-  onChange?: ChangeEventHandler<HTMLInputElement>;
+  onChange?: (checked: boolean, event: ChangeEvent<HTMLInputElement>) => void;
 };
 
 type Props = BaseProps & (ControlledProps | UncontrolledProps);
@@ -72,11 +67,12 @@ export const Checkbox: FC<Props> = ({
     ? groupContext.currentValue.includes(groupItemValue)
     : internalChecked;
 
-  const setChecked = (nextChecked: boolean) => {
+  const setChecked = (
+    nextChecked: boolean,
+    event: ChangeEvent<HTMLInputElement>,
+  ) => {
     setInternalChecked(nextChecked);
-    onChange?.({
-      target: { checked: nextChecked },
-    } as ChangeEvent<HTMLInputElement>);
+    onChange?.(nextChecked, event);
   };
 
   return (
@@ -100,7 +96,7 @@ export const Checkbox: FC<Props> = ({
             return;
           }
 
-          setChecked(event.target.checked);
+          setChecked(event.target.checked, event);
         }}
         type="checkbox"
         value={groupContext ? groupItemValue : undefined}

--- a/packages/arte-odyssey/src/components/form/file-field/file-field.tsx
+++ b/packages/arte-odyssey/src/components/form/file-field/file-field.tsx
@@ -2,7 +2,6 @@
 
 import type {
   ChangeEvent,
-  ChangeEventHandler,
   FC,
   InputHTMLAttributes,
   PropsWithChildren,
@@ -38,7 +37,12 @@ type RootProps = PropsWithChildren<
     invalid?: boolean;
     maxFiles?: number;
     defaultValue?: File[];
-    onChange?: ChangeEventHandler<HTMLInputElement>;
+    // event はファイル選択（input の change）時に渡る。プログラム的なファイル
+    // 削除では change イベントが存在しないため undefined になる。
+    onChange?: (
+      files: FileList | null,
+      event?: ChangeEvent<HTMLInputElement>,
+    ) => void;
     webkitDirectory?: boolean;
   } & Omit<
     InputHTMLAttributes<HTMLInputElement>,
@@ -72,7 +76,7 @@ const Root = ({
 
   const onFilesChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
-      onChange?.(event);
+      onChange?.(event.target.files, event);
 
       const files = Array.from(event.target.files ?? []);
       const newFiles = files.map((file) => ({
@@ -104,12 +108,7 @@ const Root = ({
         }
         inputRef.current.files = dataTransfer.files;
 
-        const event = new Event('change', { bubbles: true });
-        Object.defineProperty(event, 'target', {
-          writable: false,
-          value: inputRef.current,
-        });
-        onChange(event as unknown as ChangeEvent<HTMLInputElement>);
+        onChange(dataTransfer.files);
       }
     },
     [acceptedFiles, onChange],

--- a/packages/arte-odyssey/src/components/form/radio-card/radio-card.stories.tsx
+++ b/packages/arte-odyssey/src/components/form/radio-card/radio-card.stories.tsx
@@ -57,8 +57,8 @@ const DefaultRender = (props: ComponentProps<typeof RadioCard>) => {
         aria-labelledby={props['aria-labelledby']}
         disabled={props.disabled}
         invalid={props.invalid}
-        onChange={(event) => {
-          setValue(event.target.value);
+        onChange={(nextValue) => {
+          setValue(nextValue);
         }}
         options={props.options}
         value={value}

--- a/packages/arte-odyssey/src/components/form/radio-card/radio-card.tsx
+++ b/packages/arte-odyssey/src/components/form/radio-card/radio-card.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import type {
-  ChangeEvent,
-  ChangeEventHandler,
   FC,
   FieldsetHTMLAttributes,
   KeyboardEvent,
@@ -38,14 +36,14 @@ type BaseProps = {
 
 type ControlledProps = {
   value: string;
-  onChange: ChangeEventHandler<HTMLInputElement>;
+  onChange: (value: string) => void;
   defaultValue?: never;
 };
 
 type UncontrolledProps = {
   defaultValue?: string;
   value?: never;
-  onChange?: ChangeEventHandler<HTMLInputElement>;
+  onChange?: (value: string) => void;
 };
 
 type Props = BaseProps & (ControlledProps | UncontrolledProps);
@@ -72,9 +70,7 @@ export const RadioCard: FC<Props> = ({
 
   const selectValue = (nextValue: string) => {
     setCurrentValue(nextValue);
-    onChange?.({
-      target: { value: nextValue },
-    } as ChangeEvent<HTMLInputElement>);
+    onChange?.(nextValue);
   };
 
   const focusIndex = (index: number) => {

--- a/packages/arte-odyssey/src/components/form/radio/radio.stories.tsx
+++ b/packages/arte-odyssey/src/components/form/radio/radio.stories.tsx
@@ -36,8 +36,8 @@ const DefaultRender = (props: ComponentProps<typeof Radio>) => {
       </p>
       <Radio
         {...radioProps}
-        onChange={(event) => {
-          setValue(event.target.value);
+        onChange={(nextValue) => {
+          setValue(nextValue);
         }}
         value={value}
       />

--- a/packages/arte-odyssey/src/components/form/radio/radio.tsx
+++ b/packages/arte-odyssey/src/components/form/radio/radio.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import type {
-  ChangeEvent,
-  ChangeEventHandler,
-  FC,
-  HTMLAttributes,
-} from 'react';
+import type { ChangeEvent, FC, HTMLAttributes } from 'react';
 import { useFormStatus } from 'react-dom';
 
 import type { Option } from '../../../types/variables';
@@ -25,14 +20,14 @@ type BaseProps = {
 
 type ControlledProps = {
   value: string;
-  onChange: ChangeEventHandler<HTMLInputElement>;
+  onChange: (value: string, event: ChangeEvent<HTMLInputElement>) => void;
   defaultValue?: never;
 };
 
 type UncontrolledProps = {
   defaultValue?: string;
   value?: never;
-  onChange?: ChangeEventHandler<HTMLInputElement>;
+  onChange?: (value: string, event: ChangeEvent<HTMLInputElement>) => void;
 };
 
 type Props = BaseProps & (ControlledProps | UncontrolledProps);
@@ -57,11 +52,12 @@ export const Radio: FC<Props> = ({
   const isControlled = value !== undefined;
   const disabledResolved = disabled || pending;
 
-  const selectValue = (nextValue: string) => {
+  const selectValue = (
+    nextValue: string,
+    event: ChangeEvent<HTMLInputElement>,
+  ) => {
     setSelectedValue(nextValue);
-    onChange?.({
-      target: { value: nextValue },
-    } as ChangeEvent<HTMLInputElement>);
+    onChange?.(nextValue, event);
   };
 
   return (
@@ -89,8 +85,8 @@ export const Radio: FC<Props> = ({
             className="peer sr-only"
             disabled={disabledResolved}
             name={name ?? labelledbyId}
-            onChange={() => {
-              selectValue(option.value);
+            onChange={(event) => {
+              selectValue(option.value, event);
             }}
             type="radio"
             value={option.value}

--- a/packages/arte-odyssey/src/components/form/switch/switch.stories.tsx
+++ b/packages/arte-odyssey/src/components/form/switch/switch.stories.tsx
@@ -28,8 +28,8 @@ const DefaultRender = (props: ComponentProps<typeof Switch>) => {
       required={props.required}
       label={props.label}
       name={props.name}
-      onChange={(event) => {
-        setValue(event.target.checked);
+      onChange={(checked) => {
+        setValue(checked);
       }}
       value={value}
     />

--- a/packages/arte-odyssey/src/components/form/switch/switch.tsx
+++ b/packages/arte-odyssey/src/components/form/switch/switch.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { ChangeEventHandler, FC, InputHTMLAttributes } from 'react';
+import type { ChangeEvent, FC, InputHTMLAttributes } from 'react';
 import { useId } from 'react';
 import { useFormStatus } from 'react-dom';
 
@@ -26,14 +26,14 @@ type BaseProps = {
 
 type ControlledProps = {
   value: boolean;
-  onChange: ChangeEventHandler<HTMLInputElement>;
+  onChange: (checked: boolean, event: ChangeEvent<HTMLInputElement>) => void;
   defaultChecked?: never;
 };
 
 type UncontrolledProps = {
   defaultChecked?: boolean;
   value?: never;
-  onChange?: ChangeEventHandler<HTMLInputElement>;
+  onChange?: (checked: boolean, event: ChangeEvent<HTMLInputElement>) => void;
 };
 
 type Props = BaseProps & (ControlledProps | UncontrolledProps);
@@ -80,7 +80,7 @@ export const Switch: FC<Props> = ({
           id={inputId}
           onChange={(event) => {
             setSelected(event.target.checked);
-            onChange?.(event);
+            onChange?.(event.target.checked, event);
           }}
           required={required}
           role="switch"

--- a/packages/arte-odyssey/src/components/overlays/list-box/list-box.stories.tsx
+++ b/packages/arte-odyssey/src/components/overlays/list-box/list-box.stories.tsx
@@ -40,7 +40,7 @@ const DefaultRender = () => {
   return (
     <div className="w-56">
       <ListBox.Root
-        onSelect={(key: string) => {
+        onChange={(key: string) => {
           setSelected(key);
         }}
         options={OPTIONS}

--- a/packages/arte-odyssey/src/components/overlays/list-box/list-box.tsx
+++ b/packages/arte-odyssey/src/components/overlays/list-box/list-box.tsx
@@ -34,11 +34,11 @@ const Root: FC<
     placement?: Placement;
     options: Option[];
     value: Option['key'] | undefined;
-    onSelect: (key: Option['key']) => void;
+    onChange: (key: Option['key']) => void;
   }>
-> = ({ children, placement = 'bottom', options, value, onSelect }) => (
+> = ({ children, placement = 'bottom', options, value, onChange }) => (
   <Popover.Root flipDisabled placement={placement} type="listbox">
-    <MenuProvider onSelect={onSelect} options={options} value={value}>
+    <MenuProvider onChange={onChange} options={options} value={value}>
       {children}
     </MenuProvider>
   </Popover.Root>
@@ -48,9 +48,9 @@ const MenuProvider: FC<
   PropsWithChildren<{
     options: Option[];
     value: Option['key'] | undefined;
-    onSelect: (key: Option['key']) => void;
+    onChange: (key: Option['key']) => void;
   }>
-> = ({ children, options, onSelect, value }) => {
+> = ({ children, options, onChange, value }) => {
   const selectedIndex = options.findIndex((option) => option.key === value);
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
   const itemElementsRef = useRef<Array<HTMLElement | null>>([]);
@@ -71,7 +71,7 @@ const MenuProvider: FC<
   const handleSelect = (index: number) => {
     const key = options[index]?.key;
     if (key !== undefined && key !== '') {
-      onSelect(key);
+      onChange(key);
     }
   };
 

--- a/packages/arte-odyssey/src/integrations/_shared/renderers.tsx
+++ b/packages/arte-odyssey/src/integrations/_shared/renderers.tsx
@@ -408,9 +408,7 @@ export function renderCheckbox(
       disabled={u(props.disabled)}
       label={props.label}
       name={props.name}
-      onChange={(event) => {
-        onChange(event.target.checked);
-      }}
+      onChange={onChange}
       value={checked}
     />
   );
@@ -427,9 +425,7 @@ export function renderSwitch(
       invalid={u(props.invalid)}
       label={props.label}
       name={props.name}
-      onChange={(event) => {
-        onChange(event.target.checked);
-      }}
+      onChange={onChange}
       required={u(props.required)}
       value={checked}
     />
@@ -561,9 +557,7 @@ const RadioView: FC<{
         aria-labelledby={labelId}
         disabled={u(props.disabled)}
         name={props.name}
-        onChange={(event) => {
-          onChange(event.target.value);
-        }}
+        onChange={onChange}
         options={props.options}
         value={value}
       />
@@ -583,9 +577,7 @@ const RadioCardView: FC<{
         disabled={u(props.disabled)}
         invalid={u(props.invalid)}
         name={props.name}
-        onChange={(event) => {
-          onChange(event.target.value);
-        }}
+        onChange={onChange}
         options={props.options}
         value={value}
       />
@@ -1019,12 +1011,12 @@ export const ToastWidget: FC<{ props: ToastProps }> = ({ props }) => (
 export function renderListBox(
   props: ListBoxProps,
   value: string,
-  onSelect: (next: string) => void,
+  onChange: (next: string) => void,
 ): ReactNode {
   const options = props.options.map((o) => ({ key: o.value, label: o.label }));
   return (
     <ListBox.Root
-      onSelect={onSelect}
+      onChange={onChange}
       options={options}
       value={value === '' ? undefined : value}
     >


### PR DESCRIPTION
## 概要

v10.0.0 メジャーの一環。フォーム系 \`onChange\` のイベント型/値型混在と \`ListBox\` の \`onSelect\` 別名を解消する。**スタックPR 2/4**（base: \`v10-deps-config\`）。

## 破壊的変更

| コンポーネント | before | after |
|---|---|---|
| \`Checkbox\` / \`Switch\` | \`ChangeEventHandler\` | \`(checked: boolean) => void\` |
| \`Radio\` / \`RadioCard\` | \`ChangeEventHandler\` | \`(value: string) => void\` |
| \`FileField\` | \`ChangeEventHandler\` | \`(files: FileList \| null) => void\` |
| \`ListBox.Root\` | \`onSelect\` | \`onChange: (key: string) => void\` |

\`TextField\` / \`Textarea\` / \`Select\` / \`PasswordInput\` はネイティブ \`<input>\` 互換のためイベント型 \`onChange\` を維持。\`Slider\` / \`NumberField\` / \`Autocomplete\` / \`CheckboxCard\` / \`CheckboxGroup\` / \`Tabs\` は既に値型。

```tsx
// v9 → v10
<Checkbox onChange={(e) => setX(e.target.checked)} />
<Checkbox onChange={(checked) => setX(checked)} />

<ListBox.Root onSelect={fn} ... />
<ListBox.Root onChange={fn} ... />
```

stories / docs / examples / 統合レンダラを追従。changeset: \`v10-form-onchange-value.md\`（major）。

## スタック

deps/config → **本PR** → variant/tone → overlay。先頭からマージ。