### PR TITLE
fix(popover): [popover] の UA 既定背景(Canvas)・枠・余白を打ち消す

### DIFF
--- a/.changeset/popover-canvas-background.md
+++ b/.changeset/popover-canvas-background.md
@@ -1,0 +1,11 @@
+---
+'@k8o/arte-odyssey': patch
+---
+
+fix: Tooltip / DropdownMenu / ListBox の背景に UA 既定の白い矩形が出る不具合を修正
+
+Popover API 化で content ラッパーが `[popover]` 要素になり、UA 既定の
+`background-color: Canvas`（OS のカラースキームに追従し、アプリの `.dark` と一致しない）/
+`border: solid` / `padding: 0.25em` が残っていた。内側の角丸ボックスの背後に白い枠付きの
+矩形が透けて見えていたため、位置決め用ラッパーの背景・枠・余白を打ち消して透明にした。
+見た目（背景・余白・角丸）は内側の renderItem 側が持つため影響はない。

--- a/packages/arte-odyssey/src/components/overlays/popover/anchor-positioning.ts
+++ b/packages/arte-odyssey/src/components/overlays/popover/anchor-positioning.ts
@@ -76,6 +76,12 @@ export const getContentAnchorStyle = (
     margin: 0,
     // UA の `[popover] { overflow: auto }` は内側の影・角丸をクリップするため visible に戻す。
     overflow: 'visible',
+    // UA の `[popover]` 既定 `background-color: Canvas`（OS のカラースキームに追従し
+    // アプリの .dark と一致しない）/ `border: solid` / `padding: 0.25em` を打ち消す。
+    // 見た目（背景・余白・角丸）は内側の renderItem 側が持つため、ラッパーは透明にする。
+    background: 'transparent',
+    border: 0,
+    padding: 0,
     ...sideGap(side),
     positionAnchor: anchorName,
     positionArea: POSITION_AREA[placement],


### PR DESCRIPTION
## 概要

Tooltip / DropdownMenu / ListBox など Popover 系オーバーレイの背景に、白い枠付きの矩形が透けて見える崩れを修正します。

| Before | After |
| --- | --- |
| 内側のダークボックスの背後に白い矩形＋枠＋余分なパディング | 内側の角丸ボックスのみがクリーンに表示 |

## 原因

Popover API への移行で `Popover.Content` のラッパー `div` が `popover="manual"`（= `[popover]`）になり、ブラウザの UA スタイルシートが当たっていました。

\`\`\`css
[popover] {
  background-color: Canvas;  /* ← OS のカラースキームに追従し、アプリの .dark と一致しない */
  border: solid;
  padding: 0.25em;
  overflow: auto;            /* 既存コミット f4df18c5 で対処済み */
}
\`\`\`

- `background-color: Canvas` はシステム色で、アプリの `.dark` クラスではなく **OS のダークモード設定**に追従するため、内側ボックスの背後に白い矩形が見えていました。
- `border` / `padding` は Tailwind preflight の `*` リセットで実質 0 でしたが、`background-color` は preflight が触らないため残存していました。

## 修正

UA リセットが集約されている共有ヘルパー `getContentAnchorStyle`（`anchor-positioning.ts`）で `background: transparent` / `border: 0` / `padding: 0` を打ち消し、位置決め用ラッパーを透明にしました。見た目（背景・余白・角丸）は内側の `renderItem` 側が持つため影響はありません。

この関数は Tooltip / DropdownMenu / ListBox / Popover で共有されているため、1 箇所の修正で Popover 系全体が直ります。

## 確認

- Storybook 実機で、ラッパー背景が `rgb(255,255,255)`（白い Canvas）→ `rgba(0,0,0,0)`（透明）に変化することを確認。スクショ上も白枠が消えてダークボックスのみ表示。
- `pnpm typecheck` ✅
- `pnpm check`（Oxlint/Oxfmt）✅
- コンポーネントテスト 326 件すべて pass ✅