### PR TITLE
fix(card): InteractiveCard に dark モード用の subtle border を追加

### DIFF
--- a/.changeset/interactive-card-dark-border.md
+++ b/.changeset/interactive-card-dark-border.md
@@ -1,0 +1,9 @@
+---
+'@k8o/arte-odyssey': patch
+---
+
+`InteractiveCard` の `appearance="shadow"`（デフォルト）に、`Card` と同じ dark モード用 subtle border を追加した。
+
+dim-dark-mode の対応で `Card` には dark モード時に `border-border-subtle` の薄いボーダーを出す調整を入れたが、同じ `shadow-sm` を使う `InteractiveCard` は対象から漏れていた。そのため dark モードでは `InteractiveCard` だけ shadow がほぼ視認できず、カードが浮かない不整合が生じていた。
+
+`Card` と同様に常時 `border border-transparent` を出して light モードのレイアウトを維持しつつ、dark モードのみ `border-border-subtle` を可視化する。light モードの見た目は変わらない。

--- a/packages/arte-odyssey/src/components/data-display/card/interactive-card.tsx
+++ b/packages/arte-odyssey/src/components/data-display/card/interactive-card.tsx
@@ -13,7 +13,11 @@ export const InteractiveCard: FC<CardProps> = ({
     {...rest}
     className={cn(
       'rounded-xl transition-transform hover:scale-[1.02] active:scale-[0.98]',
-      appearance === 'shadow' && 'shadow-sm',
+      // dark mode では shadow-sm がほぼ視認できないため、subtle な border で
+      // カード境界を補強する。light 時のレイアウト維持のため transparent な
+      // border を常時出しておく。Card と同じ扱い。
+      appearance === 'shadow' &&
+        'shadow-sm border border-transparent dark:border-border-subtle',
       appearance === 'bordered' && 'border border-border-mute',
       width === 'full' && 'w-full',
       width === 'fit' && 'w-fit',


### PR DESCRIPTION
## 概要

`InteractiveCard` の `appearance="shadow"`（デフォルト）に、`Card` と同じ dark モード用の subtle border を追加します。

## 背景 / 不整合

dim-dark-mode（#493）の対応で `Card` には「dark モードでは `shadow-sm` がほぼ視認できない」問題に対し、dark モード時のみ `border-border-subtle` の薄いボーダーを出す調整が入りました。しかし同じく `appearance="shadow"` + `shadow-sm` を使う `InteractiveCard` はこの対応から漏れていました。

結果として **dark モードでは `InteractiveCard` だけ影も枠も視認できず、カードが浮かない**不整合が生じていました（例: 利用側の Top ページでカードグリッドが平面的に見える）。

## 変更

`Card` と同一の指定に揃えます。

```diff
- appearance === 'shadow' && 'shadow-sm',
+ // dark mode では shadow-sm がほぼ視認できないため、subtle な border で
+ // カード境界を補強する。light 時のレイアウト維持のため transparent な
+ // border を常時出しておく。Card と同じ扱い。
+ appearance === 'shadow' &&
+   'shadow-sm border border-transparent dark:border-border-subtle',
```

- 常時 `border border-transparent` を出すため **light モードのレイアウト・見た目は不変**（テーマ切替時のズレも無し）
- dark モードのみ `border-border-subtle` を可視化

## 検証

- `pnpm build` 成功
- `pnpm typecheck`: pass（全プロジェクト）
- `pnpm check`（oxlint/oxfmt）: 0 errors
- `pnpm test --project=components`: 312 tests pass

changeset: `patch`（`.changeset/interactive-card-dark-border.md`）

## 補足

利用側（k8o）では暫定で `AppCard` 本体に同等の枠を補っていますが、本修正がリリースされたらその暫定対応は剥がせます。