### PR TITLE
fix(form-control): 狭いコンテナで中身がはみ出す問題を修正 (fieldset に min-w-0)

### DIFF
--- a/.changeset/form-control-fieldset-min-width.md
+++ b/.changeset/form-control-fieldset-min-width.md
@@ -1,0 +1,7 @@
+---
+'@k8o/arte-odyssey': patch
+---
+
+FormControl: 狭い幅のコンテナで中身がはみ出す問題を修正
+
+`<fieldset>` はブラウザ標準スタイルで `min-inline-size: min-content` を持つため、サイドバーやグリッドなど幅の狭いコンテナ内で `FormControl` を使うと、中身（例: Autocomplete の選択チップ）がコンテナからはみ出していました。fieldset に `min-w-0` を付与し、コンテナ幅に合わせて縮むようにしました。

--- a/packages/arte-odyssey/src/components/form/form-control/form-control.stories.tsx
+++ b/packages/arte-odyssey/src/components/form/form-control/form-control.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
+import { expect } from 'storybook/test';
 
+import { Autocomplete } from '../autocomplete';
 import { TextField } from '../text-field';
 import { FormControl } from './form-control';
 
@@ -91,6 +93,7 @@ export const Legend: Story = {
     helpText: 'RFCに準拠したメールアドレスを入力してください。',
     labelAs: 'legend',
   },
+
   parameters: {
     a11y: {
       options: {
@@ -101,5 +104,46 @@ export const Legend: Story = {
         },
       },
     },
+  },
+};
+
+// 回帰: fieldset は UA 標準で min-inline-size:min-content を持つため、min-w-0 が無いと
+// 狭いコンテナで中身（Autocomplete の選択チップ）がはみ出す。枠内に収まることを検証する。
+export const NarrowContainer: Story = {
+  args: {
+    label: 'ソース',
+    renderInput: (props) => (
+      <Autocomplete
+        {...props}
+        defaultValue={['smashing-magazine']}
+        options={[
+          { value: 'smashing-magazine', label: 'Smashing Magazine' },
+          { value: 'web-dev', label: 'web.dev' },
+          { value: 'chrome', label: 'Chrome for Developers' },
+        ]}
+      />
+    ),
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-56">
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const fieldset = canvasElement.querySelector('fieldset');
+    const container = fieldset?.parentElement;
+    if (
+      !(fieldset instanceof HTMLFieldSetElement) ||
+      !(container instanceof HTMLElement)
+    ) {
+      // `Error` はこのファイルの Story 名に影が付くため globalThis 経由で参照する
+      throw new globalThis.Error('fieldset が見つかりません');
+    }
+    const fieldsetWidth = fieldset.getBoundingClientRect().width;
+    const containerWidth = container.getBoundingClientRect().width;
+    // min-w-0 が無いと fieldset が min-content まで広がりコンテナをはみ出す
+    await expect(fieldsetWidth).toBeLessThanOrEqual(containerWidth + 1);
   },
 };

--- a/packages/arte-odyssey/src/components/form/form-control/form-control.stories.tsx
+++ b/packages/arte-odyssey/src/components/form/form-control/form-control.stories.tsx
@@ -138,7 +138,8 @@ export const NarrowContainer: Story = {
       !(fieldset instanceof HTMLFieldSetElement) ||
       !(container instanceof HTMLElement)
     ) {
-      // `Error` はこのファイルの Story 名に影が付くため globalThis 経由で参照する
+      // このファイルの `export const Error: Story` がグローバルの `Error` を
+      // シャドウするため globalThis 経由で参照する
       throw new globalThis.Error('fieldset が見つかりません');
     }
     const fieldsetWidth = fieldset.getBoundingClientRect().width;

--- a/packages/arte-odyssey/src/components/form/form-control/form-control.tsx
+++ b/packages/arte-odyssey/src/components/form/form-control/form-control.tsx
@@ -41,7 +41,7 @@ export const FormControl: FC<FormControlProps> = ({
         : undefined;
   const labelId = `${id}-label`;
   return (
-    <fieldset className="flex w-full flex-col">
+    <fieldset className="flex w-full min-w-0 flex-col">
       {labelAs === 'label' ? (
         <label
           className="text-fg-base text-md mb-1 flex gap-2 pl-0.5 font-bold"


### PR DESCRIPTION
## 問題

`FormControl` を幅の狭いコンテナ（サイドバー・グリッド・flex 内など）で使うと、中身（例: `Autocomplete` の選択チップ）がコンテナからはみ出す。

## 原因

`FormControl` は `<fieldset>` で組んでおり、`<fieldset>` はブラウザ標準スタイルで **`min-inline-size: min-content`** を持つ。このため fieldset がコンテナ幅より狭くなれず、中身の min-content 幅まで広がってはみ出していた。

## 修正

fieldset に `min-w-0` を付与し、コンテナ幅に合わせて縮むようにした。

```diff
- <fieldset className="flex w-full flex-col">
+ <fieldset className="flex w-full min-w-0 flex-col">
```

## 検証

- 回帰用の `NarrowContainer` story を追加（`w-56` のコンテナ内に `Autocomplete` を置き、fieldset がコンテナ幅を超えないことを play 関数で検証）。
- **修正前**: `expected 244 to be less than or equal to 225`（fieldset が約 20px はみ出す）で fail することを確認。
- **修正後**: form-control の 8 story すべて green。`typecheck` / `check`(lint・format) OK。

## 備考

k8o の reading-list サイドバー（256px 幅）で `Autocomplete` の選択チップがはみ出す事象から特定。`FormControl` を狭い幅で使う全ケースに効く汎用修正です。
