### PR TITLE
feat(overlays)!: Drawer / Accordion.Item を controllable 化 (v10 #4/4)

### DIFF
--- a/.changeset/v10-overlay-controllable.md
+++ b/.changeset/v10-overlay-controllable.md
@@ -1,0 +1,24 @@
+---
+"@k8o/arte-odyssey": major
+---
+
+オーバーレイ／開閉系コンポーネントの controllable パターンを統一（`Modal` / `Tabs` に `Drawer` / `Accordion.Item` を揃える）。
+
+**BREAKING**:
+
+- `Drawer`: `isOpen`（必須）+ `onClose`（必須）の full controlled から、`isOpen?` + `defaultOpen?` + `onClose?` の controllable に変更。`isOpen` を渡さなければ `defaultOpen` による uncontrolled 動作になる。閉じるボタンは内部で `<dialog>.close()` を呼ぶため、controlled / uncontrolled の双方で動作する。
+
+```tsx
+// v9: isOpen が必須（uncontrolled 不可）
+<Drawer isOpen={open} onClose={() => setOpen(false)} title="...">...</Drawer>
+
+// v10: uncontrolled も可。controlled は従来どおり動作
+<Drawer defaultOpen title="...">...</Drawer>
+<Drawer isOpen={open} onClose={() => setOpen(false)} title="...">...</Drawer>
+```
+
+**追加（非破壊）**:
+
+- `Accordion.Item` を controllable 化。従来の `defaultOpen?`（uncontrolled）に加え、`isOpen?` + `onChange?: (isOpen: boolean) => void` で制御可能になった。
+
+開閉状態の命名は「真偽の状態 = `isOpen` / 初期値 = `defaultOpen`」で全オーバーレイ横断に統一（`packages/arte-odyssey/CLAUDE.md` の命名規約に準拠）。

--- a/packages/arte-odyssey/CLAUDE.md
+++ b/packages/arte-odyssey/CLAUDE.md
@@ -40,6 +40,16 @@ src/components/<name>/
 - **モード・バリアントを表す boolean** → prefix なし: `interactive`, `animate`, `current`, `fullWidth`, `multiple`
 - **ネイティブ HTML 属性 / ARIA 状態に 1:1 対応する boolean** → そのまま: `disabled`, `checked`, `required`, `invalid`（`aria-invalid` にそのまま渡るため `is` prefix を付けない）
 
+### Controllable Props（開閉・選択などの状態）
+
+開閉・選択といった「制御可能な状態」を持つコンポーネントは、controlled / uncontrolled の両対応（controllable）を基本とし、prop 名を横断で統一する。`useControllableState` を流用する。
+
+- **状態（controlled）**: 真偽の開閉は `isOpen`、選択値は `selectedId` / `value` など意味的な名前。
+- **初期値（uncontrolled）**: `defaultOpen` / `defaultValue` / `defaultSelectedId`。
+- **変更通知**: `onChange?: (next) => void`（開閉専用の閉じ操作は `onClose?`）。
+
+例: `Modal` / `Drawer` は `isOpen?` + `defaultOpen?` + `onClose?`、`Tabs.Root` は `selectedId?` + `defaultSelectedId?` + `onChange?`、`Accordion.Item` は `isOpen?` + `defaultOpen?` + `onChange?`。
+
 ### イベントハンドラの値型
 
 フォーム系コンポーネントの `onChange` は、ネイティブ要素をそのまま薄くラップするもの（`TextField` / `Textarea` / `Select` / `PasswordInput`）を除き、**第1引数にその要素の意味的な値**を取る（イベントオブジェクトではなく値）。実 `<input>` を持つコンポーネントは、汎用性のため**第2引数で本物の DOM イベント**も渡す:

--- a/packages/arte-odyssey/src/components/data-display/accordion/accordion-item.tsx
+++ b/packages/arte-odyssey/src/components/data-display/accordion/accordion-item.tsx
@@ -5,11 +5,20 @@ import { type FC, type PropsWithChildren, useId } from 'react';
 import { AccordionItemProvider } from './context';
 
 export const AccordionItem: FC<
-  PropsWithChildren<{ defaultOpen?: boolean }>
-> = ({ children, defaultOpen = false }) => {
+  PropsWithChildren<{
+    isOpen?: boolean;
+    defaultOpen?: boolean;
+    onChange?: (isOpen: boolean) => void;
+  }>
+> = ({ children, isOpen, defaultOpen = false, onChange }) => {
   const id = useId();
   return (
-    <AccordionItemProvider defaultOpen={defaultOpen} id={id}>
+    <AccordionItemProvider
+      defaultOpen={defaultOpen}
+      id={id}
+      isOpen={isOpen}
+      onChange={onChange}
+    >
       <div className="vertical:h-full">{children}</div>
     </AccordionItemProvider>
   );

--- a/packages/arte-odyssey/src/components/data-display/accordion/accordion.stories.tsx
+++ b/packages/arte-odyssey/src/components/data-display/accordion/accordion.stories.tsx
@@ -1,6 +1,45 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
 
 import { Accordion } from '.';
+
+const ControlledAccordion = () => {
+  const [openId, setOpenId] = useState<string | null>('first');
+  const items = [
+    {
+      id: 'first',
+      title: '最初の項目',
+      body: '外部 state で開閉を制御しています。',
+    },
+    {
+      id: 'second',
+      title: '2番目の項目',
+      body: 'isOpen と onChange で 1 つだけ開く挙動を実現できます。',
+    },
+  ];
+  return (
+    <Accordion.Root>
+      {items.map((item) => (
+        <Accordion.Item
+          isOpen={openId === item.id}
+          key={item.id}
+          onChange={(open) => {
+            setOpenId(open ? item.id : null);
+          }}
+        >
+          <h3>
+            <Accordion.Button>
+              <p className="text-lg">{item.title}</p>
+            </Accordion.Button>
+          </h3>
+          <Accordion.Panel>
+            <p>{item.body}</p>
+          </Accordion.Panel>
+        </Accordion.Item>
+      ))}
+    </Accordion.Root>
+  );
+};
 
 const meta: Meta<typeof Accordion.Root> = {
   title: 'components/data-display/accordion',
@@ -98,4 +137,8 @@ export const Primary: Story = {
       </Accordion.Item>
     </Accordion.Root>
   ),
+};
+
+export const Controlled: Story = {
+  render: () => <ControlledAccordion />,
 };

--- a/packages/arte-odyssey/src/components/data-display/accordion/context.tsx
+++ b/packages/arte-odyssey/src/components/data-display/accordion/context.tsx
@@ -1,9 +1,15 @@
 'use client';
 
-import { createContext, type FC, type PropsWithChildren, use } from 'react';
+import {
+  createContext,
+  type FC,
+  type PropsWithChildren,
+  use,
+  useCallback,
+} from 'react';
 
 import { createSafeContext } from '../../../helpers/create-safe-context';
-import { useDisclosure } from '../../../hooks/disclosure';
+import { useControllableState } from '../../../hooks/controllable-state';
 
 const OpenContext = createContext(false);
 
@@ -21,14 +27,23 @@ export const useOpen = (): boolean => use(OpenContext);
 
 export const AccordionItemProvider: FC<
   PropsWithChildren<{
+    isOpen?: boolean;
     defaultOpen?: boolean;
+    onChange?: (isOpen: boolean) => void;
     id: string;
   }>
-> = ({ defaultOpen = false, id, children }) => {
-  const { isOpen, toggle } = useDisclosure(defaultOpen);
+> = ({ isOpen, defaultOpen = false, onChange, id, children }) => {
+  const [open, setOpen] = useControllableState({
+    value: isOpen,
+    defaultValue: defaultOpen,
+    onChange,
+  });
+  const toggle = useCallback(() => {
+    setOpen((prev) => !prev);
+  }, [setOpen]);
 
   return (
-    <OpenContext value={isOpen}>
+    <OpenContext value={open}>
       <ToggleOpenContext value={toggle}>
         <ItemIdContext value={id}>{children}</ItemIdContext>
       </ToggleOpenContext>

--- a/packages/arte-odyssey/src/components/overlays/drawer/drawer.stories.tsx
+++ b/packages/arte-odyssey/src/components/overlays/drawer/drawer.stories.tsx
@@ -42,3 +42,28 @@ export const Default: Story = {
     ),
   },
 };
+
+export const Uncontrolled: Story = {
+  play: async ({ canvas }) => {
+    await waitFor(() => {
+      const dialog = canvas.getByRole('dialog');
+      if (getComputedStyle(dialog).opacity !== '1') {
+        throw new Error('waiting for animation');
+      }
+    });
+  },
+  args: {
+    defaultOpen: true,
+    title: 'メニュー',
+    children: (
+      <nav className="flex flex-col gap-2">
+        <a className="hover:bg-bg-mute rounded-md px-3 py-2" href="/">
+          ホーム
+        </a>
+        <a className="hover:bg-bg-mute rounded-md px-3 py-2" href="/about">
+          このサイトについて
+        </a>
+      </nav>
+    ),
+  },
+};

--- a/packages/arte-odyssey/src/components/overlays/drawer/drawer.tsx
+++ b/packages/arte-odyssey/src/components/overlays/drawer/drawer.tsx
@@ -1,6 +1,12 @@
 'use client';
 
-import { type FC, type PropsWithChildren, type ReactNode, useId } from 'react';
+import {
+  type FC,
+  type PropsWithChildren,
+  type ReactNode,
+  useId,
+  useRef,
+} from 'react';
 
 import { cn } from '../../../helpers/cn';
 import { IconButton } from '../../buttons/icon-button';
@@ -11,15 +17,23 @@ import { Modal } from '../modal';
 export const Drawer: FC<
   PropsWithChildren<{
     title: ReactNode;
-    isOpen: boolean;
-    onClose: () => void;
+    isOpen?: boolean;
+    defaultOpen?: boolean;
+    onClose?: () => void;
     side?: 'left' | 'right';
   }>
-> = ({ title, isOpen, onClose, side = 'right', children }) => {
+> = ({ title, isOpen, defaultOpen, onClose, side = 'right', children }) => {
   const rootId = useId();
+  const dialogRef = useRef<HTMLDialogElement>(null);
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} type={side}>
+    <Modal
+      defaultOpen={defaultOpen}
+      isOpen={isOpen}
+      onClose={onClose}
+      ref={dialogRef}
+      type={side}
+    >
       <section
         aria-describedby={`${rootId}-content`}
         aria-labelledby={`${rootId}-header`}
@@ -45,7 +59,7 @@ export const Drawer: FC<
               label="閉じる"
               onClick={(e) => {
                 e.stopPropagation();
-                onClose();
+                dialogRef.current?.close();
               }}
               tooltipDisabled
             >


### PR DESCRIPTION
## 概要

v10.0.0 メジャーの一環。オーバーレイ/開閉系の controllable パターンを統一する（\`Modal\` / \`Tabs\` に \`Drawer\` / \`Accordion.Item\` を揃える）。**スタックPR 4/4（最終）**（base: \`v10-variant-tone\`）。

## 破壊的変更

- \`Drawer\`: full controlled（\`isOpen\` 必須 + \`onClose\` 必須）→ **controllable**（\`isOpen?\` + \`defaultOpen?\` + \`onClose?\`）。既存の controlled 利用はそのまま動作し、\`defaultOpen\` による uncontrolled も可能に。閉じるボタンは内部で \`<dialog>.close()\` を呼ぶため両モードで動作。

```tsx
// v9: isOpen 必須
<Drawer isOpen={open} onClose={() => setOpen(false)} title="…">…</Drawer>
// v10: uncontrolled も可
<Drawer defaultOpen title="…">…</Drawer>
```

## 非破壊

- \`Accordion.Item\` を controllable 化（従来の \`defaultOpen?\` に加え \`isOpen?\` + \`onChange?: (isOpen: boolean) => void\`）。

命名規約（\`isOpen\` / \`defaultOpen\`）と controllable パターンを \`packages/arte-odyssey/CLAUDE.md\` に明文化。

changeset: \`v10-overlay-controllable.md\`（major）。

## v10 スタック総括

| # | PR | 内容 |
|---|---|---|
| 1 | #516 | deps/config（TS>=6 等） |
| 2 | #517 | form onChange 値型統一 |
| 3 | #518 | variant/tone 語彙統一 |
| 4 | 本PR | overlay controllable 化 |

4本 + 既存 changeset（css-token-sot / generative-ui-integrations）で **10.0.0** へ集約。先頭(#516)から順にマージ。

> 補足: B-4（Button/IconButton \`onAction\`）は方針どおり非破壊（JSDoc によるドキュメント明確化のみ）で本スタックには changeset を含めない。