### PR TITLE
ci: VRTコメントをsticky化（編集更新方式に変更）

### DIFF
--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -103,11 +103,13 @@ jobs:
           node .github/scripts/vrt-comment.mjs "arte-odyssey=packages/arte-odyssey/.vrt/report.json=$REPORT_URL" > comment.md
           marker='<!-- vrt-report -->'
           comment_id=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate --jq ".[] | select(.body | startswith(\"$marker\")) | .id" | head -n1)
-          # 編集では通知が飛ばないため、旧コメントを消して新規投稿する
+          # sticky comment: 既存があれば編集（PATCH）し、無ければ新規投稿する。
+          # push のたびに新規コメントが増えるのを防ぐ（通知は飛ばなくなる）
           if [ -n "$comment_id" ]; then
-            gh api --method DELETE "repos/$REPO/issues/comments/$comment_id"
+            gh api --method PATCH "repos/$REPO/issues/comments/$comment_id" -F body=@comment.md > /dev/null
+          else
+            gh api "repos/$REPO/issues/$PR_NUMBER/comments" -F body=@comment.md > /dev/null
           fi
-          gh api "repos/$REPO/issues/$PR_NUMBER/comments" -F body=@comment.md > /dev/null
 
       - name: Fail when differences exist
         if: github.event_name == 'pull_request' && steps.compare.outcome == 'failure'


### PR DESCRIPTION
## 概要

VRT のサマリーコメントを **sticky comment（1つのコメントを編集し続ける）** 方式に変更する。k8o リポジトリの同等対応（k35o/k8o#1841）を arte-odyssey にも適用する。

これまでは push のたびに「既存コメントを DELETE → 新規 POST」していたため、コメントが乱立し通知も毎回飛んでいた。既存コメントがあれば `PATCH` で本文を更新し、無ければ新規投稿するようにする。

## 変更

`.github/workflows/vrt.yml` の「Comment summary on PR」ステップのみ:

- `DELETE` + `POST` → `PATCH`（既存あり）/ `POST`（無し）
- コメント検出（marker `<!-- vrt-report -->` で id 取得）はそのまま流用

## トレードオフ

- ✅ PR に VRT コメントが乱立しなくなる（常に同じ1コメントが最新化される）
- ⚠️ 編集では GitHub 通知が飛ばなくなる（従来は通知のためにあえて削除→再投稿していた）。成否は `vrt` ステータスチェックで分かるため、通知より乱立防止を優先する

## 補足

- トリガー・`permissions`・シェルへの `${{ github.event.* }}` 直書きは変更なし