### PR TITLE
chore: コードから読み取れる不要なコメントを削除

### DIFF
--- a/apps/docs/src/components/catalog-card.tsx
+++ b/apps/docs/src/components/catalog-card.tsx
@@ -7,7 +7,6 @@ import type { NavItem } from '../data/nav-types';
 import { LocaleAnchor } from './locale-anchor';
 import { T } from './t';
 
-// ホバーは形を動かさず影の変化のみ（静かな変化）
 const cardClass =
   'group bg-bg-base focus-within:ring-border-info relative flex flex-col overflow-hidden rounded-xl shadow-sm motion-safe:transition-shadow motion-safe:duration-150 motion-safe:ease-out hover:shadow-md focus-within:ring-2';
 

--- a/apps/docs/src/components/props-table.tsx
+++ b/apps/docs/src/components/props-table.tsx
@@ -28,7 +28,6 @@ export const PropsTable: FC<{
   inherits?: string;
 }> = ({ items, inherits }) => (
   <div className="flex flex-col gap-4">
-    {/* Mobile: card list */}
     <dl className="flex flex-col gap-4 md:hidden">
       {items.map((prop) => (
         <div
@@ -49,7 +48,6 @@ export const PropsTable: FC<{
         </div>
       ))}
     </dl>
-    {/* Desktop: table */}
     <table className="hidden w-full text-left text-sm md:table">
       <thead>
         <tr className="border-border-mute border-b">

--- a/apps/docs/src/pages/components/accordion-page.tsx
+++ b/apps/docs/src/pages/components/accordion-page.tsx
@@ -27,7 +27,6 @@ const accordionPanelProps: PropItem[] = [
 export function AccordionPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">Accordion</Heading>
         <p className="text-fg-mute text-lg">
@@ -44,7 +43,6 @@ export function AccordionPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -56,7 +54,6 @@ export function AccordionPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -121,7 +118,6 @@ export function AccordionPage() {
           </ComponentPreview>
         </div>
 
-        {/* Default Open */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.accordion.defaultOpenTitle" />
@@ -169,7 +165,6 @@ export function AccordionPage() {
           </ComponentPreview>
         </div>
 
-        {/* Multiple Default Open */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.accordion.multipleDefaultOpenTitle" />
@@ -235,7 +230,6 @@ export function AccordionPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/alert-page.tsx
+++ b/apps/docs/src/pages/components/alert-page.tsx
@@ -23,7 +23,6 @@ const alertProps: PropItem[] = [
 export function AlertPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">Alert</Heading>
         <p className="text-fg-mute text-lg">
@@ -40,7 +39,6 @@ export function AlertPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -52,7 +50,6 @@ export function AlertPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -63,7 +60,6 @@ export function AlertPage() {
           </ComponentPreview>
         </div>
 
-        {/* Statuses */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.alert.statusesTitle" />
@@ -81,7 +77,6 @@ export function AlertPage() {
           </ComponentPreview>
         </div>
 
-        {/* Multiple Messages */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.alert.multipleMessagesTitle" />
@@ -109,7 +104,6 @@ export function AlertPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/anchor-page.tsx
+++ b/apps/docs/src/pages/components/anchor-page.tsx
@@ -21,7 +21,6 @@ const anchorProps: PropItem[] = [
 export function AnchorPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">Anchor</Heading>
         <p className="text-fg-mute text-lg">
@@ -38,7 +37,6 @@ export function AnchorPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -50,7 +48,6 @@ export function AnchorPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -67,7 +64,6 @@ export function AnchorPage() {
           </ComponentPreview>
         </div>
 
-        {/* Open in New Tab */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.anchor.openInNewTabTitle" />
@@ -87,7 +83,6 @@ export function AnchorPage() {
           </ComponentPreview>
         </div>
 
-        {/* renderAnchor */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.anchor.renderAnchorTitle" />
@@ -113,7 +108,6 @@ import Link from 'next/link';
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/autocomplete-page.tsx
+++ b/apps/docs/src/pages/components/autocomplete-page.tsx
@@ -37,7 +37,6 @@ const autocompleteProps: PropItem[] = [
 export function AutocompletePage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">Autocomplete</Heading>
         <p className="text-fg-mute text-lg">
@@ -54,7 +53,6 @@ export function AutocompletePage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -66,7 +64,6 @@ export function AutocompletePage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -98,7 +95,6 @@ const options = [
           </ComponentPreview>
         </div>
 
-        {/* Required */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.autocomplete.requiredTitle" />
@@ -119,7 +115,6 @@ const options = [
           </ComponentPreview>
         </div>
 
-        {/* Multiple Selection */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.autocomplete.multipleSelectionTitle" />
@@ -142,7 +137,6 @@ const options = [
           </ComponentPreview>
         </div>
 
-        {/* Disabled */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.autocomplete.disabledTitle" />
@@ -163,7 +157,6 @@ const options = [
           </ComponentPreview>
         </div>
 
-        {/* Invalid */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.autocomplete.invalidTitle" />
@@ -186,7 +179,6 @@ const options = [
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/baseline-status-page.tsx
+++ b/apps/docs/src/pages/components/baseline-status-page.tsx
@@ -14,7 +14,6 @@ const baselineStatusProps: PropItem[] = [
 export function BaselineStatusPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">BaselineStatus</Heading>
         <p className="text-fg-mute text-lg">
@@ -31,7 +30,6 @@ export function BaselineStatusPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -43,7 +41,6 @@ export function BaselineStatusPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -56,7 +53,6 @@ export function BaselineStatusPage() {
           </ComponentPreview>
         </div>
 
-        {/* Different Features */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.baselineStatus.differentFeaturesTitle" />
@@ -76,7 +72,6 @@ export function BaselineStatusPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/breadcrumb-page.tsx
+++ b/apps/docs/src/pages/components/breadcrumb-page.tsx
@@ -30,7 +30,6 @@ const breadcrumbLinkProps: PropItem[] = [
 export function BreadcrumbPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">Breadcrumb</Heading>
         <p className="text-fg-mute text-lg">
@@ -47,7 +46,6 @@ export function BreadcrumbPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -59,7 +57,6 @@ export function BreadcrumbPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -100,7 +97,6 @@ export function BreadcrumbPage() {
           </ComponentPreview>
         </div>
 
-        {/* Current Page */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.breadcrumb.currentPageTitle" />
@@ -140,7 +136,6 @@ export function BreadcrumbPage() {
           </ComponentPreview>
         </div>
 
-        {/* Sizes */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.breadcrumb.sizesTitle" />
@@ -216,7 +211,6 @@ export function BreadcrumbPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/button-page.tsx
+++ b/apps/docs/src/pages/components/button-page.tsx
@@ -57,7 +57,6 @@ const buttonProps: PropItem[] = [
 export function ButtonPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">Button</Heading>
         <p className="text-fg-mute text-lg">
@@ -74,7 +73,6 @@ export function ButtonPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -86,7 +84,6 @@ export function ButtonPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -103,7 +100,6 @@ export function ButtonPage() {
           </ComponentPreview>
         </div>
 
-        {/* Variants */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.button.variantsTitle" />
@@ -119,7 +115,6 @@ export function ButtonPage() {
           </ComponentPreview>
         </div>
 
-        {/* Colors */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.button.colorsTitle" />
@@ -135,7 +130,6 @@ export function ButtonPage() {
           </ComponentPreview>
         </div>
 
-        {/* Sizes */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.button.sizesTitle" />
@@ -151,7 +145,6 @@ export function ButtonPage() {
           </ComponentPreview>
         </div>
 
-        {/* With Icons */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.button.iconsTitle" />
@@ -173,7 +166,6 @@ export function ButtonPage() {
           </ComponentPreview>
         </div>
 
-        {/* Full Width */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.button.fullWidthTitle" />
@@ -185,7 +177,6 @@ export function ButtonPage() {
           </ComponentPreview>
         </div>
 
-        {/* Disabled */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.button.disabledTitle" />
@@ -195,7 +186,6 @@ export function ButtonPage() {
           </ComponentPreview>
         </div>
 
-        {/* Render as Link */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.button.renderItemTitle" />
@@ -217,7 +207,6 @@ export function ButtonPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/card-page.tsx
+++ b/apps/docs/src/pages/components/card-page.tsx
@@ -29,7 +29,6 @@ const cardProps: PropItem[] = [
 export function CardPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">Card</Heading>
         <p className="text-fg-mute text-lg">
@@ -46,7 +45,6 @@ export function CardPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -55,7 +53,6 @@ export function CardPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -72,7 +69,6 @@ export function CardPage() {
           </ComponentPreview>
         </div>
 
-        {/* Width */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.card.widthTitle" />
@@ -96,7 +92,6 @@ export function CardPage() {
           </ComponentPreview>
         </div>
 
-        {/* Interactive */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">Interactive</Heading>
           <p className="text-fg-mute">
@@ -117,7 +112,6 @@ export function CardPage() {
           </ComponentPreview>
         </div>
 
-        {/* Appearance */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">Appearance</Heading>
           <ComponentPreview
@@ -139,7 +133,6 @@ export function CardPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/checkbox-page.tsx
+++ b/apps/docs/src/pages/components/checkbox-page.tsx
@@ -44,7 +44,6 @@ const checkboxGroupProps: PropItem[] = [
 export function CheckboxPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">Checkbox</Heading>
         <p className="text-fg-mute text-lg">
@@ -61,7 +60,6 @@ export function CheckboxPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -73,7 +71,6 @@ export function CheckboxPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -84,7 +81,6 @@ export function CheckboxPage() {
           </ComponentPreview>
         </div>
 
-        {/* Default Checked */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.checkbox.defaultCheckedTitle" />
@@ -94,7 +90,6 @@ export function CheckboxPage() {
           </ComponentPreview>
         </div>
 
-        {/* Controlled */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.checkbox.controlledTitle" />
@@ -112,7 +107,6 @@ export function CheckboxPage() {
           </ComponentPreview>
         </div>
 
-        {/* Disabled */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.checkbox.disabledTitle" />
@@ -154,7 +148,6 @@ export function CheckboxPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/code-page.tsx
+++ b/apps/docs/src/pages/components/code-page.tsx
@@ -14,7 +14,6 @@ const codeProps: PropItem[] = [
 export function CodePage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">Code</Heading>
         <p className="text-fg-mute text-lg">
@@ -31,7 +30,6 @@ export function CodePage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -40,7 +38,6 @@ export function CodePage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -58,7 +55,6 @@ export function CodePage() {
           </ComponentPreview>
         </div>
 
-        {/* Color Detection */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.code.colorDetectionTitle" />
@@ -76,7 +72,6 @@ export function CodePage() {
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/dialog-page.tsx
+++ b/apps/docs/src/pages/components/dialog-page.tsx
@@ -33,7 +33,6 @@ const dialogContentProps: PropItem[] = [
 export function DialogPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">Dialog</Heading>
         <p className="text-fg-mute text-lg">
@@ -50,7 +49,6 @@ export function DialogPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -63,7 +61,6 @@ import { Modal } from '@k8o/arte-odyssey';`}
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -79,7 +76,6 @@ import { Modal } from '@k8o/arte-odyssey';`}
           </ComponentPreview>
         </div>
 
-        {/* Basic usage with Modal */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.common.basicUsageTitle" />
@@ -110,7 +106,6 @@ import { Modal } from '@k8o/arte-odyssey';`}
           </ComponentPreview>
         </div>
 
-        {/* Alert Dialog */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.dialog.alertDialogTitle" />
@@ -158,7 +153,6 @@ import { Modal } from '@k8o/arte-odyssey';`}
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/drawer-page.tsx
+++ b/apps/docs/src/pages/components/drawer-page.tsx
@@ -21,7 +21,6 @@ const drawerProps: PropItem[] = [
 export function DrawerPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">Drawer</Heading>
         <p className="text-fg-mute text-lg">
@@ -38,7 +37,6 @@ export function DrawerPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -50,7 +48,6 @@ export function DrawerPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -58,7 +55,6 @@ export function DrawerPage() {
           </Heading>
         </div>
 
-        {/* Basic usage */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.common.basicUsageTitle" />
@@ -85,7 +81,6 @@ export function DrawerPage() {
           </ComponentPreview>
         </div>
 
-        {/* With Custom Content */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.drawer.customContentTitle" />
@@ -127,7 +122,6 @@ export function DrawerPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/dropdown-menu-page.tsx
+++ b/apps/docs/src/pages/components/dropdown-menu-page.tsx
@@ -53,7 +53,6 @@ const dropdownMenuItemProps: PropItem[] = [
 export function DropdownMenuPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">DropdownMenu</Heading>
         <p className="text-fg-mute text-lg">
@@ -70,7 +69,6 @@ export function DropdownMenuPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -82,7 +80,6 @@ export function DropdownMenuPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -102,7 +99,6 @@ export function DropdownMenuPage() {
           </ComponentPreview>
         </div>
 
-        {/* With IconTrigger */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.dropdownMenu.iconTriggerTitle" />
@@ -126,7 +122,6 @@ export function DropdownMenuPage() {
           </ComponentPreview>
         </div>
 
-        {/* Sizes */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.dropdownMenu.sizesTitle" />
@@ -160,7 +155,6 @@ export function DropdownMenuPage() {
           </ComponentPreview>
         </div>
 
-        {/* Placement */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.dropdownMenu.placementTitle" />
@@ -196,7 +190,6 @@ export function DropdownMenuPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/file-field-page.tsx
+++ b/apps/docs/src/pages/components/file-field-page.tsx
@@ -33,7 +33,6 @@ const fileFieldProps: PropItem[] = [
 export function FileFieldPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">FileField</Heading>
         <p className="text-fg-mute text-lg">
@@ -50,7 +49,6 @@ export function FileFieldPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -62,7 +60,6 @@ export function FileFieldPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -84,7 +81,6 @@ export function FileFieldPage() {
           </ComponentPreview>
         </div>
 
-        {/* Accept Types */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.fileField.acceptTypesTitle" />
@@ -106,7 +102,6 @@ export function FileFieldPage() {
           </ComponentPreview>
         </div>
 
-        {/* Multiple Files */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.fileField.multipleFilesTitle" />
@@ -127,7 +122,6 @@ export function FileFieldPage() {
           </ComponentPreview>
         </div>
 
-        {/* Disabled */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.fileField.disabledTitle" />
@@ -148,7 +142,6 @@ export function FileFieldPage() {
           </ComponentPreview>
         </div>
 
-        {/* Invalid */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.fileField.invalidTitle" />
@@ -171,7 +164,6 @@ export function FileFieldPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/form-control-page.tsx
+++ b/apps/docs/src/pages/components/form-control-page.tsx
@@ -32,7 +32,6 @@ const formControlProps: PropItem[] = [
 export function FormControlPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">FormControl</Heading>
         <p className="text-fg-mute text-lg">
@@ -49,7 +48,6 @@ export function FormControlPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -61,7 +59,6 @@ export function FormControlPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -82,7 +79,6 @@ export function FormControlPage() {
           </ComponentPreview>
         </div>
 
-        {/* Help Text */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.formControl.helpTextTitle" />
@@ -103,7 +99,6 @@ export function FormControlPage() {
           </ComponentPreview>
         </div>
 
-        {/* Error Text */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.formControl.errorTextTitle" />
@@ -122,7 +117,6 @@ export function FormControlPage() {
           </ComponentPreview>
         </div>
 
-        {/* Required */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.formControl.requiredTitle" />
@@ -143,7 +137,6 @@ export function FormControlPage() {
           </ComponentPreview>
         </div>
 
-        {/* Disabled */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.formControl.disabledTitle" />
@@ -166,7 +159,6 @@ export function FormControlPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/grid-page.tsx
+++ b/apps/docs/src/pages/components/grid-page.tsx
@@ -36,7 +36,6 @@ function Cell({ children }: { children: string }) {
 export function GridPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">Grid</Heading>
         <p className="text-fg-mute text-lg">
@@ -53,7 +52,6 @@ export function GridPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -62,7 +60,6 @@ export function GridPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -81,7 +78,6 @@ export function GridPage() {
           </ComponentPreview>
         </div>
 
-        {/* Fixed cols */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.grid.colsTitle" />
@@ -102,7 +98,6 @@ export function GridPage() {
           </ComponentPreview>
         </div>
 
-        {/* Auto fill */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.grid.autoFillTitle" />
@@ -121,7 +116,6 @@ export function GridPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/heading-page.tsx
+++ b/apps/docs/src/pages/components/heading-page.tsx
@@ -21,7 +21,6 @@ const headingProps: PropItem[] = [
 export function HeadingPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">Heading</Heading>
         <p className="text-fg-mute text-lg">
@@ -38,7 +37,6 @@ export function HeadingPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -50,7 +48,6 @@ export function HeadingPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -61,7 +58,6 @@ export function HeadingPage() {
           </ComponentPreview>
         </div>
 
-        {/* Types */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.heading.typesTitle" />
@@ -85,7 +81,6 @@ export function HeadingPage() {
           </ComponentPreview>
         </div>
 
-        {/* Line Clamp */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.heading.lineClampTitle" />
@@ -107,7 +102,6 @@ export function HeadingPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/icon-button-page.tsx
+++ b/apps/docs/src/pages/components/icon-button-page.tsx
@@ -51,7 +51,6 @@ const iconButtonProps: PropItem[] = [
 export function IconButtonPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">IconButton</Heading>
         <p className="text-fg-mute text-lg">
@@ -68,7 +67,6 @@ export function IconButtonPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -80,7 +78,6 @@ export function IconButtonPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -99,7 +96,6 @@ export function IconButtonPage() {
           </ComponentPreview>
         </div>
 
-        {/* Sizes */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.iconButton.sizesTitle" />
@@ -127,7 +123,6 @@ export function IconButtonPage() {
           </ComponentPreview>
         </div>
 
-        {/* Backgrounds */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.iconButton.backgroundsTitle" />
@@ -161,7 +156,6 @@ export function IconButtonPage() {
           </ComponentPreview>
         </div>
 
-        {/* Disabled */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.iconButton.disabledTitle" />
@@ -177,7 +171,6 @@ export function IconButtonPage() {
           </ComponentPreview>
         </div>
 
-        {/* Render as Link */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.iconButton.renderItemTitle" />
@@ -210,7 +203,6 @@ export function IconButtonPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/icons-page.tsx
+++ b/apps/docs/src/pages/components/icons-page.tsx
@@ -77,7 +77,6 @@ const IconCard = ({
 export function IconsPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">Icons</Heading>
         <p className="text-fg-mute text-lg">
@@ -94,7 +93,6 @@ export function IconsPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -106,7 +104,6 @@ export function IconsPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Sizes */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.icons.sizesTitle" />
@@ -134,7 +131,6 @@ export function IconsPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Icon Gallery */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.usageTitle" />

--- a/apps/docs/src/pages/components/list-box-page.tsx
+++ b/apps/docs/src/pages/components/list-box-page.tsx
@@ -52,7 +52,6 @@ const listBoxContentProps: PropItem[] = [
 export function ListBoxPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">ListBox</Heading>
         <p className="text-fg-mute text-lg">
@@ -69,7 +68,6 @@ export function ListBoxPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -81,7 +79,6 @@ export function ListBoxPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -111,7 +108,6 @@ const [selected, setSelected] = useState<string>();
           </ComponentPreview>
         </div>
 
-        {/* Sizes */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.listBox.sizesTitle" />
@@ -136,7 +132,6 @@ const [selected, setSelected] = useState<string>();
           </ComponentPreview>
         </div>
 
-        {/* With TriggerIcon */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.listBox.triggerIconTitle" />
@@ -155,7 +150,6 @@ const [selected, setSelected] = useState<string>();
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/modal-page.tsx
+++ b/apps/docs/src/pages/components/modal-page.tsx
@@ -27,7 +27,6 @@ const modalProps: PropItem[] = [
 export function ModalPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">Modal</Heading>
         <p className="text-fg-mute text-lg">
@@ -44,7 +43,6 @@ export function ModalPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -56,7 +54,6 @@ export function ModalPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -64,7 +61,6 @@ export function ModalPage() {
           </Heading>
         </div>
 
-        {/* Basic usage */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.common.basicUsageTitle" />
@@ -95,7 +91,6 @@ export function ModalPage() {
           </ComponentPreview>
         </div>
 
-        {/* Types */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.modal.typesTitle" />
@@ -130,7 +125,6 @@ export function ModalPage() {
           </ComponentPreview>
         </div>
 
-        {/* Default Open */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.modal.defaultOpenTitle" />
@@ -154,7 +148,6 @@ export function ModalPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/number-field-page.tsx
+++ b/apps/docs/src/pages/components/number-field-page.tsx
@@ -28,7 +28,6 @@ const numberFieldProps: PropItem[] = [
 export function NumberFieldPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">NumberField</Heading>
         <p className="text-fg-mute text-lg">
@@ -45,7 +44,6 @@ export function NumberFieldPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -57,7 +55,6 @@ export function NumberFieldPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -74,7 +71,6 @@ export function NumberFieldPage() {
           </ComponentPreview>
         </div>
 
-        {/* Step & Precision */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.numberField.stepPrecisionTitle" />
@@ -98,7 +94,6 @@ export function NumberFieldPage() {
           </ComponentPreview>
         </div>
 
-        {/* Min / Max */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.numberField.minMaxTitle" />
@@ -124,7 +119,6 @@ export function NumberFieldPage() {
           </ComponentPreview>
         </div>
 
-        {/* Disabled */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.numberField.disabledTitle" />
@@ -140,7 +134,6 @@ export function NumberFieldPage() {
           </ComponentPreview>
         </div>
 
-        {/* Invalid */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.numberField.invalidTitle" />
@@ -158,7 +151,6 @@ export function NumberFieldPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/popover-page.tsx
+++ b/apps/docs/src/pages/components/popover-page.tsx
@@ -46,7 +46,6 @@ const popoverContentProps: PropItem[] = [
 export function PopoverPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">Popover</Heading>
         <p className="text-fg-mute text-lg">
@@ -63,7 +62,6 @@ export function PopoverPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -75,7 +73,6 @@ export function PopoverPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -106,7 +103,6 @@ export function PopoverPage() {
           </ComponentPreview>
         </div>
 
-        {/* Placement */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.popover.placementTitle" />
@@ -178,7 +174,6 @@ export function PopoverPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/progress-page.tsx
+++ b/apps/docs/src/pages/components/progress-page.tsx
@@ -17,7 +17,6 @@ const progressProps: PropItem[] = [
 export function ProgressPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">Progress</Heading>
         <p className="text-fg-mute text-lg">
@@ -34,7 +33,6 @@ export function ProgressPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -46,7 +44,6 @@ export function ProgressPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -59,7 +56,6 @@ export function ProgressPage() {
           </ComponentPreview>
         </div>
 
-        {/* Different Values */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.progress.differentValuesTitle" />
@@ -79,7 +75,6 @@ export function ProgressPage() {
           </ComponentPreview>
         </div>
 
-        {/* With Label */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.progress.withLabelTitle" />
@@ -103,7 +98,6 @@ export function ProgressPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/scroll-linked-page.tsx
+++ b/apps/docs/src/pages/components/scroll-linked-page.tsx
@@ -19,7 +19,6 @@ const scrollLinkedProps: PropItem[] = [
 export function ScrollLinkedPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">ScrollLinked</Heading>
         <p className="text-fg-mute text-lg">
@@ -36,7 +35,6 @@ export function ScrollLinkedPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -48,7 +46,6 @@ export function ScrollLinkedPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -56,7 +53,6 @@ export function ScrollLinkedPage() {
           </Heading>
         </div>
 
-        {/* Basic usage */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.common.basicUsageTitle" />
@@ -78,7 +74,6 @@ export function ScrollLinkedPage() {
           </ComponentPreview>
         </div>
 
-        {/* Window Scroll */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.scrollLinked.windowScrollTitle" />
@@ -92,7 +87,6 @@ export function ScrollLinkedPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/select-page.tsx
+++ b/apps/docs/src/pages/components/select-page.tsx
@@ -36,7 +36,6 @@ const options = [
 export function SelectPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">Select</Heading>
         <p className="text-fg-mute text-lg">
@@ -53,7 +52,6 @@ export function SelectPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -65,7 +63,6 @@ export function SelectPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -98,7 +95,6 @@ export function SelectPage() {
           </ComponentPreview>
         </div>
 
-        {/* Required */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.select.requiredTitle" />
@@ -124,7 +120,6 @@ export function SelectPage() {
           </ComponentPreview>
         </div>
 
-        {/* Default Value */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.select.defaultValueTitle" />
@@ -152,7 +147,6 @@ export function SelectPage() {
           </ComponentPreview>
         </div>
 
-        {/* Disabled */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.select.disabledTitle" />
@@ -178,7 +172,6 @@ export function SelectPage() {
           </ComponentPreview>
         </div>
 
-        {/* Invalid */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.select.invalidTitle" />
@@ -206,7 +199,6 @@ export function SelectPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/separator-page.tsx
+++ b/apps/docs/src/pages/components/separator-page.tsx
@@ -23,7 +23,6 @@ const separatorProps: PropItem[] = [
 export function SeparatorPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">Separator</Heading>
         <p className="text-fg-mute text-lg">
@@ -40,7 +39,6 @@ export function SeparatorPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -52,7 +50,6 @@ export function SeparatorPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -65,7 +62,6 @@ export function SeparatorPage() {
           </ComponentPreview>
         </div>
 
-        {/* Orientations */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.separator.orientationsTitle" />
@@ -85,7 +81,6 @@ export function SeparatorPage() {
           </ComponentPreview>
         </div>
 
-        {/* Colors */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.separator.colorsTitle" />
@@ -111,7 +106,6 @@ export function SeparatorPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/stack-page.tsx
+++ b/apps/docs/src/pages/components/stack-page.tsx
@@ -36,7 +36,6 @@ const SAMPLE_TONE = ['success', 'warning', 'error'] as const;
 export function StackPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">Stack</Heading>
         <p className="text-fg-mute text-lg">
@@ -53,7 +52,6 @@ export function StackPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -65,7 +63,6 @@ export function StackPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -86,7 +83,6 @@ export function StackPage() {
           </ComponentPreview>
         </div>
 
-        {/* Direction */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.stack.directionTitle" />
@@ -110,7 +106,6 @@ export function StackPage() {
           </ComponentPreview>
         </div>
 
-        {/* Gap */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.stack.gapTitle" />
@@ -129,7 +124,6 @@ export function StackPage() {
           </ComponentPreview>
         </div>
 
-        {/* Align & justify */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.stack.alignTitle" />
@@ -147,7 +141,6 @@ export function StackPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/tabs-page.tsx
+++ b/apps/docs/src/pages/components/tabs-page.tsx
@@ -39,7 +39,6 @@ const tabsPanelProps: PropItem[] = [
 export function TabsPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">Tabs</Heading>
         <p className="text-fg-mute text-lg">
@@ -56,7 +55,6 @@ export function TabsPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -65,7 +63,6 @@ export function TabsPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -93,7 +90,6 @@ export function TabsPage() {
           </ComponentPreview>
         </div>
 
-        {/* Default Selected */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.tabs.defaultSelectedTitle" />
@@ -125,7 +121,6 @@ export function TabsPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/text-field-page.tsx
+++ b/apps/docs/src/pages/components/text-field-page.tsx
@@ -24,7 +24,6 @@ const textFieldProps: PropItem[] = [
 export function TextFieldPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">TextField</Heading>
         <p className="text-fg-mute text-lg">
@@ -41,7 +40,6 @@ export function TextFieldPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -53,7 +51,6 @@ export function TextFieldPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -70,7 +67,6 @@ export function TextFieldPage() {
           </ComponentPreview>
         </div>
 
-        {/* Placeholder */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.textField.placeholderTitle" />
@@ -92,7 +88,6 @@ export function TextFieldPage() {
           </ComponentPreview>
         </div>
 
-        {/* Disabled */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.textField.disabledTitle" />
@@ -114,7 +109,6 @@ export function TextFieldPage() {
           </ComponentPreview>
         </div>
 
-        {/* Invalid */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.textField.invalidTitle" />
@@ -138,7 +132,6 @@ export function TextFieldPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/textarea-page.tsx
+++ b/apps/docs/src/pages/components/textarea-page.tsx
@@ -33,7 +33,6 @@ const textareaProps: PropItem[] = [
 export function TextareaPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">Textarea</Heading>
         <p className="text-fg-mute text-lg">
@@ -50,7 +49,6 @@ export function TextareaPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -62,7 +60,6 @@ export function TextareaPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -89,7 +86,6 @@ export function TextareaPage() {
           </ComponentPreview>
         </div>
 
-        {/* Rows */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.textarea.rowsTitle" />
@@ -117,7 +113,6 @@ export function TextareaPage() {
           </ComponentPreview>
         </div>
 
-        {/* Auto Resize */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.textarea.autoResizeTitle" />
@@ -147,7 +142,6 @@ export function TextareaPage() {
           </ComponentPreview>
         </div>
 
-        {/* Disabled */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.textarea.disabledTitle" />
@@ -173,7 +167,6 @@ export function TextareaPage() {
           </ComponentPreview>
         </div>
 
-        {/* Invalid */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.textarea.invalidTitle" />
@@ -201,7 +194,6 @@ export function TextareaPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/toast-page.tsx
+++ b/apps/docs/src/pages/components/toast-page.tsx
@@ -46,7 +46,6 @@ const useToastReturnProps: PropItem[] = [
 export function ToastPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">Toast</Heading>
         <p className="text-fg-mute text-lg">
@@ -63,7 +62,6 @@ export function ToastPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -75,7 +73,6 @@ export function ToastPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -83,7 +80,6 @@ export function ToastPage() {
           </Heading>
         </div>
 
-        {/* Basic usage */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.common.basicUsageTitle" />
@@ -118,7 +114,6 @@ function ToastDemo() {
           </ComponentPreview>
         </div>
 
-        {/* useToast Hook */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.toast.useToastTitle" />
@@ -138,7 +133,6 @@ onCloseAll();`}
           />
         </div>
 
-        {/* Close All */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.toast.closeAllTitle" />
@@ -166,7 +160,6 @@ onCloseAll();`}
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/components/tooltip-page.tsx
+++ b/apps/docs/src/pages/components/tooltip-page.tsx
@@ -35,7 +35,6 @@ const tooltipContentProps: PropItem[] = [
 export function TooltipPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">Tooltip</Heading>
         <p className="text-fg-mute text-lg">
@@ -52,7 +51,6 @@ export function TooltipPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.importTitle" />
@@ -64,7 +62,6 @@ export function TooltipPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -88,7 +85,6 @@ export function TooltipPage() {
           </ComponentPreview>
         </div>
 
-        {/* Placement */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="components.tooltip.placementTitle" />
@@ -144,7 +140,6 @@ export function TooltipPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Props */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="components.common.propsTitle" />

--- a/apps/docs/src/pages/generative-ui.tsx
+++ b/apps/docs/src/pages/generative-ui.tsx
@@ -16,7 +16,6 @@ export function GenerativeUi() {
       </div>
       <Separator color="mute" />
 
-      {/* Prompt generation (server) */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="generativeUi.promptTitle" />
@@ -35,7 +34,6 @@ const systemPrompt = catalog.prompt({ customRules: [...arteOdysseyRules] });`}
 
       <Separator color="mute" />
 
-      {/* Render (client) */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="generativeUi.renderTitle" />
@@ -56,7 +54,6 @@ export function GenUi({ spec }: { spec: unknown }) {
 
       <Separator color="mute" />
 
-      {/* Validate & repair */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="generativeUi.validateTitle" />
@@ -78,7 +75,6 @@ const retried = await llm(result.repairPrompt); // fix and retry`}
 
       <Separator color="mute" />
 
-      {/* Typed specs */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="generativeUi.typedTitle" />
@@ -102,7 +98,6 @@ const spec = {
 
       <Separator color="mute" />
 
-      {/* OpenUI */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="generativeUi.openuiTitle" />

--- a/apps/docs/src/pages/get-started.tsx
+++ b/apps/docs/src/pages/get-started.tsx
@@ -19,7 +19,6 @@ export function GetStarted() {
       </div>
       <Separator color="mute" />
 
-      {/* Installation */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="getStarted.installationTitle" />
@@ -36,7 +35,6 @@ export function GetStarted() {
 
       <Separator color="mute" />
 
-      {/* Setup */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="getStarted.setupTitle" />
@@ -75,7 +73,6 @@ function App({ children }) {
 
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="getStarted.usageTitle" />
@@ -100,7 +97,6 @@ function MyComponent() {
 
       <Separator color="mute" />
 
-      {/* Requirements */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="getStarted.requirementsTitle" />
@@ -118,7 +114,6 @@ function MyComponent() {
 
       <Separator color="mute" />
 
-      {/* Next Steps */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="getStarted.nextStepsTitle" />

--- a/apps/docs/src/pages/home.tsx
+++ b/apps/docs/src/pages/home.tsx
@@ -60,7 +60,6 @@ export function Home() {
 
   return (
     <div className="flex flex-1 flex-col">
-      {/* ===== 扉（非対称ヒーロー） ===== */}
       <section className="mx-auto grid w-full max-w-6xl grid-cols-1 gap-12 px-6 py-20 md:grid-cols-[1fr_auto] md:gap-16 md:px-8 md:py-28">
         <div className="flex max-w-xl flex-col justify-center gap-8">
           {/* Heading は className を受けないため、ヒーローのみ生 h1（サイト内この1箇所限定） */}
@@ -147,7 +146,6 @@ export function Home() {
         </div>
       </section>
 
-      {/* ===== 目次（特徴） ===== */}
       <section className="mx-auto w-full max-w-6xl px-6 pb-24 md:px-8">
         <Heading type="h2">{t('home.featuresTitle')}</Heading>
         <ol className="mt-8">

--- a/apps/docs/src/pages/hooks/use-click-away-page.tsx
+++ b/apps/docs/src/pages/hooks/use-click-away-page.tsx
@@ -36,7 +36,6 @@ const returnValue: PropItem[] = [
 export function UseClickAwayPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">useClickAway</Heading>
         <p className="text-fg-mute text-lg">
@@ -45,7 +44,6 @@ export function UseClickAwayPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="hooks.common.importTitle" />
@@ -57,7 +55,6 @@ export function UseClickAwayPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <Heading type="h2">
           <T k="hooks.common.usageTitle" />
@@ -88,7 +85,6 @@ return (
       </section>
       <Separator color="mute" />
 
-      {/* API */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="hooks.common.parametersTitle" />

--- a/apps/docs/src/pages/hooks/use-client-page.tsx
+++ b/apps/docs/src/pages/hooks/use-client-page.tsx
@@ -16,7 +16,6 @@ const returnValue: PropItem[] = [
 export function UseClientPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">useClient</Heading>
         <p className="text-fg-mute text-lg">
@@ -25,7 +24,6 @@ export function UseClientPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="hooks.common.importTitle" />
@@ -37,7 +35,6 @@ export function UseClientPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <Heading type="h2">
           <T k="hooks.common.usageTitle" />
@@ -60,7 +57,6 @@ return <p>Window width: {window.innerWidth}px</p>;`}
       </section>
       <Separator color="mute" />
 
-      {/* API */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="hooks.common.returnValueTitle" />

--- a/apps/docs/src/pages/hooks/use-clipboard-page.tsx
+++ b/apps/docs/src/pages/hooks/use-clipboard-page.tsx
@@ -23,7 +23,6 @@ const returnValue: PropItem[] = [
 export function UseClipboardPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">useClipboard</Heading>
         <p className="text-fg-mute text-lg">
@@ -32,7 +31,6 @@ export function UseClipboardPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="hooks.common.importTitle" />
@@ -44,7 +42,6 @@ export function UseClipboardPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <Heading type="h2">
           <T k="hooks.common.usageTitle" />
@@ -75,7 +72,6 @@ return (
       </section>
       <Separator color="mute" />
 
-      {/* API */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="hooks.common.returnValueTitle" />

--- a/apps/docs/src/pages/hooks/use-hash-page.tsx
+++ b/apps/docs/src/pages/hooks/use-hash-page.tsx
@@ -16,7 +16,6 @@ const returnValue: PropItem[] = [
 export function UseHashPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">useHash</Heading>
         <p className="text-fg-mute text-lg">
@@ -25,7 +24,6 @@ export function UseHashPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="hooks.common.importTitle" />
@@ -37,7 +35,6 @@ export function UseHashPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <Heading type="h2">
           <T k="hooks.common.usageTitle" />
@@ -62,7 +59,6 @@ return (
       </section>
       <Separator color="mute" />
 
-      {/* API */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="hooks.common.returnValueTitle" />

--- a/apps/docs/src/pages/hooks/use-interval-page.tsx
+++ b/apps/docs/src/pages/hooks/use-interval-page.tsx
@@ -23,7 +23,6 @@ const parameters: PropItem[] = [
 export function UseIntervalPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">useInterval</Heading>
         <p className="text-fg-mute text-lg">
@@ -32,7 +31,6 @@ export function UseIntervalPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="hooks.common.importTitle" />
@@ -44,7 +42,6 @@ export function UseIntervalPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <Heading type="h2">
           <T k="hooks.common.usageTitle" />
@@ -70,7 +67,6 @@ return <span>Count: {count}</span>;`}
       </section>
       <Separator color="mute" />
 
-      {/* API */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="hooks.common.parametersTitle" />

--- a/apps/docs/src/pages/hooks/use-local-storage-page.tsx
+++ b/apps/docs/src/pages/hooks/use-local-storage-page.tsx
@@ -44,7 +44,6 @@ const returnValue: PropItem[] = [
 export function UseLocalStoragePage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">useLocalStorage</Heading>
         <p className="text-fg-mute text-lg">
@@ -53,7 +52,6 @@ export function UseLocalStoragePage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="hooks.common.importTitle" />
@@ -65,13 +63,11 @@ export function UseLocalStoragePage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <Heading type="h2">
           <T k="hooks.common.usageTitle" />
         </Heading>
 
-        {/* Basic usage */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="hooks.common.basicUsageTitle" />
@@ -92,7 +88,6 @@ return (
           </ComponentPreview>
         </div>
 
-        {/* Remove */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="hooks.useLocalStorage.removeTitle" />
@@ -117,7 +112,6 @@ return (
       </section>
       <Separator color="mute" />
 
-      {/* API */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="hooks.common.parametersTitle" />

--- a/apps/docs/src/pages/hooks/use-resize-page.tsx
+++ b/apps/docs/src/pages/hooks/use-resize-page.tsx
@@ -34,7 +34,6 @@ const returnValue: PropItem[] = [
 export function UseResizePage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">useResize</Heading>
         <p className="text-fg-mute text-lg">
@@ -43,7 +42,6 @@ export function UseResizePage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="hooks.common.importTitle" />
@@ -55,7 +53,6 @@ export function UseResizePage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <Heading type="h2">
           <T k="hooks.common.usageTitle" />
@@ -85,7 +82,6 @@ return (
       </section>
       <Separator color="mute" />
 
-      {/* API */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="hooks.common.parametersTitle" />

--- a/apps/docs/src/pages/hooks/use-scroll-direction-page.tsx
+++ b/apps/docs/src/pages/hooks/use-scroll-direction-page.tsx
@@ -39,7 +39,6 @@ const returnValue: PropItem[] = [
 export function UseScrollDirectionPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">useScrollDirection</Heading>
         <p className="text-fg-mute text-lg">
@@ -48,7 +47,6 @@ export function UseScrollDirectionPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="hooks.common.importTitle" />
@@ -60,7 +58,6 @@ export function UseScrollDirectionPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <Heading type="h2">
           <T k="hooks.common.usageTitle" />
@@ -106,7 +103,6 @@ return (
       </section>
       <Separator color="mute" />
 
-      {/* API */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="hooks.common.parametersTitle" />

--- a/apps/docs/src/pages/hooks/use-session-storage-page.tsx
+++ b/apps/docs/src/pages/hooks/use-session-storage-page.tsx
@@ -44,7 +44,6 @@ const returnValue: PropItem[] = [
 export function UseSessionStoragePage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">useSessionStorage</Heading>
         <p className="text-fg-mute text-lg">
@@ -53,7 +52,6 @@ export function UseSessionStoragePage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="hooks.common.importTitle" />
@@ -65,13 +63,11 @@ export function UseSessionStoragePage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <Heading type="h2">
           <T k="hooks.common.usageTitle" />
         </Heading>
 
-        {/* Basic usage */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="hooks.common.basicUsageTitle" />
@@ -92,7 +88,6 @@ return (
           </ComponentPreview>
         </div>
 
-        {/* Remove */}
         <div className="flex flex-col gap-4">
           <Heading type="h3">
             <T k="hooks.useSessionStorage.removeTitle" />
@@ -117,7 +112,6 @@ return (
       </section>
       <Separator color="mute" />
 
-      {/* API */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="hooks.common.parametersTitle" />

--- a/apps/docs/src/pages/hooks/use-step-page.tsx
+++ b/apps/docs/src/pages/hooks/use-step-page.tsx
@@ -51,7 +51,6 @@ const returnValue: PropItem[] = [
 export function UseStepPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">useStep</Heading>
         <p className="text-fg-mute text-lg">
@@ -60,7 +59,6 @@ export function UseStepPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="hooks.common.importTitle" />
@@ -72,7 +70,6 @@ export function UseStepPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <Heading type="h2">
           <T k="hooks.common.usageTitle" />
@@ -101,7 +98,6 @@ return (
       </section>
       <Separator color="mute" />
 
-      {/* API */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="hooks.common.parametersTitle" />

--- a/apps/docs/src/pages/hooks/use-timeout-page.tsx
+++ b/apps/docs/src/pages/hooks/use-timeout-page.tsx
@@ -21,7 +21,6 @@ const parameters: PropItem[] = [
 export function UseTimeoutPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">useTimeout</Heading>
         <p className="text-fg-mute text-lg">
@@ -30,7 +29,6 @@ export function UseTimeoutPage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="hooks.common.importTitle" />
@@ -42,7 +40,6 @@ export function UseTimeoutPage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <Heading type="h2">
           <T k="hooks.common.usageTitle" />
@@ -65,7 +62,6 @@ return visible ? <p>This will disappear in 3 seconds</p> : null;`}
       </section>
       <Separator color="mute" />
 
-      {/* API */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="hooks.common.parametersTitle" />

--- a/apps/docs/src/pages/hooks/use-window-resize-page.tsx
+++ b/apps/docs/src/pages/hooks/use-window-resize-page.tsx
@@ -21,7 +21,6 @@ const parameters: PropItem[] = [
 export function UseWindowResizePage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">useWindowResize</Heading>
         <p className="text-fg-mute text-lg">
@@ -30,7 +29,6 @@ export function UseWindowResizePage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="hooks.common.importTitle" />
@@ -42,7 +40,6 @@ export function UseWindowResizePage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <Heading type="h2">
           <T k="hooks.common.usageTitle" />
@@ -61,7 +58,6 @@ export function UseWindowResizePage() {
       </section>
       <Separator color="mute" />
 
-      {/* API */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="hooks.common.parametersTitle" />

--- a/apps/docs/src/pages/hooks/use-window-size-page.tsx
+++ b/apps/docs/src/pages/hooks/use-window-size-page.tsx
@@ -23,7 +23,6 @@ const returnValue: PropItem[] = [
 export function UseWindowSizePage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">useWindowSize</Heading>
         <p className="text-fg-mute text-lg">
@@ -32,7 +31,6 @@ export function UseWindowSizePage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="hooks.common.importTitle" />
@@ -44,7 +42,6 @@ export function UseWindowSizePage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <Heading type="h2">
           <T k="hooks.common.usageTitle" />
@@ -69,7 +66,6 @@ return (
       </section>
       <Separator color="mute" />
 
-      {/* API */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="hooks.common.returnValueTitle" />

--- a/apps/docs/src/pages/hooks/use-writing-mode-page.tsx
+++ b/apps/docs/src/pages/hooks/use-writing-mode-page.tsx
@@ -24,7 +24,6 @@ const returnValue: PropItem[] = [
 export function UseWritingModePage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">useWritingMode</Heading>
         <p className="text-fg-mute text-lg">
@@ -33,7 +32,6 @@ export function UseWritingModePage() {
       </div>
       <Separator color="mute" />
 
-      {/* Import */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="hooks.common.importTitle" />
@@ -45,7 +43,6 @@ export function UseWritingModePage() {
       </section>
       <Separator color="mute" />
 
-      {/* Usage */}
       <section className="flex flex-col gap-8">
         <Heading type="h2">
           <T k="hooks.common.usageTitle" />
@@ -69,7 +66,6 @@ return (
       </section>
       <Separator color="mute" />
 
-      {/* API */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="hooks.common.parametersTitle" />

--- a/apps/docs/src/pages/theming.tsx
+++ b/apps/docs/src/pages/theming.tsx
@@ -33,7 +33,6 @@ const Z_INDEX_USAGE = {
 export function Theming() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-12 md:px-8">
-      {/* Header */}
       <div className="flex flex-col gap-4">
         <Heading type="h1">
           <T k="nav.theming" />
@@ -44,7 +43,6 @@ export function Theming() {
       </div>
       <Separator color="mute" />
 
-      {/* Color Palette */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="theming.colorPaletteTitle" />
@@ -77,7 +75,6 @@ export function Theming() {
       </section>
       <Separator color="mute" />
 
-      {/* Semantic Colors */}
       <section className="flex flex-col gap-6">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -88,7 +85,6 @@ export function Theming() {
           </p>
         </div>
 
-        {/* Foreground */}
         <div className="flex flex-col gap-3">
           <Heading type="h3">
             <T k="theming.foregroundTitle" />
@@ -100,7 +96,6 @@ export function Theming() {
           </div>
         </div>
 
-        {/* Background */}
         <div className="flex flex-col gap-3">
           <Heading type="h3">
             <T k="theming.backgroundTitle" />
@@ -112,7 +107,6 @@ export function Theming() {
           </div>
         </div>
 
-        {/* Border */}
         <div className="flex flex-col gap-3">
           <Heading type="h3">
             <T k="theming.borderTitle" />
@@ -126,7 +120,6 @@ export function Theming() {
       </section>
       <Separator color="mute" />
 
-      {/* Brand Colors */}
       <section className="flex flex-col gap-6">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -137,7 +130,6 @@ export function Theming() {
           </p>
         </div>
 
-        {/* Primary */}
         <div className="flex flex-col gap-3">
           <Heading type="h3">Primary</Heading>
           <div className="grid gap-2 sm:grid-cols-2">
@@ -151,7 +143,6 @@ export function Theming() {
           </div>
         </div>
 
-        {/* Secondary */}
         <div className="flex flex-col gap-3">
           <Heading type="h3">Secondary</Heading>
           <div className="grid gap-2 sm:grid-cols-2">
@@ -165,7 +156,6 @@ export function Theming() {
           </div>
         </div>
 
-        {/* Group */}
         <div className="flex flex-col gap-3">
           <Heading type="h3">Group</Heading>
           <div className="grid gap-2 sm:grid-cols-2">
@@ -177,7 +167,6 @@ export function Theming() {
       </section>
       <Separator color="mute" />
 
-      {/* Typography */}
       <section className="flex flex-col gap-6">
         <div className="flex flex-col gap-4">
           <Heading type="h2">
@@ -188,7 +177,6 @@ export function Theming() {
           </p>
         </div>
 
-        {/* Text Sizes */}
         <div className="flex flex-col gap-3">
           <Heading type="h3">
             <T k="theming.textSizesTitle" />
@@ -220,7 +208,6 @@ export function Theming() {
           </Card>
         </div>
 
-        {/* Font Weights */}
         <div className="flex flex-col gap-3">
           <Heading type="h3">
             <T k="theming.fontWeightsTitle" />
@@ -247,7 +234,6 @@ export function Theming() {
           </Card>
         </div>
 
-        {/* Letter Spacing */}
         <div className="flex flex-col gap-3">
           <Heading type="h3">
             <T k="theming.letterSpacingTitle" />
@@ -271,7 +257,6 @@ export function Theming() {
           </Card>
         </div>
 
-        {/* Line Height */}
         <div className="flex flex-col gap-3">
           <Heading type="h3">
             <T k="theming.lineHeightTitle" />
@@ -301,7 +286,6 @@ export function Theming() {
       </section>
       <Separator color="mute" />
 
-      {/* Border Radius */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="theming.borderRadiusTitle" />
@@ -326,7 +310,6 @@ export function Theming() {
       </section>
       <Separator color="mute" />
 
-      {/* Shadow */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="theming.shadowTitle" />
@@ -351,7 +334,6 @@ export function Theming() {
       </section>
       <Separator color="mute" />
 
-      {/* Spacing */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="theming.spacingTitle" />
@@ -380,7 +362,6 @@ export function Theming() {
       </section>
       <Separator color="mute" />
 
-      {/* Breakpoints */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="theming.breakpointsTitle" />
@@ -405,7 +386,6 @@ export function Theming() {
       </section>
       <Separator color="mute" />
 
-      {/* Z-Index */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="theming.zIndexTitle" />
@@ -433,7 +413,6 @@ export function Theming() {
       </section>
       <Separator color="mute" />
 
-      {/* Dark Mode */}
       <section className="flex flex-col gap-4">
         <Heading type="h2">
           <T k="theming.darkModeTitle" />

--- a/apps/docs/src/theme/design-tokens.ts
+++ b/apps/docs/src/theme/design-tokens.ts
@@ -29,7 +29,6 @@ export type NamedScale = { name: string; value: string };
 export type SpacingStep = { step: number; rem: string; px: string };
 export type Breakpoint = { name: string; rem: string; px: string };
 
-// --- value accessors over the extracted tokens --------------------------------
 type Scalar = string | number;
 type VarValue = Scalar | { light: Scalar; dark: Scalar };
 const VARS = new Map<string, VarValue>(Object.entries(tokens.vars));
@@ -55,7 +54,6 @@ const namedScale = (group: Record<string, unknown> | undefined): NamedScale[] =>
     value: String(value),
   }));
 
-// --- palette (families/shades/hue derived; descriptions authored) -------------
 /** Design rationale that does not exist in CSS; keyed by palette prefix. */
 const PALETTE_DESCRIPTIONS: Record<string, string> = {
   gray: 'sky blue tint, minimal chroma for branded neutral',
@@ -109,7 +107,6 @@ export const PALETTE: readonly PaletteFamily[] = PALETTE_PREFIXES.map(
   }),
 );
 
-// --- semantic tokens (mapping derived from tokens.refs) -----------------------
 // Each entry is `{ name, light, dark }` where light/dark are the palette shade
 // the semantic var aliases in that mode — recovered from the CSS, not hand-kept.
 const semanticTokens = (prefix: string): readonly SemanticToken[] =>
@@ -124,7 +121,6 @@ export const PRIMARY_TOKENS = semanticTokens('primary-');
 export const SECONDARY_TOKENS = semanticTokens('secondary-');
 export const GROUP_TOKENS = semanticTokens('group-');
 
-// --- typography / scales (values extracted) -----------------------------------
 type GeneratedText = {
   value: string;
   lineHeight: Scalar;

--- a/examples/nextjs/next.config.ts
+++ b/examples/nextjs/next.config.ts
@@ -1,7 +1,5 @@
 import type { NextConfig } from 'next';
 
-const nextConfig: NextConfig = {
-  /* config options here */
-};
+const nextConfig: NextConfig = {};
 
 export default nextConfig;

--- a/examples/nextjs/src/app/gen-ui-client.tsx
+++ b/examples/nextjs/src/app/gen-ui-client.tsx
@@ -1,14 +1,8 @@
 'use client';
 
 import type { Spec } from '@json-render/core';
-// 事前結線済みコンポーネント（'use client'）。registry の二重渡しや
-// JSONUIProvider / Renderer の生 import が不要になる。
 import { JsonRenderUI } from '@k8o/arte-odyssey/json-render/registry';
 
-/**
- * クライアントコンポーネント。
- * サーバーから渡された spec（プレーン JSON）を arte-odyssey で描画する。
- */
 export function GenUiClient({ spec }: { spec: unknown }) {
   return <JsonRenderUI spec={spec as Spec} />;
 }

--- a/examples/nextjs/src/app/page.tsx
+++ b/examples/nextjs/src/app/page.tsx
@@ -1,11 +1,7 @@
-// ★ Server Component（'use client' なし）。
-// サーバー安全な catalog を import して、サーバー上で catalog.prompt() を実行する。
-// これが成立する＝ catalog が RSC のサーバー側で使える証拠。
 import { catalog } from '@k8o/arte-odyssey/json-render';
 
 import { GenUiClient } from './gen-ui-client';
 
-// 実運用では LLM が生成する spec。ここでは手書き（プレーン JSON）。
 const spec = {
   root: 'root',
   elements: {
@@ -61,7 +57,6 @@ const spec = {
 };
 
 export default function Home() {
-  // ← サーバー上でプロンプト生成（catalog がサーバー安全でないとここで失敗する）
   const systemPrompt = catalog.prompt();
   const promptChars = systemPrompt.length;
 

--- a/examples/vite/src/json-render/demo.tsx
+++ b/examples/vite/src/json-render/demo.tsx
@@ -1,13 +1,6 @@
 import type { ArteSpec } from '@k8o/arte-odyssey/json-render';
 import { JsonRenderUI } from '@k8o/arte-odyssey/json-render/registry';
 
-/**
- * 事前結線済みの `JsonRenderUI`（'use client'）に spec を渡すだけで描画できる。
- * プロンプト生成だけならサーバー安全な `@k8o/arte-odyssey/json-render`（catalog）。
- * spec（UIツリー）は実運用では LLM が生成する。ここでは手書きだが、
- * `satisfies ArteSpec` で component 名・props の typo がコンパイルエラーになる。
- * Stack は slots なので入れ子（横並びグループ）が自由にできる。
- */
 const spec = {
   root: 'root',
   elements: {

--- a/examples/vite/src/openui/demo.tsx
+++ b/examples/vite/src/openui/demo.tsx
@@ -2,9 +2,6 @@ import { library } from '@k8o/arte-odyssey/openui';
 import { Renderer } from '@openuidev/react-lang';
 
 /**
- * 公式アダプタ `@k8o/arte-odyssey/openui` の library をそのまま使う。
- * response（OpenUI Lang / DSL）は実運用では LLM がストリーム出力する。
- *
  * 注: OpenUI は型付き子要素。Card は Stack を内包できる（root を Card にして全体を包む）。
  * Stack 自身の入れ子は非対応。引数は位置引数（props 定義順）。
  */

--- a/packages/arte-odyssey/src/components/data-display/code/code.tsx
+++ b/packages/arte-odyssey/src/components/data-display/code/code.tsx
@@ -17,17 +17,14 @@ export const Code: FC<Props> = ({ children, ...rest }) => {
     );
   }
 
-  // 各色の前にカラースウォッチを挿入してコンテンツを構築
   const parts: React.ReactNode[] = [];
   let lastIndex = 0;
 
   for (const [index, colorInfo] of colors.entries()) {
-    // 色の前のテキストを追加
     if (colorInfo.start > lastIndex) {
       parts.push(children.slice(lastIndex, colorInfo.start));
     }
 
-    // 色のテキストの前にカラースウォッチを追加
     parts.push(
       <Fragment key={`color-${String(index)}`}>
         <span
@@ -43,7 +40,6 @@ export const Code: FC<Props> = ({ children, ...rest }) => {
     lastIndex = colorInfo.end;
   }
 
-  // 残りのテキストを追加
   if (lastIndex < children.length) {
     parts.push(children.slice(lastIndex));
   }

--- a/packages/arte-odyssey/src/components/data-display/code/find-all-colors.ts
+++ b/packages/arte-odyssey/src/components/data-display/code/find-all-colors.ts
@@ -9,7 +9,6 @@ const extractFunctionContent = (
   let match = funcPattern.exec(source);
 
   while (match !== null) {
-    // 開き括弧の位置
     const startIndex = match.index + match[0].length - 1;
     let depth = 0;
     let endIndex = -1;
@@ -57,7 +56,6 @@ export function findAllColors(text: string): ColorMatch[] {
     results.push(...matches);
   }
 
-  // HEX色を見つける
   const hexPattern = /#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})(?=\s|;|,|$|\)|\]|\})/gu;
   let hexMatch = hexPattern.exec(text);
   while (hexMatch !== null) {
@@ -70,7 +68,6 @@ export function findAllColors(text: string): ColorMatch[] {
     hexMatch = hexPattern.exec(text);
   }
 
-  // 名前付き色を見つける
   const namedColors = [
     'red',
     'blue',
@@ -102,14 +99,12 @@ export function findAllColors(text: string): ColorMatch[] {
     let startIndex = 0;
     let index = lowerText.indexOf(color, startIndex);
     while (index !== -1) {
-      // 完全な単語かどうかをチェック
       const beforeChar = index > 0 ? (lowerText[index - 1] ?? ' ') : ' ';
       const afterChar =
         index + color.length < lowerText.length
           ? (lowerText[index + color.length] ?? ' ')
           : ' ';
 
-      // 前後が英数字でないことを確認（完全一致のみ）
       const isWordBoundary = !(
         /[a-zA-Z0-9]/u.test(beforeChar) || /[a-zA-Z0-9]/u.test(afterChar)
       );
@@ -127,7 +122,6 @@ export function findAllColors(text: string): ColorMatch[] {
     }
   }
 
-  // 位置でソートし、重複を除去
   results.sort((a, b) => a.start - b.start);
   const filteredResults: Array<{
     color: string;

--- a/packages/arte-odyssey/src/components/icons/arte-odyssey.tsx
+++ b/packages/arte-odyssey/src/components/icons/arte-odyssey.tsx
@@ -18,10 +18,8 @@ const ArteOdysseyLogo: FC<{
       </linearGradient>
     </defs>
 
-    {/* ノード */}
     <circle cx="128" cy="250" r="20" fill="url(#arte-odyssey-g1)" />
 
-    {/* ドーム（上弧） */}
     <path
       d="M146 242 C158 155 215 90 300 78 C375 68 425 120 432 195 C436 235 420 268 392 282"
       stroke="url(#arte-odyssey-g1)"
@@ -29,7 +27,6 @@ const ArteOdysseyLogo: FC<{
       strokeLinecap="round"
     />
 
-    {/* ドーム（下弧） */}
     <path
       d="M146 258 C185 278 250 288 320 284 C355 280 378 274 392 265"
       stroke="url(#arte-odyssey-g1)"
@@ -37,7 +34,6 @@ const ArteOdysseyLogo: FC<{
       strokeLinecap="round"
     />
 
-    {/* 触手1 */}
     <path
       d="M200 286 C195 330 185 375 192 425"
       stroke="url(#arte-odyssey-g1)"
@@ -45,7 +41,6 @@ const ArteOdysseyLogo: FC<{
       strokeLinecap="round"
     />
 
-    {/* 触手2 */}
     <path
       d="M280 288 C282 332 288 378 298 430"
       stroke="url(#arte-odyssey-g1)"
@@ -53,7 +48,6 @@ const ArteOdysseyLogo: FC<{
       strokeLinecap="round"
     />
 
-    {/* 触手3 */}
     <path
       d="M350 280 C358 320 370 365 388 415"
       stroke="url(#arte-odyssey-g1)"

--- a/packages/arte-odyssey/src/components/navigation/tabs/tabs.tsx
+++ b/packages/arte-odyssey/src/components/navigation/tabs/tabs.tsx
@@ -62,7 +62,6 @@ const Root: FC<
 
   return (
     <TabsProvider value={contextValue}>
-      {/* TODO: スクロール以外の見せ方を考えても良さそう */}
       <div className="flex flex-col gap-1 overflow-x-auto p-0.5">
         {children}
       </div>

--- a/packages/arte-odyssey/src/components/overlays/popover/popover.tsx
+++ b/packages/arte-odyssey/src/components/overlays/popover/popover.tsx
@@ -67,7 +67,6 @@ const Root: FC<
     placement,
     open: isOpen,
     whileElementsMounted: autoUpdate,
-    // 要素と8pxだけ離す
     middleware: [
       offset(8),
       !flipDisabled &&

--- a/packages/arte-odyssey/src/hooks/client/index.ts
+++ b/packages/arte-odyssey/src/hooks/client/index.ts
@@ -4,9 +4,7 @@ import { useSyncExternalStore } from 'react';
 
 export const useClient = (): boolean =>
   useSyncExternalStore(
-    () => () => {
-      // なにもしない
-    },
+    () => () => {},
     () => true,
     () => false,
   );

--- a/packages/arte-odyssey/src/hooks/debounced-transition/index.test.ts
+++ b/packages/arte-odyssey/src/hooks/debounced-transition/index.test.ts
@@ -72,12 +72,8 @@ describe('useDebouncedTransition', () => {
     const { result } = await renderHook(() => useDebouncedTransition(20));
 
     result.current[1](aborting);
-    await vi.waitFor(() => {
-      // action が start するまで待つ
-    });
-    result.current[1](() => {
-      // 置き換えで前回を abort する
-    });
+    await vi.waitFor(() => {});
+    result.current[1](() => {});
 
     await new Promise<void>((resolve) => {
       setTimeout(resolve, 100);

--- a/packages/arte-odyssey/src/hooks/hash/index.ts
+++ b/packages/arte-odyssey/src/hooks/hash/index.ts
@@ -20,7 +20,6 @@ const subscribe = (callback: () => void) => {
     setTimeout(callback);
   };
 
-  // hash changeに応じてhashを更新
   window.addEventListener('hashchange', callback);
   return () => {
     window.removeEventListener('hashchange', callback);

--- a/packages/arte-odyssey/src/hooks/scroll-direction/index.test.ts
+++ b/packages/arte-odyssey/src/hooks/scroll-direction/index.test.ts
@@ -46,7 +46,6 @@ describe('useScrollDirection', () => {
     it('上にスクロールするとy: upを返す', async () => {
       const { result, act } = await renderHook(() => useScrollDirection());
 
-      // 最初に下にスクロール
       act(() => {
         Object.defineProperty(window, 'scrollY', { value: 200 });
         window.dispatchEvent(new Event('scroll'));
@@ -54,7 +53,6 @@ describe('useScrollDirection', () => {
 
       expect(result.current.y).toBe('down');
 
-      // 上にスクロール
       act(() => {
         Object.defineProperty(window, 'scrollY', { value: 100 });
         window.dispatchEvent(new Event('scroll'));
@@ -90,7 +88,6 @@ describe('useScrollDirection', () => {
     it('左にスクロールするとx: leftを返す', async () => {
       const { result, act } = await renderHook(() => useScrollDirection());
 
-      // 最初に右にスクロール
       act(() => {
         Object.defineProperty(window, 'scrollX', { value: 200 });
         window.dispatchEvent(new Event('scroll'));
@@ -98,7 +95,6 @@ describe('useScrollDirection', () => {
 
       expect(result.current.x).toBe('right');
 
-      // 左にスクロール
       act(() => {
         Object.defineProperty(window, 'scrollX', { value: 100 });
         window.dispatchEvent(new Event('scroll'));

--- a/packages/arte-odyssey/src/hooks/window-resize/index.test.ts
+++ b/packages/arte-odyssey/src/hooks/window-resize/index.test.ts
@@ -11,7 +11,6 @@ describe('useWindowResize', () => {
       useWindowResize(callback);
     });
 
-    // 初回のレンダリング時には呼ばれない
     expect(callback).not.toHaveBeenCalled();
 
     window.innerWidth = resizedWindowSize.width;

--- a/packages/arte-odyssey/src/hooks/writing-mode/index.ts
+++ b/packages/arte-odyssey/src/hooks/writing-mode/index.ts
@@ -6,7 +6,6 @@ export type WritingMode = 'horizontal' | 'vertical';
 
 const getServerSnapshot = (): WritingMode => 'horizontal';
 
-// writing-mode が `vertical-*` / `sideways-*` のいずれかなら 'vertical' として扱う。
 const resolve = (value: string): WritingMode =>
   value.startsWith('vertical') || value.startsWith('sideways')
     ? 'vertical'

--- a/packages/arte-odyssey/src/integrations/_shared/openui-defs.ts
+++ b/packages/arte-odyssey/src/integrations/_shared/openui-defs.ts
@@ -31,7 +31,6 @@ export const buildArteOdysseyLibrary = <C>(
   ) =>
     defineComponent({ name, description, props, component: render[name] as C });
 
-  // --- leaf / data / form（コンテナ以外） ---
   const Button = def(
     'Button',
     'アクションボタン。href を指定するとリンク（<a>）になる。',
@@ -202,7 +201,6 @@ export const buildArteOdysseyLibrary = <C>(
     s.formControlProps,
   );
 
-  // コンテナに入れられる leaf / data / form コンポーネント（Stack 自身は除く）。
   const childRefs = [
     Button.ref,
     IconButton.ref,
@@ -247,7 +245,6 @@ export const buildArteOdysseyLibrary = <C>(
     FormControl.ref,
   ] as const;
 
-  // Stack / Grid は leaf / form のみを子に取る（コンテナは入れられない）。
   const Stack = def(
     'Stack',
     '子要素を縦/横に等間隔で並べるレイアウトコンテナ。Stack の直下に Stack/Grid/Card は置けない。入れ子レイアウトが必要なら Card の中に Stack や Grid を入れる。',
@@ -263,7 +260,6 @@ export const buildArteOdysseyLibrary = <C>(
     }),
   );
 
-  // Stack / Grid を含めた汎用 child refs（コンテナの中身として使う）。
   const containerChildRefs = [...childRefs, Stack.ref, Grid.ref] as const;
 
   const Card = def(

--- a/packages/arte-odyssey/src/integrations/_shared/renderers.tsx
+++ b/packages/arte-odyssey/src/integrations/_shared/renderers.tsx
@@ -236,17 +236,12 @@ const iconMap = {
 const u = <T,>(value: T | null | undefined): T | undefined =>
   value ?? undefined;
 
-// ---------------------------------------------------------------------------
-// leaf renderers
-// ---------------------------------------------------------------------------
-
 export function renderButton(props: ButtonProps): ReactNode {
   const { label, href } = props;
   return (
     <Button
       color={u(props.color)}
       fullWidth={u(props.fullWidth)}
-      // ★ render props の橋渡し: href（文字列）から renderItem を内部生成。
       renderItem={
         href !== undefined && href !== ''
           ? ({ className, children }) => (
@@ -297,10 +292,6 @@ export function renderSeparator(props: SeparatorProps): ReactNode {
   );
 }
 
-// ---------------------------------------------------------------------------
-// containers (children は各 FW が描画して渡す)
-// ---------------------------------------------------------------------------
-
 // The bare Card has no padding and the generative catalog has no className
 // escape hatch, so map the integration `size` to a sensible inner padding
 // (default md). Mirrors the size→padding convention in Chakra / Fluent / Radix.
@@ -321,10 +312,6 @@ export function renderCard(props: CardProps, children: ReactNode): ReactNode {
     </Card>
   );
 }
-
-// ---------------------------------------------------------------------------
-// tabs（テキストパネルのデータ駆動版）
-// ---------------------------------------------------------------------------
 
 // Tabs は ARIA の `aria-controls` / `aria-labelledby` で ID を参照するため、
 // 同一ページに複数描画されても衝突しないよう `useId()` で生成する必要がある。
@@ -357,10 +344,6 @@ export function renderTabs(props: TabsProps): ReactNode {
   return <TabsView props={props} />;
 }
 
-// ---------------------------------------------------------------------------
-// layout
-// ---------------------------------------------------------------------------
-
 export function renderStack(props: StackProps, children: ReactNode): ReactNode {
   return (
     <Stack
@@ -386,10 +369,6 @@ export function renderGrid(props: GridProps, children: ReactNode): ReactNode {
     </Grid>
   );
 }
-
-// ---------------------------------------------------------------------------
-// form renderers (値とセッターは各 FW の状態機構から渡す)
-// ---------------------------------------------------------------------------
 
 export function renderTextField(
   props: TextFieldProps,
@@ -648,10 +627,6 @@ export function renderPagination(
   );
 }
 
-// ---------------------------------------------------------------------------
-// leaf / display (追加分)
-// ---------------------------------------------------------------------------
-
 export function renderIcon(props: IconProps): ReactNode {
   const IconComponent = iconMap[props.name];
   return <IconComponent size={u(props.size) ?? 'md'} />;
@@ -664,9 +639,6 @@ export function renderChevronIcon(props: ChevronIconProps): ReactNode {
   );
 }
 
-// arte-odyssey の AlertIcon を「StatusIcon」として公開（status は文脈と分かるが、
-// 生成 UI 利用者からは AlertIcon という名前だと「Alert コンポーネントを使え」と
-// 誤解されやすいため改名）。
 export function renderStatusIcon(props: StatusIconProps): ReactNode {
   return <AlertIcon size={u(props.size) ?? 'md'} status={props.status} />;
 }
@@ -724,10 +696,6 @@ export function renderSkeleton(props: SkeletonProps): ReactNode {
     />
   );
 }
-
-// ---------------------------------------------------------------------------
-// data-driven (items 配列)
-// ---------------------------------------------------------------------------
 
 export function renderAccordion(props: AccordionProps): ReactNode {
   return (
@@ -798,20 +766,10 @@ export function renderTable(props: TableProps): ReactNode {
   );
 }
 
-// ---------------------------------------------------------------------------
-// containers (children を持つ追加分)
-// ---------------------------------------------------------------------------
-
 export function renderForm(props: FormProps, children: ReactNode): ReactNode {
   return <Form action={u(props.action)}>{children}</Form>;
 }
 
-// ---------------------------------------------------------------------------
-// overlays（自己完結ウィジェット: トリガーボタン＋コンテンツ、開閉は内部 state）
-// ---------------------------------------------------------------------------
-
-// Modal/Dialog ウィジェットはトリガーボタン＋Modal＋Dialog の骨格を共有する。
-// 差分はトリガーボタンの見た目と Modal の type のみ。
 const OverlayWidget: FC<{
   triggerLabel: string;
   title: string;
@@ -969,10 +927,6 @@ export function renderDropdownMenu(props: DropdownMenuProps): ReactNode {
   );
 }
 
-// ---------------------------------------------------------------------------
-// leaf / data 追加分
-// ---------------------------------------------------------------------------
-
 export function renderScrollLinked(_props: ScrollLinkedProps): ReactNode {
   return <ScrollLinked />;
 }
@@ -981,11 +935,7 @@ export function renderBaselineStatus(props: BaselineStatusProps): ReactNode {
   return <BaselineStatus featureId={props.featureId} />;
 }
 
-// ---------------------------------------------------------------------------
-// Toast: トースト発火ボタンを生成 UI から扱うためのウィジェット。
 // ToastProvider はラッパー側で巻く必要があるため、ローカルにも 1 段被せる。
-// ---------------------------------------------------------------------------
-
 const ToastTriggerInner: FC<{ props: ToastProps }> = ({ props }) => {
   const { onOpen } = useToast();
   return (
@@ -1005,10 +955,6 @@ export const ToastWidget: FC<{ props: ToastProps }> = ({ props }) => (
     <ToastTriggerInner props={props} />
   </ToastProvider>
 );
-
-// ---------------------------------------------------------------------------
-// form 追加分
-// ---------------------------------------------------------------------------
 
 export function renderListBox(
   props: ListBoxProps,
@@ -1088,8 +1034,6 @@ export const FileFieldWidget: FC<{ props: FileFieldProps }> = ({ props }) => (
   </FileField.Root>
 );
 
-// FormControl: text/textarea/password のいずれかの入力をラベル＋ヘルプ/エラー付きで包む。
-// 自己完結ウィジェット（入力値はローカル state）。
 export const FormControlWidget: FC<{ props: FormControlProps }> = ({
   props,
 }) => {

--- a/packages/arte-odyssey/src/integrations/_shared/schemas.ts
+++ b/packages/arte-odyssey/src/integrations/_shared/schemas.ts
@@ -54,10 +54,6 @@ const safeUrl = z
   .string()
   .regex(/^(https?:\/\/|\/)/u, '外部 URL（http/https）または相対 URL のみ許可');
 
-// ---------------------------------------------------------------------------
-// buttons
-// ---------------------------------------------------------------------------
-
 type ButtonIntegrationProps = {
   label: string;
   variant?: ComponentProps<typeof Button>['variant'];
@@ -171,10 +167,6 @@ export const statusIconProps = z.object({
   size: z.enum(['sm', 'md', 'lg']).optional(),
 }) satisfies z.ZodType<StatusIconIntegrationProps>;
 
-// ---------------------------------------------------------------------------
-// data-display
-// ---------------------------------------------------------------------------
-
 type BadgeIntegrationProps = {
   text: string;
   tone?: ComponentProps<typeof Badge>['tone'];
@@ -267,7 +259,7 @@ type CardIntegrationProps = {
   appearance?: ComponentProps<typeof Card>['appearance'];
   interactive?: ComponentProps<typeof Card>['interactive'];
   // Integration-only: the bare Card has no padding, so `size` drives the
-  // generated card's inner padding (sm/md/lg). Hand-written abstraction.
+  // generated card's inner padding (sm/md/lg).
   size?: 'sm' | 'md' | 'lg';
 };
 export const cardProps = z.object({
@@ -276,10 +268,6 @@ export const cardProps = z.object({
   interactive: z.boolean().optional(),
   size: z.enum(['sm', 'md', 'lg']).optional(),
 }) satisfies z.ZodType<CardIntegrationProps>;
-
-// ---------------------------------------------------------------------------
-// feedback
-// ---------------------------------------------------------------------------
 
 type AlertIntegrationProps = {
   tone: ComponentProps<typeof Alert>['tone'];
@@ -333,10 +321,6 @@ export const toastProps = z.object({
   tone: z.enum(['success', 'info', 'warning', 'error']),
   message: z.string(),
 }) satisfies z.ZodType<ToastIntegrationProps>;
-
-// ---------------------------------------------------------------------------
-// layout
-// ---------------------------------------------------------------------------
 
 type SeparatorIntegrationProps = {
   orientation?: ComponentProps<typeof Separator>['orientation'];
@@ -403,10 +387,6 @@ export const baselineStatusProps = z.object({
   featureId: z.string().describe('Web feature の ID'),
 }) satisfies z.ZodType<BaselineStatusIntegrationProps>;
 
-// ---------------------------------------------------------------------------
-// navigation
-// ---------------------------------------------------------------------------
-
 type AnchorIntegrationProps = {
   text: string;
   href: string;
@@ -468,10 +448,6 @@ export const tabsProps = z.object({
     .min(1)
     .describe('各タブのラベルとテキストパネル'),
 }) satisfies z.ZodType<TabsIntegrationProps>;
-
-// ---------------------------------------------------------------------------
-// form （多くは name + defaultValue ベースの独自抽象）
-// ---------------------------------------------------------------------------
 
 type TextFieldIntegrationProps = {
   name: string;
@@ -713,12 +689,8 @@ export const formProps = z.object({
   action: safeUrl.optional().describe('送信先 URL（任意）'),
 }) satisfies z.ZodType<FormIntegrationProps>;
 
-// ---------------------------------------------------------------------------
-// overlays（generative UI 用に自己完結ウィジェット化したコンポーネント。
-//          本体側は isOpen/onClose の命令的 API なので、ここでは triggerLabel +
-//          children のみを zod に乗せる）
-// ---------------------------------------------------------------------------
-
+// 本体側は isOpen/onClose の命令的 API なので、ここでは triggerLabel +
+// children のみを zod に乗せる。
 type ModalIntegrationProps = {
   triggerLabel: string;
   title: string;
@@ -769,10 +741,6 @@ export const dropdownMenuProps = z.object({
     .min(1)
     .describe('メニュー項目'),
 }) satisfies z.ZodType<DropdownMenuIntegrationProps>;
-
-// ---------------------------------------------------------------------------
-// inferred types（renderers.tsx と registry が利用する）
-// ---------------------------------------------------------------------------
 
 export type ButtonProps = z.infer<typeof buttonProps>;
 export type BadgeProps = z.infer<typeof badgeProps>;
@@ -825,14 +793,9 @@ export type AutocompleteProps = z.infer<typeof autocompleteProps>;
 export type FileFieldProps = z.infer<typeof fileFieldProps>;
 export type FormControlProps = z.infer<typeof formControlProps>;
 
-// ---------------------------------------------------------------------------
-// widening 検査
-//
 // satisfies は enum の narrowing しか検知しない。本体が値を追加したときの
 // 追従漏れを塞ぐため、本体ユニオンが schema の enum に被覆されているかを型で
 // 検査する。本体に値が増えると AssertCovered の制約違反でコンパイルが止まる。
-// ---------------------------------------------------------------------------
-
 type CoversComponent<Component, Zod> = [
   Exclude<NonNullable<Component>, Zod>,
 ] extends [never]

--- a/packages/arte-odyssey/src/integrations/json-render/catalog.ts
+++ b/packages/arte-odyssey/src/integrations/json-render/catalog.ts
@@ -233,13 +233,10 @@ export const arteOdysseyRules: readonly string[] = [
   'Tabs と Accordion の content はプレーンテキストのみ。コンポーネントは入れ子にできない。',
 ];
 
-/** catalog に登録されたコンポーネント定義のマップ（型レベル）。 */
 type ComponentSchemas = (typeof catalog)['data']['components'];
 
-/** catalog に登録されたコンポーネント名のユニオン。 */
 export type ComponentName = keyof ComponentSchemas;
 
-/** 指定したコンポーネントの props 型（Zod スキーマから推論）。 */
 export type ComponentProps<K extends ComponentName> = z.infer<
   ComponentSchemas[K]['props']
 >;
@@ -275,7 +272,6 @@ export type ArteSpec = {
   state?: Spec['state'];
 };
 
-/** 検証で見つかった 1 件の問題。 */
 export type GeneratedSpecIssue = {
   /** 問題のあった要素キー（spec 全体の問題なら未指定）。 */
   elementKey?: string;
@@ -283,7 +279,6 @@ export type GeneratedSpecIssue = {
   message: string;
 };
 
-/** {@link validateGeneratedSpec} の結果。 */
 export type ValidateGeneratedSpecResult =
   | { ok: true; spec: ArteSpec; fixes: string[] }
   | { ok: false; issues: GeneratedSpecIssue[]; repairPrompt: string };

--- a/packages/arte-odyssey/src/integrations/json-render/registry.tsx
+++ b/packages/arte-odyssey/src/integrations/json-render/registry.tsx
@@ -86,7 +86,6 @@ export const { registry } = defineRegistry(catalog, {
       return ui.renderSelect(props, value, setValue);
     },
 
-    // 表示・データ駆動（状態なし）
     Anchor: ({ props }) => ui.renderAnchor(props),
     Avatar: ({ props }) => ui.renderAvatar(props),
     Code: ({ props }) => ui.renderCode(props),
@@ -100,7 +99,6 @@ export const { registry } = defineRegistry(catalog, {
     Breadcrumb: ({ props }) => ui.renderBreadcrumb(props),
     Table: ({ props }) => ui.renderTable(props),
 
-    // フォーム（文字列）
     Textarea: ({ props, bindings }) => {
       const [value, setValue] = useBoundOrLocal<string>(
         props.defaultValue,
@@ -136,7 +134,6 @@ export const { registry } = defineRegistry(catalog, {
       return ui.renderRadioCard(props, value, setValue);
     },
 
-    // フォーム（数値）
     NumberField: ({ props, bindings }) => {
       const [value, setValue] = useBoundOrLocal<number>(
         props.defaultValue,
@@ -155,7 +152,6 @@ export const { registry } = defineRegistry(catalog, {
       return ui.renderSlider(props, value, setValue);
     },
 
-    // フォーム（複数選択）
     CheckboxCard: ({ props, bindings }) => {
       const [value, setValue] = useBoundOrLocal<string[]>(
         props.defaultValue,
@@ -165,7 +161,6 @@ export const { registry } = defineRegistry(catalog, {
       return ui.renderCheckboxCard(props, value, setValue);
     },
 
-    // ページネーション（defaultPage を $bindState で束縛、無ければローカル状態）
     Pagination: ({ props, bindings }) => {
       const [page, setPage] = useBoundOrLocal<number>(
         props.defaultPage,
@@ -175,10 +170,8 @@ export const { registry } = defineRegistry(catalog, {
       return ui.renderPagination(props, page, setPage);
     },
 
-    // コンテナ追加
     Form: ({ props, children }) => ui.renderForm(props, children),
 
-    // オーバーレイ（自己完結ウィジェット）
     Modal: ({ props, children }) => (
       <ui.ModalWidget props={props}>{children}</ui.ModalWidget>
     ),
@@ -193,11 +186,9 @@ export const { registry } = defineRegistry(catalog, {
     DropdownMenu: ({ props }) => ui.renderDropdownMenu(props),
     Toast: ({ props }) => <ui.ToastWidget props={props} />,
 
-    // leaf 追加
     ScrollLinked: ({ props }) => ui.renderScrollLinked(props),
     BaselineStatus: ({ props }) => ui.renderBaselineStatus(props),
 
-    // フォーム追加
     ListBox: ({ props, bindings }) => {
       const path = bindings?.defaultValue;
       const hasBinding = path !== undefined && path !== '';

--- a/packages/arte-odyssey/src/integrations/openui/form-views.tsx
+++ b/packages/arte-odyssey/src/integrations/openui/form-views.tsx
@@ -9,16 +9,6 @@ import type { FC } from 'react';
 import * as ui from '../_shared/renderers';
 import type * as s from '../_shared/schemas';
 
-/**
- * OpenUI のフォーム状態（`useStateField`）に接続する関数コンポーネント群。
- *
- * `defineComponent` の `component` フィールドにそのまま渡せる FC として実装する。
- * フックを使うので React の rules-of-hooks を満たす大文字始まり関数として
- * 定義する必要があり、`library.tsx` の宣言的な `defineComponent` 並びから
- * 切り出してここに集約した。値域と setter の解決だけを担当し、見た目の組み立て
- * は `_shared/renderers` の `renderXxx` に委譲する。
- */
-
 export const TextFieldView: FC<ComponentRenderProps<s.TextFieldProps>> = ({
   props,
 }) => {

--- a/packages/arte-odyssey/src/integrations/openui/library.tsx
+++ b/packages/arte-odyssey/src/integrations/openui/library.tsx
@@ -41,7 +41,6 @@ import {
  * 入れ子は非対応（Card には Stack/Grid を入れられる）。
  */
 
-// 子要素を持つコンテナの props（children は描画対象のサブコンポーネント配列）。
 type ContainerRenderProps<P> = ComponentRenderProps<
   P & { children: ReadonlyArray<{ typeName: string }> }
 >;
@@ -56,10 +55,7 @@ const renderChildren = (
     <Fragment key={`${child.typeName}-${index}`}>{renderNode(child)}</Fragment>
   ));
 
-// 各コンポーネントの描画関数。スキーマ・説明・子要素構成は openui-defs 側にある。
-// 各 props はスキーマ由来の型で注釈し、ファクトリには描画関数の union として渡す。
 const renderers = {
-  // コンテナ
   Stack: ({ props, renderNode }: ContainerRenderProps<sc.StackProps>) =>
     ui.renderStack(props, renderChildren(props.children, renderNode)),
   Grid: ({ props, renderNode }: ContainerRenderProps<sc.GridProps>) =>
@@ -69,7 +65,6 @@ const renderers = {
   Form: ({ props, renderNode }: ContainerRenderProps<sc.FormProps>) =>
     ui.renderForm(props, renderChildren(props.children, renderNode)),
 
-  // オーバーレイ（自己完結ウィジェット）
   Modal: ({ props, renderNode }: ContainerRenderProps<sc.ModalProps>) => (
     <ui.ModalWidget props={props}>
       {renderChildren(props.children, renderNode)}
@@ -95,7 +90,6 @@ const renderers = {
     <ui.ToastWidget props={props} />
   ),
 
-  // leaf / data（状態なし）
   Button: ({ props }: ComponentRenderProps<sc.ButtonProps>) =>
     ui.renderButton(props),
   IconButton: ({ props }: ComponentRenderProps<sc.IconButtonProps>) =>
@@ -136,7 +130,6 @@ const renderers = {
   Table: ({ props }: ComponentRenderProps<sc.TableProps>) =>
     ui.renderTable(props),
 
-  // フォーム（hook を呼ぶ View FC は form-views へ切り出し済み）
   TextField: TextFieldView,
   Textarea: TextareaView,
   PasswordInput: PasswordInputView,

--- a/packages/arte-odyssey/src/styles/base.css
+++ b/packages/arte-odyssey/src/styles/base.css
@@ -65,7 +65,6 @@
   }
 }
 
-/* dark・light themeの値を使うための宣言 */
 @custom-variant dark (&:where(.dark, .dark *));
 @custom-variant light (&:where(.light, .light *));
 

--- a/packages/arte-odyssey/src/styles/tokens.css
+++ b/packages/arte-odyssey/src/styles/tokens.css
@@ -299,7 +299,6 @@
   --color-transparent: transparent;
   --color-back-drop: var(--back-drop);
 
-  /* group */
   --color-group-primary: var(--group-primary);
   --color-group-secondary: var(--group-secondary);
   --color-group-tertiary: var(--group-tertiary);


### PR DESCRIPTION
## 概要

リポジトリ全体から、コードを読めば自明な内容や実装の経緯・背景を説明するだけの不要なコメントを削除した。

## 動機

コードから読み取れる情報の重複や、実装時の背景説明（コミット履歴から辿れる）がコメントとして残っており、ノイズになっていた。本当に必要なコメントだけを残すことで可読性を上げる。

## 詳細

削除したもの:
- コードが示す内容をそのまま言い換えただけのコメント（空処理への `// なにもしない`、docs 各ページの `{/* Header */}` `{/* Import */}` `{/* Props */}` などのセクションラベル等）
- 実装の経緯・背景・変更理由を述べるだけのコメント（`// ★ Server Component…`、`// 事前結線済み…` などのチュートリアル的記述）
- 純粋な装飾目的の区切り/バナーコメント（`schemas.ts` / `renderers.tsx` の `// ----- buttons -----` ブロック等）

残したもの:
- lint / 型チェックのディレクティブ（`oxlint-disable`、`@ts-expect-error`、`'use client'` 等）
- ライセンスヘッダー
- コードからは読み取れない「なぜ」を説明するコメント（型による網羅検査の意図、Card の `size`→padding、ARIA の `useId` 衝突回避、writing-mode と ResizeObserver の関係、`vite.config.ts` の lint ルール無効化理由 など）
- ドキュメントページ内に表示用として埋め込まれたサンプルコード（文字列リテラル内のコメント）

規模: 79 ファイル変更、コメント行は約 736 → 278 に減少。

## 気をつけるポイント

- ディレクティブ系コメントを誤って削除していないか（`@ts-expect-error` 1件 / `oxlint-disable` 系 13件はそのまま、`'use client'` 文も維持）
- docs ページの表示用サンプルコード内のコメントは変更していない

## 影響範囲

コメントのみの削除でコードの挙動・公開ビルド成果物への影響はなし。

## テスト

build / typecheck（5プロジェクト）/ lint / format / test（313件）すべてパスを確認済み。