### PR TITLE
feat(json-render): Stack padding prop + Card/InteractiveCard size→padding

### DIFF
--- a/.changeset/json-render-padding.md
+++ b/.changeset/json-render-padding.md
@@ -1,0 +1,14 @@
+---
+'@k8o/arte-odyssey': minor
+---
+
+feat(json-render): Stack に `padding` prop、Card / InteractiveCard に `size`(sm/md/lg) を追加
+
+生成UI統合には内側 padding を表現する手段が無く（gap のみ・className エスケープも排除）、
+生成された Card / InteractiveCard が余白ゼロで描画されていた。
+
+- `Stack` に `padding`（none〜xl）prop を追加（openui 統合とも共有）。
+- Card / InteractiveCard に `size`（sm/md/lg、デフォルト md）を追加し、内側 padding を
+  サイズで決める（16/24/32px）。shadcn/Chakra/Fluent/Radix の size→padding 慣習に倣う。
+- Tailwind の `@source` に `../integrations` を追加。生成UI の renderer が出すユーティリティ
+  クラス（カードの padding 等）が、利用側で未スキャン→未生成になる問題を修正。

--- a/packages/arte-odyssey/src/components/layout/_shared/padding.ts
+++ b/packages/arte-odyssey/src/components/layout/_shared/padding.ts
@@ -1,0 +1,9 @@
+export type PaddingSize = 'none' | 'sm' | 'md' | 'lg' | 'xl';
+
+export const PADDING_CLASS = {
+  none: 'p-0',
+  sm: 'p-2',
+  md: 'p-4',
+  lg: 'p-6',
+  xl: 'p-8',
+} as const satisfies Record<PaddingSize, string>;

--- a/packages/arte-odyssey/src/components/layout/stack/stack.tsx
+++ b/packages/arte-odyssey/src/components/layout/stack/stack.tsx
@@ -1,12 +1,15 @@
 import type { FC, HTMLAttributes, PropsWithChildren } from 'react';
 
 import { GAP_CLASS, type GapSize } from '../_shared/gap';
+import { PADDING_CLASS, type PaddingSize } from '../_shared/padding';
 import { cn } from './../../../helpers/cn';
 
 export type StackProps = PropsWithChildren<
   {
     direction?: 'row' | 'column';
     gap?: GapSize;
+    /** Inner padding on all sides. Stack has no padding by default. */
+    padding?: PaddingSize;
     align?: 'start' | 'center' | 'end' | 'stretch';
     justify?: 'start' | 'center' | 'end' | 'between';
   } & Omit<HTMLAttributes<HTMLDivElement>, 'className' | 'style'>
@@ -29,6 +32,7 @@ const JUSTIFY_CLASS = {
 export const Stack: FC<StackProps> = ({
   direction = 'column',
   gap = 'md',
+  padding,
   align,
   justify,
   children,
@@ -40,6 +44,7 @@ export const Stack: FC<StackProps> = ({
       'flex',
       direction === 'row' ? 'flex-row' : 'flex-col',
       GAP_CLASS[gap],
+      padding && PADDING_CLASS[padding],
       align && ALIGN_CLASS[align],
       justify && JUSTIFY_CLASS[justify],
     )}

--- a/packages/arte-odyssey/src/integrations/_shared/renderers.tsx
+++ b/packages/arte-odyssey/src/integrations/_shared/renderers.tsx
@@ -302,10 +302,19 @@ export function renderSeparator(props: SeparatorProps): ReactNode {
 // containers (children は各 FW が描画して渡す)
 // ---------------------------------------------------------------------------
 
+// The bare Card has no padding and the generative catalog has no className
+// escape hatch, so map the integration `size` to a sensible inner padding
+// (default md). Mirrors the size→padding convention in Chakra / Fluent / Radix.
+const CARD_PADDING_CLASS = {
+  sm: 'p-4',
+  md: 'p-6',
+  lg: 'p-8',
+} as const satisfies Record<'sm' | 'md' | 'lg', string>;
+
 export function renderCard(props: CardProps, children: ReactNode): ReactNode {
   return (
     <Card appearance={u(props.appearance)} width={u(props.width)}>
-      {children}
+      <div className={CARD_PADDING_CLASS[props.size ?? 'md']}>{children}</div>
     </Card>
   );
 }
@@ -356,6 +365,7 @@ export function renderStack(props: StackProps, children: ReactNode): ReactNode {
       direction={u(props.direction)}
       gap={u(props.gap)}
       justify={u(props.justify)}
+      padding={u(props.padding)}
     >
       {children}
     </Stack>
@@ -793,9 +803,11 @@ export function renderInteractiveCard(
   props: InteractiveCardProps,
   children: ReactNode,
 ): ReactNode {
+  // Same as `renderCard`: the card surface has no padding, so `size` drives
+  // the inner padding (the generative catalog has no className escape).
   return (
     <InteractiveCard appearance={u(props.appearance)} width={u(props.width)}>
-      {children}
+      <div className={CARD_PADDING_CLASS[props.size ?? 'md']}>{children}</div>
     </InteractiveCard>
   );
 }

--- a/packages/arte-odyssey/src/integrations/_shared/schemas.ts
+++ b/packages/arte-odyssey/src/integrations/_shared/schemas.ts
@@ -265,10 +265,14 @@ export const tableProps = z.object({
 type CardIntegrationProps = {
   width?: ComponentProps<typeof Card>['width'];
   appearance?: ComponentProps<typeof Card>['appearance'];
+  // Integration-only: the bare Card has no padding, so `size` drives the
+  // generated card's inner padding (sm/md/lg). Hand-written abstraction.
+  size?: 'sm' | 'md' | 'lg';
 };
 export const cardProps = z.object({
   width: z.enum(['full', 'fit']).optional(),
   appearance: z.enum(['shadow', 'bordered']).optional(),
+  size: z.enum(['sm', 'md', 'lg']).optional(),
 }) satisfies z.ZodType<CardIntegrationProps>;
 
 // InteractiveCard は本体側で Card と同じ Props を共有するため schema も共有する。
@@ -347,12 +351,14 @@ export const separatorProps = z.object({
 type StackIntegrationProps = {
   direction?: ComponentProps<typeof Stack>['direction'];
   gap?: ComponentProps<typeof Stack>['gap'];
+  padding?: ComponentProps<typeof Stack>['padding'];
   align?: ComponentProps<typeof Stack>['align'];
   justify?: ComponentProps<typeof Stack>['justify'];
 };
 export const stackProps = z.object({
   direction: z.enum(['row', 'column']).optional(),
   gap: z.enum(['none', 'sm', 'md', 'lg', 'xl']).optional(),
+  padding: z.enum(['none', 'sm', 'md', 'lg', 'xl']).optional(),
   align: z.enum(['start', 'center', 'end', 'stretch']).optional(),
   justify: z.enum(['start', 'center', 'end', 'between']).optional(),
 }) satisfies z.ZodType<StackIntegrationProps>;

--- a/packages/arte-odyssey/src/integrations/json-render/catalog.ts
+++ b/packages/arte-odyssey/src/integrations/json-render/catalog.ts
@@ -17,7 +17,8 @@ export const catalog = defineCatalog(schema, {
     Stack: {
       props: s.stackProps,
       slots: ['default'],
-      description: '子要素を縦/横に等間隔で並べるレイアウトコンテナ。',
+      description:
+        '子要素を縦/横に等間隔で並べるレイアウトコンテナ。gap で子要素間の間隔、padding（none〜xl）で内側の余白を付ける。セクションに余白が欲しいときは padding を指定する。',
     },
     Grid: {
       props: s.gridProps,
@@ -32,7 +33,8 @@ export const catalog = defineCatalog(schema, {
     Card: {
       props: s.cardProps,
       slots: ['default'],
-      description: 'コンテンツをまとめるカード（コンテナ）。',
+      description:
+        'コンテンツをまとめるカード（コンテナ）。内側 padding は size（sm/md/lg、デフォルト md）で決まる。中身を Stack で囲む場合に重ねて padding を指定する必要はない。',
     },
     Badge: { props: s.badgeProps, description: 'ステータスやラベルのバッジ。' },
     Heading: { props: s.headingProps, description: '見出し（h1〜h6）。' },
@@ -142,7 +144,8 @@ export const catalog = defineCatalog(schema, {
     InteractiveCard: {
       props: s.interactiveCardProps,
       slots: ['default'],
-      description: 'ホバーアニメーション付きのカード。',
+      description:
+        'ホバーアニメーション付きのカード。Card と同様に内側 padding は size（sm/md/lg、デフォルト md）で決まる。',
     },
     Form: {
       props: s.formProps,

--- a/packages/arte-odyssey/src/styles/index.css
+++ b/packages/arte-odyssey/src/styles/index.css
@@ -16,3 +16,7 @@
 @import './tokens.css';
 @import './utilities.css';
 @source '../components';
+/* The json-render / openui integrations' renderers emit utility classes too
+   (e.g. card padding), so they must be scanned alongside components — else a
+   class only used in a renderer (not in any component) is never generated. */
+@source '../integrations';


### PR DESCRIPTION
## 背景

生成UI統合（`@k8o/arte-odyssey/json-render`）には内側 padding を表現する手段が無く（`gap` のみ、`className` エスケープも意図的に排除）、生成された `Card` / `InteractiveCard` が余白ゼロ（端ベタ付き）で描画されていた。

## 変更

- **`Stack`**: `padding`（none〜xl）prop を追加（`PADDING_CLASS` は `GAP_CLASS` に倣う）。共有スキーマ＋`renderStack` 経由で json-render / openui 両統合に反映。
- **`Card` / `InteractiveCard`**: `size`（sm/md/lg、デフォルト md）を追加し、内側 padding を 16/24/32px で決める。shadcn/Chakra/Fluent/Radix の size→padding 慣習に倣う。base の `Card` コンポーネントは無変更（素のサーフェスのまま）— padding は統合の renderer に閉じる。
- **`@source '../integrations'` を追加**: renderer が出すユーティリティクラス（カード padding 等）は統合層にしか存在せず、利用側の Tailwind にスキャンされず未生成になっていた。これを修正（potential bug — 利用側で `.p-8` 等が生成されない）。
- catalog 説明に prop を明記。

## 検証

- typecheck / lint（0 errors）/ **312 tests**（catalog↔openui parity 含む）
- 利用側（decoro）で実プレビュー: sm/md/lg = **16 / 24 / 32px** を確認