### PR TITLE
feat: CodeXmlIcon を追加

### DIFF
--- a/.changeset/add-code-xml-icon.md
+++ b/.changeset/add-code-xml-icon.md
@@ -1,0 +1,5 @@
+---
+'@k8o/arte-odyssey': minor
+---
+
+`CodeXmlIcon`（`</>` 形のコードアイコン）を追加しました。lucide-react の `code-xml` を `BaseIcon` でラップした、他アイコンと同じ `size` API のアイコンです。

--- a/packages/arte-odyssey/src/components/icons/icons.stories.tsx
+++ b/packages/arte-odyssey/src/components/icons/icons.stories.tsx
@@ -13,6 +13,7 @@ import {
   CheckIcon,
   ChevronIcon,
   CloseIcon,
+  CodeXmlIcon,
   ColorContrastIcon,
   ColorInfoIcon,
   CopyIcon,
@@ -87,6 +88,10 @@ export const Primary: Story = {
       <div className="flex flex-col items-center justify-center">
         <CloseIcon />
         <p className="text-center">Close</p>
+      </div>
+      <div className="flex flex-col items-center justify-center">
+        <CodeXmlIcon />
+        <p className="text-center">CodeXml</p>
       </div>
       <div className="flex flex-col items-center justify-center">
         <ChevronIcon direction="left" />

--- a/packages/arte-odyssey/src/components/icons/index.ts
+++ b/packages/arte-odyssey/src/components/icons/index.ts
@@ -12,6 +12,7 @@ export {
   CheckIcon,
   ChevronIcon,
   CloseIcon,
+  CodeXmlIcon,
   ColorContrastIcon,
   ColorInfoIcon,
   CopyIcon,

--- a/packages/arte-odyssey/src/components/icons/lucide-imports.ts
+++ b/packages/arte-odyssey/src/components/icons/lucide-imports.ts
@@ -22,6 +22,7 @@ import CircleAlert from 'lucide-react/dist/esm/icons/circle-alert.mjs';
 import CircleCheck from 'lucide-react/dist/esm/icons/circle-check.mjs';
 import ClipboardPenLine from 'lucide-react/dist/esm/icons/clipboard-pen-line.mjs';
 import Clock from 'lucide-react/dist/esm/icons/clock.mjs';
+import CodeXml from 'lucide-react/dist/esm/icons/code-xml.mjs';
 import Contrast from 'lucide-react/dist/esm/icons/contrast.mjs';
 import Droplets from 'lucide-react/dist/esm/icons/droplets.mjs';
 import ExternalLink from 'lucide-react/dist/esm/icons/external-link.mjs';
@@ -86,6 +87,7 @@ export {
   CircleCheck,
   ClipboardPenLine,
   Clock,
+  CodeXml,
   Contrast,
   Droplets,
   ExternalLink,

--- a/packages/arte-odyssey/src/components/icons/lucide.tsx
+++ b/packages/arte-odyssey/src/components/icons/lucide.tsx
@@ -24,6 +24,7 @@ import {
   CircleCheck,
   ClipboardPenLine,
   Clock,
+  CodeXml,
   Contrast,
   Droplets,
   ExternalLink,
@@ -87,6 +88,10 @@ export const ChevronIcon: FC<IconProps & { direction: Direction }> = ({
 
 export const CloseIcon: FC<IconProps> = ({ size = 'md' }) => (
   <BaseIcon renderItem={(props) => <X {...props} />} size={size} />
+);
+
+export const CodeXmlIcon: FC<IconProps> = ({ size = 'md' }) => (
+  <BaseIcon renderItem={(props) => <CodeXml {...props} />} size={size} />
 );
 
 export const CheckIcon: FC<IconProps> = ({ size = 'md' }) => (


### PR DESCRIPTION
## 概要
`</>` 形のコードアイコン `CodeXmlIcon` を追加します。

## 内容
- lucide-react の `code-xml` を `BaseIcon` でラップ（他アイコンと同じ `size` API / currentColor / 24x24）
- `lucide-imports.ts` に deep import を追加（dev バンドル対策の集約方針に追従）
- `icons/index.ts` で re-export、`icons.stories.tsx` のギャラリーに追加
- changeset（minor）

## 確認
- `typecheck` / `vp check` クリーン、unit 326 件パス
- `build` で公開 `dist/index.d.mts` に `CodeXmlIcon` が含まれることを確認
- VRT: アイコン一覧の baseline 更新が必要（本PRで差分が出ます）

## 背景
k8o（ポートフォリオ）の HTML いれ子マップで `</>` アイコンが必要になり、暫定でローカル実装していたものを設計システム側へ正式に移植するもの。リリース後に k8o 側のローカル実装を本アイコンへ差し替えます。
