### PR TITLE
fix(tokens): ダークモードの bg-raised を gray-800 に変更

### DIFF
--- a/.changeset/dark-raised-surface-tone.md
+++ b/.changeset/dark-raised-surface-tone.md
@@ -1,0 +1,7 @@
+---
+'@k8o/arte-odyssey': patch
+---
+
+ダークモードのオーバーレイ背景（`bg-raised`）を gray-700 から gray-800 に変更
+
+ダークモードの `--bg-raised` は gray-700（明度 0.42）で、Modal / Popover / DropdownMenu などのオーバーレイがほぼ黒の背景の上で白っぽく浮いて見えていました。ライトモードの raised が base と同じ white で影によって分離しているのと同様に、ダークモードも `bg-base` と同じ gray-800（明度 0.3）にして、影で分離する構成に揃えました。ライトモードは変更ありません。

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "docs",
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["--filter", "docs", "dev"],
-      "port": 5173
+      "port": 5173,
+      "autoPort": true
     },
     {
       "name": "docs-prod",

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -4,6 +4,10 @@ import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+  server: {
+    // プレビューツール等がポートを割り当てられるよう PORT を尊重する
+    port: Number(process.env.PORT) || 5173,
+  },
   plugins: [
     funstackStatic({
       root: './src/root.tsx',

--- a/packages/arte-odyssey/src/styles/tokens.css
+++ b/packages/arte-odyssey/src/styles/tokens.css
@@ -207,7 +207,7 @@
   --fg-error: var(--red-200);
 
   --bg-base: var(--gray-800);
-  --bg-raised: var(--gray-700);
+  --bg-raised: var(--gray-800);
   --bg-surface: var(--gray-950);
   --bg-subtle: var(--gray-900);
   --bg-mute: var(--gray-700);

--- a/packages/arte-odyssey/src/styles/tokens.generated.ts
+++ b/packages/arte-odyssey/src/styles/tokens.generated.ts
@@ -68,7 +68,7 @@ export const tokens = {
       },
       'bg-raised': {
         light: 'oklch(1 0 0)',
-        dark: 'oklch(0.42 0.003 235)',
+        dark: 'oklch(0.3 0.002 235)',
       },
       'bg-surface': {
         light: 'oklch(0.975 0.001 235)',
@@ -496,7 +496,7 @@ export const tokens = {
     },
     'bg-raised': {
       light: 'oklch(1 0 0)',
-      dark: 'oklch(0.42 0.003 235)',
+      dark: 'oklch(0.3 0.002 235)',
     },
     'bg-surface': {
       light: 'oklch(0.975 0.001 235)',
@@ -669,7 +669,7 @@ export const tokens = {
     },
     'bg-raised': {
       light: 'white',
-      dark: 'gray-700',
+      dark: 'gray-800',
     },
     'bg-surface': {
       light: 'gray-50',


### PR DESCRIPTION
## 概要

ダークモードの `--bg-raised` を gray-700 から gray-800 に変更する（patch）。

## 動機

ダークモードの `bg-raised`（gray-700、明度 0.42）は、Modal / Popover / DropdownMenu などのオーバーレイがほぼ黒のページ背景の上でグレーの板のように白っぽく浮いて見えていた。

ライトモードでは raised = base（どちらも white）で、面の分離は影が担っている。ダークモードも同じ構成（raised = base = gray-800、明度 0.3）に揃えることで、オーバーレイがダークテーマに馴染む落ち着いたトーンになる。

## 詳細

- `.dark` の `--bg-raised` を `var(--gray-700)` → `var(--gray-800)` に変更
- `pnpm generate:tokens` で `tokens.generated.ts` を再生成
- changeset（patch）を追加
- あわせて docs の dev サーバーが `PORT` 環境変数を尊重するように変更（5173 が使用中でも別ポートで起動できる）

## 気をつけるポイント

- `bg-base` の面の上に出る DropdownMenu / Popover はページと同色になり、分離は影のみになる（ライトモードの white on white と同じ振る舞い）
- palette・semantic トークンの構成に増減はなく、ライトモードにも変更はない

## 影響範囲

ダークモードで `bg-raised` を使うすべてのコンポーネント（Modal / Drawer / Dialog / DropdownMenu / ListBox / Autocomplete のドロップダウン / Toast 系レンダラー）の背景色。

## テスト

- Storybook のダークモードで Modal / DropdownMenu の見た目を確認
- docs のテーマページ（palette / semantic カラー一覧）の表示を確認
- `pnpm check` / `pnpm typecheck` / `pnpm test`（335 件）パス