### PR TITLE
fix(docs): ページ遷移時にスクロール位置が引き継がれる問題を修正

### DIFF
--- a/apps/docs/src/layouts/locale-layout.tsx
+++ b/apps/docs/src/layouts/locale-layout.tsx
@@ -3,7 +3,7 @@
 /* oxlint-disable import/max-dependencies -- メインレイアウトとして必要な依存 */
 import { Outlet, useLocation } from '@funstack/router';
 import { Drawer, Heading, IconButton, ListIcon } from '@k8o/arte-odyssey';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
 import { ErrorFallback } from '../components/error-fallback';
@@ -88,10 +88,26 @@ function LayoutContent() {
   const sideNavConfig = useSideNavConfig();
   const { t } = useTranslation();
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  // documentをスクローラーにしたため、サイドバーは sticky で固定する。
+  // ヘッダー高さはフォント読込やブレークポイントで変動するので実測して追従させる。
+  const headerRef = useRef<HTMLDivElement>(null);
+  const [headerHeight, setHeaderHeight] = useState(0);
+  useEffect(() => {
+    const el = headerRef.current;
+    if (!el) return undefined;
+    const observer = new ResizeObserver(() => {
+      setHeaderHeight(el.offsetHeight);
+    });
+    observer.observe(el);
+    setHeaderHeight(el.offsetHeight);
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
 
   return sideNavConfig ? (
     <>
-      <div className="shrink-0">
+      <div className="bg-bg-surface sticky top-0 z-30 shrink-0" ref={headerRef}>
         <Navigation />
         <div className="lg:hidden">
           <div className="border-border-mute bg-bg-surface flex items-center border-b px-4 py-2">
@@ -106,11 +122,17 @@ function LayoutContent() {
           </div>
         </div>
       </div>
-      <div className="flex min-h-0 flex-1">
-        <aside className="border-border-mute hidden w-60 shrink-0 overflow-y-auto border-r px-3 py-4 lg:block">
+      <div className="flex flex-1">
+        <aside
+          className="border-border-mute sticky hidden w-60 shrink-0 self-start overflow-y-auto border-r px-3 py-4 lg:block"
+          style={{
+            top: `${headerHeight}px`,
+            height: `calc(100dvh - ${headerHeight}px)`,
+          }}
+        >
           <SideNavigation categories={sideNavConfig.categories} />
         </aside>
-        <main className="flex min-w-0 flex-1 flex-col overflow-y-auto">
+        <main className="flex min-w-0 flex-1 flex-col">
           <div className="flex-1">
             <OutletWithErrorBoundary />
           </div>
@@ -141,12 +163,12 @@ function LayoutContent() {
     </>
   ) : (
     <>
-      <div className="shrink-0">
+      <div className="bg-bg-surface sticky top-0 z-30 shrink-0" ref={headerRef}>
         <Navigation />
       </div>
       {/* ラッパーはブロックのまま保つ。flexにするとページ側の mx-auto コンテナが
           flexアイテム化し、stretchが効かず中身のmin-content幅で横にあふれる */}
-      <main className="flex min-w-0 flex-1 flex-col overflow-y-auto">
+      <main className="flex min-w-0 flex-1 flex-col">
         <div className="min-w-0 flex-1">
           <OutletWithErrorBoundary />
         </div>
@@ -185,7 +207,7 @@ export function LocaleLayout({ params }: { params: { locale: string } }) {
       <LocaleProvider locale={localeParam}>
         <ThemeProvider>
           <WritingModeProvider>
-            <div className="flex h-dvh flex-col">
+            <div className="flex min-h-dvh flex-col">
               <LayoutContent />
             </div>
           </WritingModeProvider>

--- a/apps/docs/src/router.tsx
+++ b/apps/docs/src/router.tsx
@@ -3,10 +3,62 @@
 import type { RouterProps } from '@funstack/router';
 import { Router as FunStackRouter } from '@funstack/router';
 import { ArteOdysseyProvider } from '@k8o/arte-odyssey';
-import type { FC } from 'react';
+import { type FC, useEffect } from 'react';
 
-export const Router: FC<RouterProps> = (props) => (
-  <ArteOdysseyProvider>
-    <FunStackRouter {...props} />
-  </ArteOdysseyProvider>
-);
+/**
+ * Navigation API は同一ドキュメント遷移後にスクロールをトップへ戻す挙動を仕様で
+ * 定めているが、Chrome / Safari は未実装で、funstack もこれをアプリ側に委ねている。
+ * そのため push / replace 遷移では手動でトップへ戻す。
+ * 参照: node_modules/@funstack/router/dist/docs/FaqPage.tsx
+ *
+ * 戻る / 進む（traverse）はブラウザのスクロール復元に任せ、ここでは何もしない。
+ */
+function useScrollToTopOnNavigate(): void {
+  useEffect(() => {
+    const controller = new AbortController();
+    navigation.addEventListener(
+      'navigatesuccess',
+      () => {
+        const { transition } = navigation;
+        const navigationType = transition?.navigationType;
+        if (navigationType !== 'push' && navigationType !== 'replace') {
+          return;
+        }
+        // 同一パスへの遷移（現在ページのリンク再クリック等）は読み位置を保つ
+        const fromUrl = transition?.from.url;
+        if (
+          fromUrl !== null &&
+          fromUrl !== undefined &&
+          new URL(fromUrl).pathname === location.pathname
+        ) {
+          return;
+        }
+        // フラグメント遷移（#section）はブラウザのアンカースクロールを尊重する
+        if (location.hash !== '') {
+          return;
+        }
+        // Safari は遷移直後のスクロールを無視するため少し待つ。さらに top:0 は
+        // 「現在位置と同じ座標へのスクロール」を最適化で無視され得るので、funstack の
+        // 参照実装に倣い -1（0 にクランプされる）を指定して確実に発火させる。
+        setTimeout(() => {
+          window.scrollTo({ left: 0, top: -1 });
+        }, 10);
+      },
+      { signal: controller.signal },
+    );
+
+    return () => {
+      controller.abort();
+    };
+  }, []);
+}
+
+export const Router: FC<RouterProps> = (props) => {
+  useScrollToTopOnNavigate();
+
+  return (
+    <ArteOdysseyProvider>
+      <FunStackRouter {...props} />
+    </ArteOdysseyProvider>
+  );
+};


### PR DESCRIPTION
## 概要

docs サイトで別ページへ遷移したときに、前ページのスクロール位置がそのまま引き継がれる問題を修正した。

## 動機

Navigation API は同一ドキュメント遷移後にスクロールをトップへ戻す挙動を仕様で定めているが、**Chrome / Safari はこの仕様を未実装**で、`@funstack/router` もこの処理をアプリ側に委ねている（参照: `node_modules/@funstack/router/dist/docs/FaqPage.tsx`）。

docs はこのワークアラウンドを実装しておらず、さらにレイアウトが `h-dvh` + 内側 `overflow-y-auto` で document を一切スクロールさせていなかったため、ページ遷移後もスクロール位置が残っていた。

## 詳細

- **レイアウトを document スクロールへ変更**（`apps/docs/src/layouts/locale-layout.tsx`）
  - `h-dvh` → `min-h-dvh`、内側 `main` / `aside` の `overflow-y-auto` を撤去
  - ヘッダーを `sticky top-0 z-30` 化
  - サイドバーは `sticky` + 独立スクロールを維持（項目数が多くビューポートを超えるため）。sticky オフセット（`top` / `height`）はヘッダー高さを `ResizeObserver` で実測して追従（フォント読込・ブレークポイントによる高さ変動に対応）
- **funstack 推奨のスクロール復元を追加**（`apps/docs/src/router.tsx`）
  - 全ルートを包むクライアント境界で `navigatesuccess` を購読し、`push` / `replace` 遷移時のみ `window.scrollTo`
  - **同一パスへの遷移**（現在ページのリンク再クリック等）は読み位置を保つ
  - Safari は遷移直後のスクロールを無視するため遅延させ、参照実装に倣い `top:-1`（0 にクランプ）で確実に発火。`#` アンカー遷移は除外
  - 戻る / 進む（traverse）はブラウザのスクロール復元に委ねる

## 気をつけるポイント

- スクロールコンテナが内側 `main` から document（`<html>`）へ変わる。ページ側で `100dvh` や `sticky` を内側スクロール前提で使っている箇所がないことは確認済み（`use-scroll-*` のデモは自前の `overflow-auto` ボックスで完結）。
- サイドバーの内部スクロール位置はページ遷移後も意図的に保持する（ナビが飛ばないため）。リセットされるのは document（本文）側のみ。

## 影響範囲

- docs サイト全ページのスクロール挙動・ヘッダー / サイドバーの固定表示

## テスト

ローカルの dev サーバー（Chromium）で確認:

| シナリオ | 結果 |
|---|---|
| コンポーネント間 SPA 遷移 | document がトップへリセット |
| 同一ページのリンク再クリック | 読み位置を保持（トップへ飛ばない） |
| サイドバーの内部スクロール | 遷移後も保持 |
| 戻る（traverse） | ブラウザがスクロール位置を復元 |
| 非サイドナビページ間の遷移 | トップへリセット |
| モバイル | サイドバー非表示・ヘッダー sticky・ドロワー開閉 OK |
| typecheck / lint / format | すべてパス |

## 既知の積み残し（本PR対象外）

- **SPA 遷移時のフォーカス移動なし**（a11y）: スクリーンリーダー / キーボード利用者に遷移が伝わらない。元コードからの既存ギャップで、本PRの目的（スクロール）とは直交するため別対応とする。
- sticky ヘッダーに対する `scroll-padding-top` 未設定（現状アンカー UI が無く発火経路なし）。