### PR TITLE
ci: VRT差分があってもCIを落とさずwarningにする

### DIFF
--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -111,8 +111,9 @@ jobs:
             gh api "repos/$REPO/issues/$PR_NUMBER/comments" -F body=@comment.md > /dev/null
           fi
 
-      - name: Fail when differences exist
+      # 差分があっても CI は落とさず、warning 注釈で可視化するだけにする。
+      # 意図した変更かの判断は人間が PR コメント（sticky）と report を見て行う。
+      - name: Warn when differences exist
         if: github.event_name == 'pull_request' && steps.compare.outcome == 'failure'
         run: |
-          echo '視覚的な差分があります。PRコメントとvrt-report artifactを確認してください。'
-          exit 1
+          echo '::warning::視覚的な差分があります。PRコメントとvrt-report artifactを確認してください。'


### PR DESCRIPTION
## 概要

VRT は差分を検知すると `exit 1` で `vrt` チェックを赤にしていたが、意図した見た目変更でもマージがブロックされるため、差分があっても CI を落とさないようにする。k35o/k8o#1842 と同じ対応。

## 変更

`.github/workflows/vrt.yml` の差分検知ステップのみ:

- `Fail when differences exist`（`exit 1`）→ `Warn when differences exist`（`::warning::` 注釈のみ、`exit 1` 削除）

## 効果

- ✅ 差分があっても `vrt` チェックは緑のまま（マージをブロックしない）
- ✅ 差分時は PR の warning 注釈＋ sticky コメントで気づける
- 比較ロジック（`svrt compare`）・撮影・レポート生成はそのまま