### PR TITLE
ci: migrate the Pavo caller to the reusable workflow

### DIFF
--- a/.github/workflows/pavo.yml
+++ b/.github/workflows/pavo.yml
@@ -2,39 +2,20 @@ name: Pavo
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
   pull_request_review_comment:
     types: [created]
-
-# Same-PR pushes cancel earlier in-flight reviews so only the latest commit is reviewed.
-# event_name in the group keeps review and reply jobs from cancelling each other.
-concurrency:
-  group: pavo-${{ github.event_name }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  issue_comment:
+    types: [created]
 
 jobs:
   pavo:
-    # Skip on PRs from forks: secrets are not exposed to fork workflows so the App
-    # token step would fail anyway, and we don't want a permanent red Actions run.
-    if: ${{ github.event.pull_request.head.repo.fork != true }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ secrets.K35O_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.K35O_BOT_PRIVATE_KEY }}
-
-      - uses: k35o/pavo@23335aeafea2005c3be7088e0e02410f8788ab38 # main
-        with:
-          github_token: ${{ steps.app-token.outputs.token }}
-          app_slug: ${{ steps.app-token.outputs.app-slug }}
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          instructions: default,react
-          extra_prompt: |
-            React コンポーネントライブラリ（デザインシステム）です。
-            Storybook で各コンポーネントの表示・操作テストを書いており、Chromatic で視覚回帰テストを行っています。
+    # /pavo コマンド以外の通常コメントで runner を起こさないための事前フィルタ
+    if: ${{ github.event_name != 'issue_comment' || startsWith(github.event.comment.body, '/pavo') }}
+    uses: k35o/pavo/.github/workflows/review.yml@main
+    with:
+      instructions: default,react,typescript
+      extra_prompt: |
+        React コンポーネントライブラリ（デザインシステム）です。
+        Storybook で各コンポーネントの表示・操作テストを書いており、Chromatic で視覚回帰テストを行っています。
+    secrets: inherit


### PR DESCRIPTION
## 概要

Pavo の caller workflow を reusable workflow（`k35o/pavo/.github/workflows/review.yml@main`）経由に移行する。旧 SHA pin の composite 直呼びから置き換え、concurrency・fork スキップ・timeout・App token 発行の定型を Pavo 側に集約する。

## 詳細

- 新エンジン（構造化出力アーキテクチャ）への切り替え。レビュー投稿・APPROVE 判定は Pavo のスクリプトが決定的に行い、Claude に許可されるツールは読み取り系のみになる
- 新トリガー: draft → ready for review でレビュー開始、PR コメント `/pavo`（または `/pavo review`）でオンデマンド再レビュー
- 連続返信が concurrency キャンセルで取りこぼされる問題が解消される（group に comment.id が入った）
- 観点に `typescript` を追加

## 気をつけるポイント

- **`k35o/pavo` の PR 14 の merge 後にこの PR を merge してください**。それ以前だと呼び出し先が `pull-requests: write` を要求するため startup_failure になります
- 停止手段: PR 単位は `pavo:skip` ラベル、全体は Actions variable `PAVO_DISABLED=true`
