### PR TITLE
ci: VRTで日本語が豆腐化しないようCJKフォントを導入

### DIFF
--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -30,7 +30,9 @@ jobs:
         uses: ./.github/composite-actions/install
 
       - name: Install Playwright browsers
-        run: pnpm exec playwright install
+        # --with-deps installs the OS font packages (incl. CJK: fonts-ipafont-gothic /
+        # fonts-wqy-zenhei) so Japanese text renders instead of tofu (□) boxes.
+        run: pnpm exec playwright install --with-deps chromium
 
       - name: Capture story screenshots
         run: pnpm --filter @k8o/arte-odyssey test:vrt


### PR DESCRIPTION
## 概要

VRT のスクリーンショット内の日本語が豆腐（□）になっていたのを修正する。

## 原因

キャプチャ環境（CI の headless Chromium）に日本語フォントが無く、グリフを解決できず豆腐化していた。HTML レポート自体は UTF-8 で正常に配信されており、画像の中身だけが化けていた。

## 変更

`vrt.yml` の Playwright 導入を `playwright install` → `playwright install --with-deps chromium` に変更。`--with-deps` が CI に OS のフォントパッケージ（`fonts-ipafont-gothic` / `fonts-wqy-zenhei` など CJK 含む）を導入するため、日本語が描画されるようになる。VRT が使うのは chromium のみなのでブラウザも絞った（k8o 側の install-playwright と同じ構成）。

## 気をつけるポイント

- VRT は差分検出が目的のため、本番のデザインフォント（Noto Sans JP / M PLUS 2）ではなく **OS フォールバックのゴシック**で描画される。意図フォントとは見た目に差が出るが、ベースラインと actual が同じフォントで揃うため差分検出としては問題ない。
- **ベースライン再生成が必要**。現在 main のベースラインは豆腐のままなので、この PR の VRT は「旧ベースライン（豆腐）vs 日本語 actual」で一度差分が出て落ちる想定。main にマージ後、main の VRT が走ると正しい日本語のベースラインに再生成され、以降の PR は正常比較に戻る。
