### PR TITLE
feat: add storybook-addon-determinism for deterministic stories

### DIFF
--- a/packages/arte-odyssey/.storybook/main.ts
+++ b/packages/arte-odyssey/.storybook/main.ts
@@ -8,6 +8,7 @@ const config: StorybookConfig = {
     '@storybook/addon-docs',
     '@storybook/addon-mcp',
     'storybook-addon-mock-date',
+    'storybook-addon-determinism',
     '@chromatic-com/storybook',
   ],
   framework: {

--- a/packages/arte-odyssey/.storybook/preview.tsx
+++ b/packages/arte-odyssey/.storybook/preview.tsx
@@ -62,6 +62,7 @@ const preview: Preview = {
     backgrounds: { disable: true },
     layout: 'fullscreen',
     mockingDate: new Date(2023, 0, 2, 12, 34, 56),
+    determinism: true,
     a11y: {
       test: 'error',
     },

--- a/packages/arte-odyssey/package.json
+++ b/packages/arte-odyssey/package.json
@@ -119,6 +119,7 @@
     "react": "catalog:",
     "react-dom": "catalog:",
     "storybook": "10.4.1",
+    "storybook-addon-determinism": "0.1.1",
     "storybook-addon-mock-date": "3.0.2",
     "storybook-addon-vrt": "0.1.0",
     "tailwind-token-extractor": "0.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,6 +297,9 @@ importers:
       storybook:
         specifier: 10.4.1
         version: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@2.8.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plus@0.1.23(@types/node@24.12.4)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.7)(jiti@2.7.0)(typescript@6.0.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)))
+      storybook-addon-determinism:
+        specifier: 0.1.1
+        version: 0.1.1(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@2.8.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plus@0.1.23(@types/node@24.12.4)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.7)(jiti@2.7.0)(typescript@6.0.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0))))
       storybook-addon-mock-date:
         specifier: 3.0.2
         version: 3.0.2(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@2.8.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plus@0.1.23(@types/node@24.12.4)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.7)(jiti@2.7.0)(typescript@6.0.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0))))
@@ -3538,6 +3541,12 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
+  storybook-addon-determinism@0.1.1:
+    resolution: {integrity: sha512-VEK2gaauPL79b+T1GlmXjKJuZeqNvfrIETh7kPWzPXQ69agfHQ7dhsGySLtPmBWO11i+ZKTk+ElLghRiDBxiZg==}
+    engines: {node: '>=22.0.0'}
+    peerDependencies:
+      storybook: ^10.0.0
+
   storybook-addon-mock-date@3.0.2:
     resolution: {integrity: sha512-B7ulwhdt3xpTDAUZVX5VCoMPk4xU1oJXVqlu7/Dbp3h+5hOtJ9FSAy6YVv7kfhhkCmVwX+Aty4evt6VU+LOMTw==}
     engines: {node: '>=22.0.0'}
@@ -6767,6 +6776,10 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@4.1.0: {}
+
+  storybook-addon-determinism@0.1.1(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@2.8.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plus@0.1.23(@types/node@24.12.4)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.7)(jiti@2.7.0)(typescript@6.0.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)))):
+    dependencies:
+      storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@2.8.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plus@0.1.23(@types/node@24.12.4)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.7)(jiti@2.7.0)(typescript@6.0.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)))
 
   storybook-addon-mock-date@3.0.2(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@2.8.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plus@0.1.23(@types/node@24.12.4)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(esbuild@0.27.7)(jiti@2.7.0)(typescript@6.0.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)))):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,6 +32,7 @@ minimumReleaseAge: 10080
 
 minimumReleaseAgeExclude:
   - '@k8o/*'
+  - 'storybook-addon-determinism'
   - 'storybook-addon-vrt'
   - 'tailwind-token-extractor'
   - 'vite-plus-inspector'


### PR DESCRIPTION
## Summary

Introduce `storybook-addon-determinism@0.1.1` so stories that rely on `Math.random()` / `crypto.randomUUID()` / `crypto.getRandomValues()` render deterministically, stabilizing VRT snapshots.

## Details

- Register the addon in `.storybook/main.ts`
- Enable `determinism: true` globally in `.storybook/preview.tsx` (alongside the existing `mockingDate`)
- Add the dependency to `packages/arte-odyssey/package.json`
- Add it to `minimumReleaseAgeExclude` in `pnpm-workspace.yaml` — it was just published, so it would otherwise be blocked by the 7-day `minimumReleaseAge`

## Notes

- Composes with `storybook-addon-mock-date` (entropy vs. clock — separate concerns). Unlike `mockingDate`, the determinism patch never throws, so enabling it globally is safe; opt a story out with `determinism: false`.

## Test

- `pnpm install` resolves `storybook-addon-determinism@0.1.1` against `storybook@10.4.1`
- `vp check` (oxc lint / format) passes
- `build-storybook` completes successfully with the addon registered
