### PR TITLE
docs: slim CLAUDE.md down to gotchas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,70 +1,23 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+ArteOdyssey is a monorepo for `@k8o/arte-odyssey` (React UI library) and its docs site. Vite+ (`vp`) is the unified toolchain — dev, build, test, lint/format (Oxlint/Oxfmt) — with Tailwind CSS 4 driven by semantic design tokens.
 
-## Architecture
-
-ArteOdyssey is a monorepo containing a React UI library (`@k8o/arte-odyssey`) and its documentation site, built with:
-
-- **Vite+** (`vp`) as unified toolchain (dev, build, test, lint, format, task runner)
-- **pnpm** for package management (v11.15.1, Node.js >=24.13.0)
-- **TypeScript** (strict mode, `noUncheckedIndexedAccess: true`)
-- **Oxlint/Oxfmt** for linting and formatting (via `vp check`)
-- **Tailwind CSS 4** with semantic design tokens
-- **pnpm's built-in release management** with [k35o/pnpm-release-action](https://github.com/k35o/pnpm-release-action) for versioning and publishing
-
-### Project Structure
-
-```
-packages/
-  arte-odyssey/          # Main UI library package (@k8o/arte-odyssey)
-apps/
-  docs/                  # Documentation site (Vite + @funstack/router)
-examples/
-  vite/                  # Example Vite app
-  nextjs/                # Example Next.js app
-```
-
-## Development Commands
-
-All commands run from the repository root unless noted.
-
-### Building
+## Commands
 
 ```bash
-pnpm build              # Build all packages
-pnpm typecheck          # Type checking across all packages
+pnpm build              # build all packages
+pnpm typecheck
+pnpm test
+pnpm check              # lint/format check (pnpm check:write to auto-fix)
 ```
 
-### Code Quality
+## Gotchas
 
-```bash
-pnpm check             # Run Oxlint/Oxfmt linting/formatting checks
-pnpm check:write       # Run checks and auto-fix issues
-```
-
-### Testing
-
-```bash
-pnpm test              # Run all tests
-```
-
-## Code Conventions
-
-### Formatting & Linting
-
-- Oxfmt with **single quotes**, 2-space indentation
-- Use `type` keyword, not `interface`
-- No `@ts-ignore` (use `@ts-expect-error` with explanation if needed)
-- No skipped tests (`test.skip`, `describe.skip`)
-- Git pre-commit hook: `vp staged` runs `vp check --fix` and auto-stages fixes
+- Use `type`, not `interface`.
+- No `@ts-ignore` — use `@ts-expect-error` with an explanation.
+- No skipped tests (`test.skip`, `describe.skip`).
+- The pre-commit hook (`vp staged`) runs `vp check --fix` and auto-stages the fixes.
 
 ## Release
 
-Versioning and publishing use [pnpm's built-in release management](https://pnpm.io/versioning) (pnpm >= 11.13), driven in CI by [k35o/pnpm-release-action](https://github.com/k35o/pnpm-release-action) via `.github/workflows/release.yml`.
-
-To author a change, run `pnpm change` (writes a `.changeset/<name>.md` intent in the changesets format) and include it in the PR.
-
-On every push to `main` the action either opens/updates the release PR (branch `pnpm-release/main`) that bumps versions and updates `CHANGELOG.md`, or — when no intents are pending — builds, publishes to npm via OIDC trusted publishing, pushes the version tag, and creates the GitHub Release.
-
-Config lives in the `versioning` key of `pnpm-workspace.yaml` (`changelog.storage: repository` keeps `CHANGELOG.md` committed). Consumed intents are recorded in `.changeset/ledger.yaml`. Package is published as `@k8o/arte-odyssey` with public access (`publishConfig` in its `package.json`).
+Versioning uses pnpm's built-in release management, driven in CI by [k35o/pnpm-release-action](https://github.com/k35o/pnpm-release-action). To author a change, run `pnpm change` and include the generated `.changeset/<name>.md` in the PR. Pushes to `main` either update the release PR (branch `pnpm-release/main`) or, when no intents are pending, publish to npm via OIDC trusted publishing. Config lives under the `versioning` key in `pnpm-workspace.yaml`.


### PR DESCRIPTION
Rewrites CLAUDE.md following the context-engineering guidance for Claude 5 generation models: keep it lightweight and spend the tokens on gotchas. Drops the project-structure tree, toolchain listing, and formatter-enforced style rules (all inferable from the repo), keeping non-enforced conventions, the pre-commit auto-staging behavior, and the release flow. 70 → 24 lines.