### PR TITLE
fix: アイコンを lucide-react の個別ファイルから import する

### DIFF
--- a/.changeset/fix-lucide-deep-imports.md
+++ b/.changeset/fix-lucide-deep-imports.md
@@ -1,0 +1,5 @@
+---
+"@k8o/arte-odyssey": patch
+---
+
+アイコンを lucide-react のバレル（巨大な再エクスポート）ではなく個別ファイルから import するようにした。バレル import は Vite dev サーバの事前バンドルで named export が undefined 化し、consumer 側でアイコンが描画時に落ちることがあったため、それを回避する（本番ビルドでは元から問題なし）。

--- a/packages/arte-odyssey/src/components/icons/lucide-deep.d.ts
+++ b/packages/arte-odyssey/src/components/icons/lucide-deep.d.ts
@@ -1,0 +1,9 @@
+// lucide-react の個別アイコンファイル（dist/esm/icons/*.mjs）には型宣言が無いため、
+// deep import に型を与える。実体は LucideIcon（forwardRef コンポーネント）。
+// バレル import を避けて Vite dev の事前バンドル不具合（named export の undefined 化）を回避する。
+declare module 'lucide-react/dist/esm/icons/*' {
+  import type { LucideIcon } from 'lucide-react';
+
+  const icon: LucideIcon;
+  export default icon;
+}

--- a/packages/arte-odyssey/src/components/icons/lucide-imports.ts
+++ b/packages/arte-odyssey/src/components/icons/lucide-imports.ts
@@ -1,0 +1,121 @@
+/* eslint-disable import/max-dependencies -- lucide-react のバレル(約1700件の再エクスポート)は
+   Vite dev の事前バンドルで named export が undefined 化し、アイコンが描画時に落ちる。
+   個別アイコンファイルを直接 import して回避する。本ファイルはその集約専用。 */
+
+import Accessibility from 'lucide-react/dist/esm/icons/accessibility.mjs';
+import Angry from 'lucide-react/dist/esm/icons/angry.mjs';
+import Annoyed from 'lucide-react/dist/esm/icons/annoyed.mjs';
+import Atom from 'lucide-react/dist/esm/icons/atom.mjs';
+import Bell from 'lucide-react/dist/esm/icons/bell.mjs';
+import Blend from 'lucide-react/dist/esm/icons/blend.mjs';
+import BookOpenText from 'lucide-react/dist/esm/icons/book-open-text.mjs';
+import BookText from 'lucide-react/dist/esm/icons/book-text.mjs';
+import Bookmark from 'lucide-react/dist/esm/icons/bookmark.mjs';
+import Bot from 'lucide-react/dist/esm/icons/bot.mjs';
+import Calendar from 'lucide-react/dist/esm/icons/calendar.mjs';
+import Check from 'lucide-react/dist/esm/icons/check.mjs';
+import ChevronDown from 'lucide-react/dist/esm/icons/chevron-down.mjs';
+import ChevronLeft from 'lucide-react/dist/esm/icons/chevron-left.mjs';
+import ChevronRight from 'lucide-react/dist/esm/icons/chevron-right.mjs';
+import ChevronUp from 'lucide-react/dist/esm/icons/chevron-up.mjs';
+import CircleAlert from 'lucide-react/dist/esm/icons/circle-alert.mjs';
+import CircleCheck from 'lucide-react/dist/esm/icons/circle-check.mjs';
+import ClipboardPenLine from 'lucide-react/dist/esm/icons/clipboard-pen-line.mjs';
+import Clock from 'lucide-react/dist/esm/icons/clock.mjs';
+import Contrast from 'lucide-react/dist/esm/icons/contrast.mjs';
+import Droplets from 'lucide-react/dist/esm/icons/droplets.mjs';
+import ExternalLink from 'lucide-react/dist/esm/icons/external-link.mjs';
+import EyeOff from 'lucide-react/dist/esm/icons/eye-off.mjs';
+import Eye from 'lucide-react/dist/esm/icons/eye.mjs';
+import FlaskConical from 'lucide-react/dist/esm/icons/flask-conical.mjs';
+import History from 'lucide-react/dist/esm/icons/history.mjs';
+import Info from 'lucide-react/dist/esm/icons/info.mjs';
+import Laugh from 'lucide-react/dist/esm/icons/laugh.mjs';
+import Lightbulb from 'lucide-react/dist/esm/icons/lightbulb.mjs';
+import Link from 'lucide-react/dist/esm/icons/link.mjs';
+import ListMinus from 'lucide-react/dist/esm/icons/list-minus.mjs';
+import List from 'lucide-react/dist/esm/icons/list.mjs';
+import Mail from 'lucide-react/dist/esm/icons/mail.mjs';
+import MapPin from 'lucide-react/dist/esm/icons/map-pin.mjs';
+import Minus from 'lucide-react/dist/esm/icons/minus.mjs';
+import MoonStar from 'lucide-react/dist/esm/icons/moon-star.mjs';
+import Package from 'lucide-react/dist/esm/icons/package.mjs';
+import PaintBucket from 'lucide-react/dist/esm/icons/paint-bucket.mjs';
+import Palette from 'lucide-react/dist/esm/icons/palette.mjs';
+import Plus from 'lucide-react/dist/esm/icons/plus.mjs';
+import Presentation from 'lucide-react/dist/esm/icons/presentation.mjs';
+import Rocket from 'lucide-react/dist/esm/icons/rocket.mjs';
+import Rss from 'lucide-react/dist/esm/icons/rss.mjs';
+import Send from 'lucide-react/dist/esm/icons/send.mjs';
+import ShieldCheck from 'lucide-react/dist/esm/icons/shield-check.mjs';
+import Smile from 'lucide-react/dist/esm/icons/smile.mjs';
+import Sparkles from 'lucide-react/dist/esm/icons/sparkles.mjs';
+import Squircle from 'lucide-react/dist/esm/icons/squircle.mjs';
+import Sun from 'lucide-react/dist/esm/icons/sun.mjs';
+import Table2 from 'lucide-react/dist/esm/icons/table-2.mjs';
+import Tag from 'lucide-react/dist/esm/icons/tag.mjs';
+import AlignRight from 'lucide-react/dist/esm/icons/text-align-end.mjs';
+import ThumbsDown from 'lucide-react/dist/esm/icons/thumbs-down.mjs';
+import ThumbsUp from 'lucide-react/dist/esm/icons/thumbs-up.mjs';
+import TriangleAlert from 'lucide-react/dist/esm/icons/triangle-alert.mjs';
+import X from 'lucide-react/dist/esm/icons/x.mjs';
+
+export {
+  Accessibility,
+  AlignRight,
+  Angry,
+  Annoyed,
+  Atom,
+  Bell,
+  Blend,
+  Bookmark,
+  BookOpenText,
+  BookText,
+  Bot,
+  Calendar,
+  Check,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  ChevronUp,
+  CircleAlert,
+  CircleCheck,
+  ClipboardPenLine,
+  Clock,
+  Contrast,
+  Droplets,
+  ExternalLink,
+  Eye,
+  EyeOff,
+  FlaskConical,
+  History,
+  Info,
+  Laugh,
+  Lightbulb,
+  Link,
+  List,
+  ListMinus,
+  Mail,
+  MapPin,
+  Minus,
+  MoonStar,
+  Package,
+  PaintBucket,
+  Palette,
+  Plus,
+  Presentation,
+  Rocket,
+  Rss,
+  Send,
+  ShieldCheck,
+  Smile,
+  Sparkles,
+  Squircle,
+  Sun,
+  Table2,
+  Tag,
+  ThumbsDown,
+  ThumbsUp,
+  TriangleAlert,
+  X,
+};

--- a/packages/arte-odyssey/src/components/icons/lucide.tsx
+++ b/packages/arte-odyssey/src/components/icons/lucide.tsx
@@ -1,3 +1,7 @@
+import type { FC } from 'react';
+
+import type { Direction, Status } from './../../types/variables';
+import { BaseIcon, type BaseIconProps } from './base';
 import {
   Accessibility,
   AlignRight,
@@ -56,11 +60,7 @@ import {
   ThumbsUp,
   TriangleAlert,
   X,
-} from 'lucide-react';
-import type { FC } from 'react';
-
-import type { Direction, Status } from './../../types/variables';
-import { BaseIcon, type BaseIconProps } from './base';
+} from './lucide-imports';
 
 type IconProps = Partial<BaseIconProps>;
 


### PR DESCRIPTION
## 何を直すか

`@k8o/arte-odyssey` のアイコン（`BaseIcon` でラップした lucide-react ベースのアイコン群）が、**Vite dev サーバを使う consumer 側で描画時に落ちる**ことがある問題を修正する。

```
Element type is invalid: expected a string ... but got: undefined.
Check the render method of `BaseIcon`.
```

## 原因

`lucide.tsx` は `import { Check, X, ... } from 'lucide-react'` のように**バレル**（約1,700件の `export { default as X } from './icons/x.mjs'` を集めた再エクスポートファイル）から import していた。

lucide-react@1.17.0 は `exports` フィールドを持たず、ESM 実体がこの巨大バレル。**Vite dev の esbuild 事前バンドル**がこのバレルの named export を解決しきれず `undefined` に化けることがあり、その結果 `<BaseIcon renderItem={(p) => <Check {...p} />} />` の `Check` が `undefined` となって React が描画時にクラッシュする。

- **本番ビルド（Rollup）では再現しない** — Rollup は同じバレルを正しく解決する。Vite dev（esbuild optimizer）に固有の問題。
- arte-odyssey 自身の Storybook では出ていなかったが、このパッケージを依存に持ち Vite dev で動かす consumer（生成UIのライブプレビュー等）で顕在化した。

## 直し方

バレルを経由せず、**個別アイコンファイルを deep import** して回避する。

- `lucide-imports.ts`（新規）: 使用する 57 アイコンを `lucide-react/dist/esm/icons/<name>.mjs` から個別 import し、まとめて再エクスポート。バレルを踏まない。
- `lucide-deep.d.ts`（新規）: deep import 先の `.mjs` には型宣言が無いため、`declare module 'lucide-react/dist/esm/icons/*'` で `LucideIcon` 型を与える。
- `lucide.tsx`（変更）: import 元を `'lucide-react'` から `'./lucide-imports'` に差し替え。アイコンの実体・props・公開 API は不変。

## トレードオフ

deep path（`dist/esm/icons/*.mjs`）は lucide-react の dist 構造に依存する。lucide のメジャー更新でディレクトリ構成が変わると追従が必要になる（その場合 `lucide-imports.ts` の解決が壊れて即検知できる）。アイコン名→ファイル名はバレルの対応表に合わせている（例: `AlignRight` → `text-align-end.mjs`）。

## 検証

- `type-check` ✓ / `lint` ✓ / `build`（vp pack）✓
- ビルド成果物 `dist` でバレル import が消え、deep import（`lucide-imports.mjs`）になっていることを確認