### PR TITLE
fix: ランタイム依存を exact 固定に戻す

### DIFF
--- a/.changeset/repin-runtime-deps.md
+++ b/.changeset/repin-runtime-deps.md
@@ -1,0 +1,5 @@
+---
+'@k8o/arte-odyssey': patch
+---
+
+ランタイム依存（`clsx` / `lucide-react` / `motion` / `tailwind-merge`）を exact 固定に戻しました。caret 範囲は Renovate の運用方針（rangeStrategy: pin）と衝突し、未検証バージョンが利用者環境に混入しうるためです。二重バンドルの懸念は motion 依存の段階的削除で解消していきます。

--- a/packages/arte-odyssey/package.json
+++ b/packages/arte-odyssey/package.json
@@ -93,10 +93,10 @@
     "check:write": "vp check --fix"
   },
   "dependencies": {
-    "clsx": "^2.1.1",
-    "lucide-react": "^1.17.0",
-    "motion": "^12.40.0",
-    "tailwind-merge": "^3.6.0"
+    "clsx": "2.1.1",
+    "lucide-react": "1.17.0",
+    "motion": "12.40.0",
+    "tailwind-merge": "3.6.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,16 +210,16 @@ importers:
   packages/arte-odyssey:
     dependencies:
       clsx:
-        specifier: ^2.1.1
+        specifier: 2.1.1
         version: 2.1.1
       lucide-react:
-        specifier: ^1.17.0
+        specifier: 1.17.0
         version: 1.17.0(react@19.2.6)
       motion:
-        specifier: ^12.40.0
+        specifier: 12.40.0
         version: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       tailwind-merge:
-        specifier: ^3.6.0
+        specifier: 3.6.0
         version: 3.6.0
       typescript:
         specifier: '>=5.4.0'


### PR DESCRIPTION
## 概要

#583 で caret 化したランタイム依存（`clsx` / `lucide-react` / `motion` / `tailwind-merge`）を exact 固定に戻す。

## 動機

- リポジトリの Renovate 共有設定（k35o/renovate-config）は `rangeStrategy: "pin"` + `:pinAllExceptPeerDependencies` のため、caret は次回の Renovate 実行で自動的に再 pin され、指定が安定しない
- 未検証の新しい minor/patch が利用者の新規インストール時に解決されうるリスクを、供給網を絞る方針（全 pin + minimumReleaseAge 7日）と整合させて排除する
- caret 化の動機だった「利用側での motion の二重バンドル」は、motion 依存の段階的な全面削除（Toast → Modal → Tabs → ScrollLinked の CSS 化）で根本解消する方針に変更

参考: Radix / Chakra / Mantine は外部依存を caret にしているが、これは各プロジェクトの Renovate/リリース運用とセットの選択であり、本リポジトリの運用には pin が整合する。