### PR TITLE
ci: make release-PR merges owner-triggered again

### DIFF
--- a/.changeset/manual-release-merge.md
+++ b/.changeset/manual-release-merge.md
@@ -1,0 +1,5 @@
+---
+'@k8o/arte-odyssey': none
+---
+
+Turn off release-PR auto-merge: merging the release PR is the owner's release trigger again. Workflow-only change.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,4 +41,3 @@ jobs:
         with:
           build: pnpm build
           github-token: ${{ steps.app-token.outputs.token }}
-          auto-merge: true


### PR DESCRIPTION
Removes `auto-merge: true` from the k35o/pnpm-release-action step in `.github/workflows/release.yml`, so the release PR is no longer auto-merged. Merging the release PR is the owner's deliberate release trigger again — the auto-merge was a batch-migration convenience, not the desired steady state.

Includes a bump-none intent (`.changeset/manual-release-merge.md`) since this is a workflow-only change.