### PR TITLE
ci: restore Pavo code review (Actions + Claude Code Max)

### DIFF
--- a/.github/workflows/pavo.yml
+++ b/.github/workflows/pavo.yml
@@ -1,0 +1,22 @@
+name: Pavo
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+
+jobs:
+  pavo:
+    if: ${{ github.event_name != 'issue_comment' || startsWith(github.event.comment.body, '/pavo') }}
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: k35o/pavo/.github/workflows/review.yml@main
+    with:
+      instructions: default,react,typescript
+      extra_prompt: |
+        React コンポーネントライブラリ（デザインシステム）。Storybook + Chromatic VRT。
+    secrets: inherit

--- a/.github/workflows/pavo.yml
+++ b/.github/workflows/pavo.yml
@@ -11,9 +11,6 @@ on:
 jobs:
   pavo:
     if: ${{ github.event_name != 'issue_comment' || startsWith(github.event.comment.body, '/pavo') }}
-    permissions:
-      contents: read
-      pull-requests: write
     uses: k35o/pavo/.github/workflows/review.yml@main
     with:
       instructions: default,react,typescript


### PR DESCRIPTION
## 概要

コードレビューを Actions 版 Pavo（Claude Code Max・追加費用 $0）に戻す。eve(Fugu) は枠がきつく個人利用のコスト方針に合わないため撤収した。

## 詳細
- reusable workflow `k35o/pavo/.github/workflows/review.yml@main` 経由。App インストール済み・secret 設定済みで即動く
- 停止: `pavo:skip` ラベル（PR 単位）
- この caller は将来ゼロフットプリント化（webhook リレー）で不要になる可能性あり