### PR TITLE
fix: 監査で見つかったバグ級の問題を一括修正する（a11y・デッドプロップ・トークン）

### DIFF
--- a/.changeset/audit-small-fixes.md
+++ b/.changeset/audit-small-fixes.md
@@ -1,0 +1,35 @@
+---
+'@k8o/arte-odyssey': minor
+---
+
+監査で見つかったバグ級の問題を一括修正しました。
+
+**Autocomplete（スクリーンリーダーでほぼ操作不能だった問題の解消）**
+
+- 矢印キーのハイライトを `aria-activedescendant` で支援技術に伝えるようにした
+- Escape でリストを閉じられるようにした
+- 絞り込み後に矢印キーの上限が全候補数のままで Enter が無反応になるバグを修正
+- 候補リストに `overflow-y-auto` とアクティブ行への自動スクロールを追加し、`aria-multiselectable` を付与
+- `placeholder` / `onBlur` / `onClick` / `onKeyDown` が内部実装に無言で上書きされていた問題を修正（利用者のハンドラと連結）
+- document への click リスナーを開いている間だけ登録するようにした
+
+**フォーム・表示系の修正**
+
+- `Progress`: 読み上げ値が 100 倍されず「0.5%」になるバグを修正（`minProgress` オフセットも考慮）
+- `Heading`: `lineClamp` が動的クラス生成のため CSS が生成されず機能していなかった問題を静的マップで修正。型は `1〜6` のリテラルに変更（従来はどの値でも無効だったため実害なし）
+- `FileField`: 型定義のみで未実装だった `defaultValue` を実装
+- `FormControl`: `labelAs="legend"` 時に radiogroup 等の `aria-labelledby` が空参照になる問題を修正
+- `NumberField`: 利用者の `onBlur` / `onKeyDown` が破棄されていた問題を修正
+
+**アクセシビリティ**
+
+- 全アイコン（lucide ラッパー・自前 SVG とも）の svg に `aria-hidden="true"` / `focusable="false"` を注入
+- `Dialog` / `Drawer`: アクセシブルネームに「閉じる」ボタンのラベルが混入していた問題を修正
+- `Breadcrumb`: セパレータを a11y ツリーから除外し、現在ページに `aria-current="page"` を付与。nav ラベルの誤記「パンクズリスト」を修正
+- `Pagination`: ページカウンタへの `aria-current` 誤用を削除
+- `DropdownMenu` / `ListBox`: Tab でフォーカスが外れたときメニューが開いたままになる問題を修正（Popover の focusout 処理）
+
+**ビジュアル（VRT に差分が出ます）**
+
+- `fg-subtle` のコントラストを WCAG AA 準拠に（light: gray-400→gray-600 で 2.22:1→5.50:1、dark: gray-500→gray-400 で 4.39:1→6.13:1）
+- ダークモードでメニュー・リストボックスの境界が見えなかった問題に対し、ポップアップ面へ `border-border-subtle` を追加

--- a/packages/arte-odyssey/src/components/data-display/heading/heading.stories.tsx
+++ b/packages/arte-odyssey/src/components/data-display/heading/heading.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect } from 'storybook/test';
 
 import { Heading } from './heading';
 
@@ -50,4 +51,23 @@ export const H6: Story = {
     type: 'h6',
   },
   render: (args) => <Heading {...args}>k8o</Heading>,
+};
+
+export const LineClamp: Story = {
+  args: {
+    type: 'h1',
+    lineClamp: 2,
+  },
+  render: (args) => (
+    <div className="w-48">
+      <Heading {...args}>
+        k8oの見出しはとても長くなることがあるため、行数を制限して折り返しを2行までに抑えられることを確認する。
+      </Heading>
+    </div>
+  ),
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('heading', { level: 1 })).toHaveClass(
+      'line-clamp-2',
+    );
+  },
 };

--- a/packages/arte-odyssey/src/components/data-display/heading/heading.tsx
+++ b/packages/arte-odyssey/src/components/data-display/heading/heading.tsx
@@ -4,13 +4,21 @@ import { cn } from './../../../helpers/cn';
 
 type Props = {
   type: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
-  lineClamp?: number;
+  lineClamp?: 1 | 2 | 3 | 4 | 5 | 6;
 } & Omit<HTMLAttributes<HTMLHeadingElement>, 'className' | 'style'>;
 
+const LINE_CLAMP_CLASS = {
+  1: 'line-clamp-1',
+  2: 'line-clamp-2',
+  3: 'line-clamp-3',
+  4: 'line-clamp-4',
+  5: 'line-clamp-5',
+  6: 'line-clamp-6',
+} as const;
+
 export const Heading: FC<Props> = ({ children, type, lineClamp, ...rest }) => {
-  const lineClampClass = {
-    [`line-clamp-${lineClamp?.toString() ?? ''}`]: lineClamp,
-  };
+  const lineClampClass =
+    lineClamp === undefined ? undefined : LINE_CLAMP_CLASS[lineClamp];
   if (type === 'h1') {
     return (
       <h1

--- a/packages/arte-odyssey/src/components/feedback/progress/progress.stories.tsx
+++ b/packages/arte-odyssey/src/components/feedback/progress/progress.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect } from 'storybook/test';
 
 import { Progress } from '.';
 
@@ -14,5 +15,19 @@ export const Primary: Story = {
   args: {
     progress: 50,
     maxProgress: 100,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('progressbar')).toHaveAccessibleName('50%');
+  },
+};
+
+export const WithMinProgress: Story = {
+  args: {
+    progress: 150,
+    minProgress: 100,
+    maxProgress: 200,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('progressbar')).toHaveAccessibleName('50%');
   },
 };

--- a/packages/arte-odyssey/src/components/feedback/progress/progress.tsx
+++ b/packages/arte-odyssey/src/components/feedback/progress/progress.tsx
@@ -15,23 +15,28 @@ export const Progress: FC<Props> = ({
   minProgress = 0,
   label,
   ...rest
-}) => (
-  <div
-    {...rest}
-    className="bg-bg-emphasize vertical:inline-48 rounded-full block-4 inline-full"
-    style={
-      {
-        '--progress-fill': `${((progress / maxProgress) * 100).toString()}%`,
-      } as CSSProperties
-    }
-  >
+}) => {
+  const percentage = toPrecision(
+    ((progress - minProgress) / (maxProgress - minProgress)) * 100,
+  );
+  return (
     <div
-      aria-label={label ?? `${toPrecision(progress / maxProgress).toString()}%`}
-      aria-valuemax={maxProgress}
-      aria-valuemin={minProgress}
-      aria-valuenow={progress}
-      className="bg-primary-bg rounded-full transition-all block-full inline-(--progress-fill)"
-      role="progressbar"
-    />
-  </div>
-);
+      {...rest}
+      className="bg-bg-emphasize vertical:inline-48 rounded-full block-4 inline-full"
+      style={
+        {
+          '--progress-fill': `${percentage.toString()}%`,
+        } as CSSProperties
+      }
+    >
+      <div
+        aria-label={label ?? `${percentage.toString()}%`}
+        aria-valuemax={maxProgress}
+        aria-valuemin={minProgress}
+        aria-valuenow={progress}
+        className="bg-primary-bg rounded-full transition-[inline-size] block-full inline-(--progress-fill)"
+        role="progressbar"
+      />
+    </div>
+  );
+};

--- a/packages/arte-odyssey/src/components/form/autocomplete/autocomplete.stories.tsx
+++ b/packages/arte-odyssey/src/components/form/autocomplete/autocomplete.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { type ComponentProps, useState } from 'react';
-import { expect } from 'storybook/test';
+import { expect, waitFor } from 'storybook/test';
 
 import { Autocomplete } from './autocomplete';
 
@@ -104,6 +104,103 @@ export const NarrowContainer: Story = {
     }
     await expect(clearAll.getBoundingClientRect().right).toBeLessThanOrEqual(
       box.getBoundingClientRect().right + 1,
+    );
+  },
+};
+
+// 回帰: 矢印キーの clamp が全 options 基準だと、絞り込みで候補が減ったとき
+// selectIndex が実在しない行を指して Enter が無反応になる
+export const FilteredKeyboardSelection: Story = {
+  args: {
+    id: 'autocomplete-filter',
+    'aria-describedby': undefined,
+    invalid: false,
+    disabled: false,
+    required: false,
+  },
+  play: async ({ canvas, userEvent }) => {
+    const input = canvas.getByRole('combobox');
+    await userEvent.type(input, '1');
+    await canvas.findByRole('listbox');
+    await waitFor(async () => {
+      await expect(canvas.getAllByRole('option')).toHaveLength(2);
+    });
+
+    await userEvent.keyboard('{ArrowDown}');
+    await userEvent.keyboard('{ArrowDown}');
+    await userEvent.keyboard('{ArrowDown}');
+    await userEvent.keyboard('{ArrowDown}');
+
+    await expect(input).toHaveAttribute(
+      'aria-activedescendant',
+      'autocomplete-filter_option_16',
+    );
+
+    await userEvent.keyboard('{Enter}');
+
+    await expect(canvas.queryByRole('listbox')).not.toBeInTheDocument();
+    await expect(input).toHaveValue('');
+    await expect(canvas.getByText('16進数')).toBeInTheDocument();
+  },
+};
+
+export const EscapeCloses: Story = {
+  args: {
+    id: 'autocomplete-escape',
+    'aria-describedby': undefined,
+    invalid: false,
+    disabled: false,
+    required: false,
+  },
+  play: async ({ canvas, userEvent }) => {
+    const input = canvas.getByRole('combobox');
+    await userEvent.click(input);
+    await canvas.findByRole('listbox');
+    await userEvent.keyboard('{ArrowDown}');
+
+    await expect(input).toHaveAttribute('aria-activedescendant');
+
+    await userEvent.keyboard('{Escape}');
+
+    await expect(canvas.queryByRole('listbox')).not.toBeInTheDocument();
+    await expect(input).not.toHaveAttribute('aria-activedescendant');
+  },
+};
+
+export const ActiveDescendant: Story = {
+  args: {
+    id: 'autocomplete-active',
+    'aria-describedby': undefined,
+    invalid: false,
+    disabled: false,
+    required: false,
+  },
+  play: async ({ canvas, userEvent }) => {
+    const input = canvas.getByRole('combobox');
+
+    await expect(input).not.toHaveAttribute('aria-activedescendant');
+
+    await userEvent.click(input);
+    await canvas.findByRole('listbox');
+
+    await expect(input).not.toHaveAttribute('aria-activedescendant');
+
+    await userEvent.keyboard('{ArrowDown}');
+
+    await expect(input).toHaveAttribute(
+      'aria-activedescendant',
+      'autocomplete-active_option_2',
+    );
+
+    await userEvent.keyboard('{ArrowDown}');
+
+    await expect(input).toHaveAttribute(
+      'aria-activedescendant',
+      'autocomplete-active_option_8',
+    );
+    await expect(canvas.getByRole('option', { name: '8進数' })).toHaveAttribute(
+      'id',
+      'autocomplete-active_option_8',
     );
   },
 };

--- a/packages/arte-odyssey/src/components/form/autocomplete/autocomplete.tsx
+++ b/packages/arte-odyssey/src/components/form/autocomplete/autocomplete.tsx
@@ -3,15 +3,18 @@
 import {
   type CSSProperties,
   type FC,
+  type FocusEventHandler,
   type InputHTMLAttributes,
+  type KeyboardEventHandler,
+  type MouseEventHandler,
   useCallback,
-  useEffect,
   useRef,
   useState,
 } from 'react';
 import { useFormStatus } from 'react-dom';
 
 import {
+  useClickAway,
   useControllableState,
   useDeferredDebounce,
   useDisclosure,
@@ -21,6 +24,7 @@ import type { Option } from '../../../types/variables';
 import { FOCUS_RING_WITHIN } from '../../_internal/focus-ring';
 import { IconButton } from '../../buttons/icon-button';
 import { CloseIcon } from '../../icons';
+import { chain } from './../../../helpers/chain';
 import { cn } from './../../../helpers/cn';
 
 type BaseProps = {
@@ -42,6 +46,7 @@ type BaseProps = {
   | 'aria-autocomplete'
   | 'aria-controls'
   | 'aria-expanded'
+  | 'aria-activedescendant'
 >;
 
 type ControlledProps = {
@@ -68,6 +73,10 @@ export const Autocomplete: FC<Props> = ({
   value,
   defaultValue,
   onChange,
+  placeholder = '入力して絞り込めます',
+  onBlur,
+  onClick,
+  onKeyDown,
   ...rest
 }) => {
   const [currentValue, handleChange] = useControllableState({
@@ -105,6 +114,14 @@ export const Autocomplete: FC<Props> = ({
   const filteredOptions = options.filter((option) =>
     option.label.includes(deferredText),
   );
+  // selectIndex は state のまま保持し、deferredText の変化で filteredOptions が
+  // 縮んでも実在する行を指すよう、描画のたびにクランプして導出する
+  const activeIndex =
+    selectIndex === undefined || filteredOptions.length === 0
+      ? undefined
+      : Math.min(selectIndex, filteredOptions.length - 1);
+  const activeOption =
+    activeIndex === undefined ? undefined : filteredOptions[activeIndex];
   const { pending: formPending } = useFormStatus();
   const disabledResolved = disabled || formPending;
 
@@ -114,17 +131,11 @@ export const Autocomplete: FC<Props> = ({
     setSelectIndex(undefined);
   }, [close]);
 
-  useEffect(() => {
-    const handleClick = (e: MouseEvent) => {
-      if (e.target instanceof Node && ref.current?.contains(e.target) === true)
-        return;
-      reset();
-    };
-    document.addEventListener('click', handleClick);
-    return () => {
-      document.removeEventListener('click', handleClick);
-    };
-  }, [reset]);
+  useClickAway(ref, reset, isOpen);
+
+  const scrollActiveIntoView = useCallback((node: HTMLLIElement | null) => {
+    node?.scrollIntoView({ block: 'nearest' });
+  }, []);
 
   const setReferenceRef = useCallback(
     (node: HTMLDivElement | null) => {
@@ -135,6 +146,77 @@ export const Autocomplete: FC<Props> = ({
     },
     [anchorName],
   );
+
+  const handleBlur: FocusEventHandler<HTMLInputElement> = (e) => {
+    if (e.relatedTarget?.id.startsWith(`${id}_option_`) === true) {
+      return;
+    }
+    close();
+  };
+
+  const handleClick: MouseEventHandler<HTMLInputElement> = () => {
+    if (isOpen && text.length === 0) {
+      close();
+      return;
+    }
+    open();
+    setSelectIndex(undefined);
+  };
+
+  const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = (e) => {
+    if (e.key === 'Backspace' && text.length === 0) {
+      reset();
+      handleChange(currentValue.slice(0, -1));
+      return;
+    }
+    if (e.key === 'Escape') {
+      if (isOpen) {
+        e.preventDefault();
+        close();
+        setSelectIndex(undefined);
+      }
+      return;
+    }
+    if (e.key === 'ArrowDown') {
+      open();
+      if (filteredOptions.length === 0) {
+        return;
+      }
+      setSelectIndex(
+        activeIndex === undefined
+          ? 0
+          : Math.min(activeIndex + 1, filteredOptions.length - 1),
+      );
+      return;
+    }
+    if (e.key === 'ArrowUp') {
+      open();
+      if (filteredOptions.length === 0) {
+        return;
+      }
+      setSelectIndex(
+        activeIndex === undefined ? 0 : Math.max(activeIndex - 1, 0),
+      );
+      return;
+    }
+    if (e.key === 'Enter' && activeIndex !== undefined) {
+      if (isPending) {
+        e.preventDefault();
+        return;
+      }
+      const selected = filteredOptions[activeIndex];
+      if (!selected) {
+        return;
+      }
+      if (currentValue.includes(selected.value)) {
+        handleChange(currentValue.filter((v) => v !== selected.value));
+        reset();
+        return;
+      }
+      handleChange([...currentValue, selected.value]);
+      reset();
+    }
+  };
 
   return (
     <div
@@ -187,6 +269,11 @@ export const Autocomplete: FC<Props> = ({
           })}
           <input
             {...rest}
+            aria-activedescendant={
+              isOpen && activeOption !== undefined
+                ? `${id}_option_${activeOption.value}`
+                : undefined
+            }
             aria-autocomplete="list"
             aria-controls={isOpen ? `${id}_listbox` : undefined}
             aria-expanded={isOpen}
@@ -199,76 +286,15 @@ export const Autocomplete: FC<Props> = ({
             )}
             disabled={disabledResolved}
             id={id}
-            onBlur={(e) => {
-              if (e.relatedTarget?.id.startsWith(`${id}_option_`) === true) {
-                return;
-              }
-              close();
-            }}
+            onBlur={chain(handleBlur, onBlur)}
             onChange={(e) => {
               open();
               setText(e.target.value);
               setSelectIndex(undefined);
             }}
-            onClick={() => {
-              if (isOpen && text.length === 0) {
-                close();
-                return;
-              }
-              open();
-              setSelectIndex(undefined);
-            }}
-            onKeyDown={(e) => {
-              if (e.key === 'Backspace' && text.length === 0) {
-                reset();
-                handleChange(currentValue.slice(0, -1));
-                return;
-              }
-              if (e.key === 'ArrowDown') {
-                open();
-                setSelectIndex((prev) => {
-                  if (prev === undefined) {
-                    return 0;
-                  }
-                  return Math.min(prev + 1, options.length - 1);
-                });
-                return;
-              }
-              if (e.key === 'ArrowUp') {
-                open();
-                setSelectIndex((prev) => {
-                  if (prev === undefined) {
-                    return 0;
-                  }
-                  return Math.max(prev - 1, 0);
-                });
-                return;
-              }
-              if (
-                e.key === 'Enter' &&
-                selectIndex !== undefined &&
-                selectIndex >= 0
-              ) {
-                if (isPending) {
-                  e.preventDefault();
-                  return;
-                }
-                const selected = filteredOptions[selectIndex];
-                if (!selected) {
-                  return;
-                }
-                if (currentValue.includes(selected.value)) {
-                  handleChange(
-                    currentValue.filter((v) => v !== selected.value),
-                  );
-                  reset();
-                  return;
-                }
-                handleChange([...currentValue, selected.value]);
-                reset();
-              }
-            }}
-            placeholder="入力して絞り込めます"
+            onClick={chain(handleClick, onClick)}
+            onKeyDown={chain(handleKeyDown, onKeyDown)}
+            placeholder={placeholder}
             role="combobox"
             type="text"
             value={text}
@@ -289,14 +315,15 @@ export const Autocomplete: FC<Props> = ({
       </div>
       {isOpen && (
         <div
-          className="bg-bg-raised z-10 rounded-xl shadow-md"
+          className="bg-bg-raised border-border-subtle z-10 rounded-xl border shadow-md"
           role="presentation"
           style={listboxStyle}
         >
           <ul
             aria-busy={isPending || undefined}
+            aria-multiselectable="true"
             className={cn(
-              'max-h-96 py-2 transition-opacity vertical:max-h-none vertical:max-w-96',
+              'max-h-96 overflow-y-auto py-2 transition-opacity vertical:max-h-none vertical:max-w-96 vertical:overflow-x-auto vertical:overflow-y-visible',
               isPending && 'opacity-60',
             )}
             id={`${id}_listbox`}
@@ -315,13 +342,14 @@ export const Autocomplete: FC<Props> = ({
                   className={cn(
                     'cursor-pointer px-3 py-2 transition-colors',
                     selected && 'bg-primary-bg-subtle text-primary-fg',
-                    selectIndex === idx && !selected && 'bg-bg-subtle',
-                    selectIndex === idx &&
+                    activeIndex === idx && !selected && 'bg-bg-subtle',
+                    activeIndex === idx &&
                       selected &&
                       'bg-primary-bg-mute text-primary-fg',
                   )}
                   id={`${id}_option_${option.value}`}
                   key={option.value}
+                  ref={activeIndex === idx ? scrollActiveIntoView : undefined}
                   role="option"
                   onClick={(e) => {
                     e.stopPropagation();

--- a/packages/arte-odyssey/src/components/form/file-field/file-field.stories.tsx
+++ b/packages/arte-odyssey/src/components/form/file-field/file-field.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect } from 'storybook/test';
 
 import { Button } from '../../buttons/button';
 import { FileField } from './file-field';
@@ -61,6 +62,20 @@ export const MaxFiles: Story = {
     required: false,
     multiple: true,
     maxFiles: 3,
+  },
+};
+
+export const DefaultValue: Story = {
+  args: {
+    disabled: false,
+    invalid: false,
+    required: false,
+    defaultValue: [
+      new File(['file content'], 'default.txt', { type: 'text/plain' }),
+    ],
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('default.txt')).toBeInTheDocument();
   },
 };
 

--- a/packages/arte-odyssey/src/components/form/file-field/file-field.tsx
+++ b/packages/arte-odyssey/src/components/form/file-field/file-field.tsx
@@ -63,6 +63,7 @@ const Root = ({
   required = false,
   multiple = false,
   maxFiles,
+  defaultValue,
   onChange,
   webkitDirectory = false,
   ...rest
@@ -72,7 +73,12 @@ const Root = ({
   const { pending } = useFormStatus();
   const disabledResolved = disabled || pending;
 
-  const [acceptedFiles, setAcceptedFiles] = useState<AcceptedFile[]>([]);
+  const [acceptedFiles, setAcceptedFiles] = useState<AcceptedFile[]>(() =>
+    (defaultValue ?? []).map((file) => ({
+      file,
+      id: crypto.randomUUID(),
+    })),
+  );
 
   const onFilesChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {

--- a/packages/arte-odyssey/src/components/form/form-control/form-control.stories.tsx
+++ b/packages/arte-odyssey/src/components/form/form-control/form-control.stories.tsx
@@ -105,6 +105,12 @@ export const Legend: Story = {
       },
     },
   },
+
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByRole('textbox', { name: 'メールアドレス' }),
+    ).toBeVisible();
+  },
 };
 
 // 回帰: fieldset は UA 標準で min-inline-size:min-content を持つため、min-w-0 が無いと

--- a/packages/arte-odyssey/src/components/form/form-control/form-control.tsx
+++ b/packages/arte-odyssey/src/components/form/form-control/form-control.tsx
@@ -52,7 +52,10 @@ export const FormControl: FC<FormControlProps> = ({
           {required && <span className="text-fg-error font-medium">必須</span>}
         </label>
       ) : (
-        <legend className="text-fg-base text-md mb-1 flex gap-2 pl-0.5 font-bold">
+        <legend
+          className="text-fg-base text-md mb-1 flex gap-2 pl-0.5 font-bold"
+          id={labelId}
+        >
           {label}
           {required && <span className="text-fg-error font-medium">必須</span>}
         </legend>

--- a/packages/arte-odyssey/src/components/form/number-field/number-field.stories.tsx
+++ b/packages/arte-odyssey/src/components/form/number-field/number-field.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { expect } from 'storybook/test';
+import { expect, fn } from 'storybook/test';
 
 import { NumberField } from './number-field';
 
@@ -75,6 +75,29 @@ export const Min0Max100: Story = {
     await userEvent.keyboard('{ArrowUp}');
 
     await expect(input).toHaveValue('100');
+  },
+};
+
+export const PassesThroughHandlers: Story = {
+  args: {
+    disabled: false,
+    invalid: false,
+    required: false,
+    onKeyDown: fn(),
+    onBlur: fn(),
+  },
+  play: async ({ args, canvas, userEvent }) => {
+    const input = canvas.getByRole('spinbutton');
+    await userEvent.click(input);
+    await userEvent.keyboard('{ArrowUp}');
+
+    await expect(args.onKeyDown).toHaveBeenCalled();
+    await expect(input).toHaveValue('1');
+
+    await userEvent.tab();
+
+    await expect(args.onBlur).toHaveBeenCalled();
+    await expect(input).toHaveValue('1');
   },
 };
 

--- a/packages/arte-odyssey/src/components/form/number-field/number-field.tsx
+++ b/packages/arte-odyssey/src/components/form/number-field/number-field.tsx
@@ -5,6 +5,7 @@ import { useFormStatus } from 'react-dom';
 
 import { FOCUS_RING_WITHIN } from '../../_internal/focus-ring';
 import { ChevronIcon } from '../../icons';
+import { chain } from './../../../helpers/chain';
 import { cn } from './../../../helpers/cn';
 import { useControllableState } from './../../../hooks/controllable-state';
 import { clamp } from './../../../internal/clamp';
@@ -54,6 +55,8 @@ export const NumberField: FC<Props> = ({
   value,
   defaultValue,
   onChange,
+  onBlur,
+  onKeyDown,
   step = 1,
   precision = 0,
   max = 9_007_199_254_740_991,
@@ -106,11 +109,11 @@ export const NumberField: FC<Props> = ({
         )}
         disabled={disabled}
         readOnly={pending || undefined}
-        onBlur={() => {
+        onBlur={chain(onBlur, () => {
           const newValue = clamp(cast(displayValue, precision), min, max);
           handleChange(newValue);
           setDisplayValue(newValue.toFixed(precision));
-        }}
+        })}
         onChange={(e) => {
           if (
             e.nativeEvent instanceof InputEvent &&
@@ -120,7 +123,7 @@ export const NumberField: FC<Props> = ({
           }
           setDisplayValue(e.target.value);
         }}
-        onKeyDown={(e) => {
+        onKeyDown={chain(onKeyDown, (e) => {
           if (e.key === 'ArrowUp') {
             const newValue = clamp(
               toPrecision(cast(displayValue, precision) + step, precision),
@@ -139,7 +142,7 @@ export const NumberField: FC<Props> = ({
             handleChange(newValue);
             setDisplayValue(newValue.toFixed(precision));
           }
-        }}
+        })}
         pattern="[0-9]*(.[0-9]+)?"
         role="spinbutton"
         type="text"

--- a/packages/arte-odyssey/src/components/icons/arte-odyssey.tsx
+++ b/packages/arte-odyssey/src/components/icons/arte-odyssey.tsx
@@ -1,12 +1,11 @@
 import type { FC } from 'react';
 
-import { BaseIcon, type BaseIconProps } from './base';
+import { BaseIcon, type BaseIconProps, type IconRenderProps } from './base';
 
-const ArteOdysseyLogo: FC<{
-  className?: string;
-}> = ({ className }) => (
+const ArteOdysseyLogo: FC<IconRenderProps> = ({ className, ...rest }) => (
   <svg
     className={className}
+    {...rest}
     viewBox="0 0 512 512"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"

--- a/packages/arte-odyssey/src/components/icons/base.tsx
+++ b/packages/arte-odyssey/src/components/icons/base.tsx
@@ -16,11 +16,20 @@ const sizeClass: Record<BaseIconProps['size'], string> = {
   '3xl': 'size-14',
 };
 
+export type IconRenderProps = {
+  className: string;
+  'aria-hidden': true;
+  focusable: 'false';
+};
+
 export const BaseIcon: FC<
   BaseIconProps & {
-    renderItem: (arg: { className: string }) => ReactNode;
+    renderItem: (arg: IconRenderProps) => ReactNode;
   }
 > = ({ size, renderItem }) =>
   renderItem({
     className: cn(sizeClass[size]),
+    // アイコンは装飾扱い(意味を持たせる場合は利用側が sr-only テキストで名前を付ける)
+    'aria-hidden': true,
+    focusable: 'false',
   });

--- a/packages/arte-odyssey/src/components/icons/browsers.stories.tsx
+++ b/packages/arte-odyssey/src/components/icons/browsers.stories.tsx
@@ -32,6 +32,16 @@ export const Primary: Story = {
       </div>
     </div>
   ),
+  play: async ({ canvasElement }) => {
+    const svgs = [...canvasElement.querySelectorAll('svg')];
+    await expect(svgs).toHaveLength(4);
+    await Promise.all(
+      svgs.flatMap((svg) => [
+        expect(svg).toHaveAttribute('aria-hidden', 'true'),
+        expect(svg).toHaveAttribute('focusable', 'false'),
+      ]),
+    );
+  },
 };
 
 // 対応表のように同じアイコンを 1 ページで何度も描画するケース。useId により

--- a/packages/arte-odyssey/src/components/icons/browsers.tsx
+++ b/packages/arte-odyssey/src/components/icons/browsers.tsx
@@ -1,16 +1,17 @@
 import { useId } from 'react';
 import type { FC } from 'react';
 
-import { BaseIcon, type BaseIconProps } from './base';
+import { BaseIcon, type BaseIconProps, type IconRenderProps } from './base';
 
 // 公式ブラウザロゴ。色・形は改変せず、複数同時描画でのグラデーション id 衝突を避けるため
 // useId() でコンポーネントインスタンスごとに id を一意化している。
 
-const Chrome: FC<{ className?: string }> = ({ className }) => {
+const Chrome: FC<IconRenderProps> = ({ className, ...rest }) => {
   const uid = useId();
   return (
     <svg
       className={className}
+      {...rest}
       viewBox="-10 -10 276 276"
       xmlns="http://www.w3.org/2000/svg"
     >
@@ -65,11 +66,12 @@ const Chrome: FC<{ className?: string }> = ({ className }) => {
   );
 };
 
-const Edge: FC<{ className?: string }> = ({ className }) => {
+const Edge: FC<IconRenderProps> = ({ className, ...rest }) => {
   const uid = useId();
   return (
     <svg
       className={className}
+      {...rest}
       viewBox="0 0 256 256"
       xmlns="http://www.w3.org/2000/svg"
     >
@@ -184,11 +186,12 @@ const Edge: FC<{ className?: string }> = ({ className }) => {
   );
 };
 
-const Firefox: FC<{ className?: string }> = ({ className }) => {
+const Firefox: FC<IconRenderProps> = ({ className, ...rest }) => {
   const uid = useId();
   return (
     <svg
       className={className}
+      {...rest}
       viewBox="0 0 531 548"
       xmlns="http://www.w3.org/2000/svg"
     >
@@ -394,11 +397,12 @@ const Firefox: FC<{ className?: string }> = ({ className }) => {
   );
 };
 
-const Safari: FC<{ className?: string }> = ({ className }) => {
+const Safari: FC<IconRenderProps> = ({ className, ...rest }) => {
   const uid = useId();
   return (
     <svg
       className={className}
+      {...rest}
       viewBox="194.5 190.1 135.1 135.1"
       xmlns="http://www.w3.org/2000/svg"
     >

--- a/packages/arte-odyssey/src/components/icons/color-scale.tsx
+++ b/packages/arte-odyssey/src/components/icons/color-scale.tsx
@@ -1,10 +1,11 @@
 import type { FC } from 'react';
 
-import { BaseIcon, type BaseIconProps } from './base';
+import { BaseIcon, type BaseIconProps, type IconRenderProps } from './base';
 
-const ColorScale: FC<{ className: string }> = ({ className }) => (
+const ColorScale: FC<IconRenderProps> = ({ className, ...rest }) => (
   <svg
     className={className}
+    {...rest}
     fill="none"
     stroke="currentColor"
     strokeLinecap="round"

--- a/packages/arte-odyssey/src/components/icons/github-mark.tsx
+++ b/packages/arte-odyssey/src/components/icons/github-mark.tsx
@@ -1,12 +1,11 @@
 import type { FC } from 'react';
 
-import { BaseIcon, type BaseIconProps } from './base';
+import { BaseIcon, type BaseIconProps, type IconRenderProps } from './base';
 
-const GitHub: FC<{
-  className?: string;
-}> = ({ className }) => (
+const GitHub: FC<IconRenderProps> = ({ className, ...rest }) => (
   <svg
     className={className}
+    {...rest}
     viewBox="0 0 98 96"
     xmlns="http://www.w3.org/2000/svg"
   >

--- a/packages/arte-odyssey/src/components/icons/icons.stories.tsx
+++ b/packages/arte-odyssey/src/components/icons/icons.stories.tsx
@@ -1,5 +1,8 @@
+/* eslint-disable import/max-dependencies -- 全アイコンを一覧するカタログ story のため依存数上限を超える */
+
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { FC } from 'react';
+import { expect } from 'storybook/test';
 
 import { ArteOdyssey } from './arte-odyssey';
 import { ColorScaleIcon } from './color-scale';
@@ -78,6 +81,16 @@ export const Sizes: Story = {
       ))}
     </div>
   ),
+  play: async ({ canvasElement }) => {
+    const svgs = [...canvasElement.querySelectorAll('svg')];
+    await expect(svgs).toHaveLength(sizes.length);
+    await Promise.all(
+      svgs.flatMap((svg) => [
+        expect(svg).toHaveAttribute('aria-hidden', 'true'),
+        expect(svg).toHaveAttribute('focusable', 'false'),
+      ]),
+    );
+  },
 };
 
 export const Primary: Story = {
@@ -325,4 +338,16 @@ export const Primary: Story = {
       </div>
     </div>
   ),
+  // lucide ラッパーだけでなく自前 SVG (GitHub / Qiita / ArteOdyssey 等) も
+  // renderItem の aria-hidden / focusable を svg まで伝播していることを網羅検証する
+  play: async ({ canvasElement }) => {
+    const svgs = [...canvasElement.querySelectorAll('svg')];
+    await expect(svgs.length).toBeGreaterThan(0);
+    await Promise.all(
+      svgs.flatMap((svg) => [
+        expect(svg).toHaveAttribute('aria-hidden', 'true'),
+        expect(svg).toHaveAttribute('focusable', 'false'),
+      ]),
+    );
+  },
 };

--- a/packages/arte-odyssey/src/components/icons/logo.tsx
+++ b/packages/arte-odyssey/src/components/icons/logo.tsx
@@ -1,12 +1,11 @@
 import type { FC } from 'react';
 
-import { BaseIcon, type BaseIconProps } from './base';
+import { BaseIcon, type BaseIconProps, type IconRenderProps } from './base';
 
-export const Logo: FC<{
-  className?: string;
-}> = ({ className }) => (
+export const Logo: FC<Partial<IconRenderProps>> = ({ className, ...rest }) => (
   <svg
     className={className}
+    {...rest}
     viewBox="0 128 1280 896"
     xmlns="http://www.w3.org/2000/svg"
   >

--- a/packages/arte-odyssey/src/components/icons/qiita.tsx
+++ b/packages/arte-odyssey/src/components/icons/qiita.tsx
@@ -1,10 +1,11 @@
 import type { FC } from 'react';
 
-import { BaseIcon, type BaseIconProps } from './base';
+import { BaseIcon, type BaseIconProps, type IconRenderProps } from './base';
 
-const Qiita: FC<{ className: string }> = ({ className }) => (
+const Qiita: FC<IconRenderProps> = ({ className, ...rest }) => (
   <svg
     className={className}
+    {...rest}
     enableBackground="new 0 0 300 300"
     version="1.1"
     viewBox="0 0 300 300"

--- a/packages/arte-odyssey/src/components/icons/twitter.tsx
+++ b/packages/arte-odyssey/src/components/icons/twitter.tsx
@@ -1,10 +1,11 @@
 import type { FC } from 'react';
 
-import { BaseIcon, type BaseIconProps } from './base';
+import { BaseIcon, type BaseIconProps, type IconRenderProps } from './base';
 
-const Twitter: FC<{ className?: string }> = ({ className }) => (
+const Twitter: FC<IconRenderProps> = ({ className, ...rest }) => (
   <svg
     className={className}
+    {...rest}
     fill="none"
     viewBox="0 0 1200 1227"
     xmlns="http://www.w3.org/2000/svg"

--- a/packages/arte-odyssey/src/components/icons/vertical-writing.tsx
+++ b/packages/arte-odyssey/src/components/icons/vertical-writing.tsx
@@ -1,10 +1,11 @@
 import type { FC } from 'react';
 
-import { BaseIcon, type BaseIconProps } from './base';
+import { BaseIcon, type BaseIconProps, type IconRenderProps } from './base';
 
-const VerticalWriting: FC<{ className: string }> = ({ className }) => (
+const VerticalWriting: FC<IconRenderProps> = ({ className, ...rest }) => (
   <svg
     className={className}
+    {...rest}
     fill="none"
     stroke="currentColor"
     strokeLinecap="round"

--- a/packages/arte-odyssey/src/components/navigation/breadcrumb/breadcrumb.stories.tsx
+++ b/packages/arte-odyssey/src/components/navigation/breadcrumb/breadcrumb.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect } from 'storybook/test';
 
 import { Breadcrumb } from './breadcrumb';
 
@@ -28,6 +29,19 @@ export const Medium: Story = {
       </Breadcrumb.Item>
     </Breadcrumb.List>
   ),
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByRole('navigation', { name: 'パンくずリスト' }),
+    ).toBeInTheDocument();
+    await expect(canvas.getAllByRole('listitem')).toHaveLength(3);
+    await expect(canvas.getByText('うおへんクイズ')).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+    await expect(
+      canvas.getByRole('link', { name: 'Home' }),
+    ).not.toHaveAttribute('aria-current');
+  },
 };
 
 export const Large: Story = {

--- a/packages/arte-odyssey/src/components/navigation/breadcrumb/breadcrumb.tsx
+++ b/packages/arte-odyssey/src/components/navigation/breadcrumb/breadcrumb.tsx
@@ -8,7 +8,7 @@ const List: FC<
     size?: 'sm' | 'md' | 'lg';
   }>
 > = ({ children, size = 'md' }) => (
-  <nav aria-label="パンクズリスト">
+  <nav aria-label="パンくずリスト">
     <ol
       className={cn(
         'flex list-none items-center gap-1 text-fg-mute',
@@ -27,7 +27,7 @@ const Item: FC<PropsWithChildren> = ({ children }) => (
 );
 
 const Separator: FC = () => (
-  <li className="text-fg-mute vertical:rotate-90">
+  <li aria-hidden="true" className="text-fg-mute vertical:rotate-90">
     <ChevronIcon direction="right" size="sm" />
   </li>
 );
@@ -44,7 +44,9 @@ const Link = <T extends string>({
 }>) => {
   const Component = component ?? 'a';
   return current ? (
-    <span className="text-fg-base">{children}</span>
+    <span aria-current="page" className="text-fg-base">
+      {children}
+    </span>
   ) : (
     <Component
       className="hover:text-fg-base focus-visible:ring-border-info underline transition-colors focus-visible:rounded-sm focus-visible:ring-2 focus-visible:outline-hidden"

--- a/packages/arte-odyssey/src/components/navigation/pagination/pagination.stories.tsx
+++ b/packages/arte-odyssey/src/components/navigation/pagination/pagination.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
+import { expect } from 'storybook/test';
 
 import { Pagination } from './pagination';
 
@@ -34,6 +35,13 @@ const LastRender = () => {
 
 export const Default: Story = {
   render: () => <DefaultRender />,
+  play: async ({ canvas, userEvent }) => {
+    const counter = canvas.getByRole('paragraph');
+    await expect(counter).toHaveTextContent('1/10');
+    await expect(counter).not.toHaveAttribute('aria-current');
+    await userEvent.click(canvas.getByRole('button', { name: '次へ' }));
+    await expect(counter).toHaveTextContent('2/10');
+  },
 };
 
 export const Middle: Story = {

--- a/packages/arte-odyssey/src/components/navigation/pagination/pagination.tsx
+++ b/packages/arte-odyssey/src/components/navigation/pagination/pagination.tsx
@@ -49,7 +49,6 @@ export const Pagination: FC<Props> = ({
           {prevLabel}
         </Button>
         <p
-          aria-current="page"
           aria-live="polite"
           className="text-fg-mute px-3 text-sm tabular-nums"
         >

--- a/packages/arte-odyssey/src/components/overlays/dialog/dialog.stories.tsx
+++ b/packages/arte-odyssey/src/components/overlays/dialog/dialog.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { type FC, type HTMLProps, useState } from 'react';
-import { fn } from 'storybook/test';
+import { expect, fn, waitFor } from 'storybook/test';
 
 import { Button } from '../../buttons/button';
 import { Modal } from '../modal';
@@ -22,6 +22,11 @@ export const Default: Story = {
       <Dialog.Content>こんにちは</Dialog.Content>
     </Dialog.Root>
   ),
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByRole('dialog', { name: 'ダイアログ' }),
+    ).toBeInTheDocument();
+  },
 };
 
 const StoryDialog: FC<HTMLProps<HTMLElement>> = (props) => {
@@ -103,6 +108,11 @@ export const ModalDialog: Story = {
     });
     trigger.focus();
     await userEvent.keyboard('{Enter}');
+    await waitFor(() => {
+      expect(
+        canvas.getByRole('dialog', { name: 'モーダル' }),
+      ).toBeInTheDocument();
+    });
   },
   parameters: {
     a11y: {

--- a/packages/arte-odyssey/src/components/overlays/dialog/dialog.tsx
+++ b/packages/arte-odyssey/src/components/overlays/dialog/dialog.tsx
@@ -32,7 +32,7 @@ const Root: FC<
   return (
     <section
       aria-describedby={`${rootId}-content`}
-      aria-labelledby={`${rootId}-header`}
+      aria-labelledby={`${rootId}-title`}
       className="bg-bg-raised relative w-full rounded-lg shadow-md"
       id={id}
       ref={ref}
@@ -50,11 +50,10 @@ const Header: FC<{
 }> = ({ title, onClose }) => {
   const { rootId } = useDialogContext();
   return (
-    <div
-      className="flex items-center justify-center p-4 pb-2"
-      id={`${rootId}-header`}
-    >
-      <Heading type="h3">{title}</Heading>
+    <div className="flex items-center justify-center p-4 pb-2">
+      <Heading id={`${rootId}-title`} type="h3">
+        {title}
+      </Heading>
       <div className="absolute top-2 right-2">
         <IconButton
           label="閉じる"

--- a/packages/arte-odyssey/src/components/overlays/drawer/drawer.stories.tsx
+++ b/packages/arte-odyssey/src/components/overlays/drawer/drawer.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { fn, waitFor } from 'storybook/test';
+import { expect, fn, waitFor } from 'storybook/test';
 
 import { Drawer } from './drawer';
 
@@ -19,6 +19,9 @@ export const Default: Story = {
         throw new Error('waiting for animation');
       }
     });
+    await expect(
+      canvas.getByRole('region', { name: 'メニュー' }),
+    ).toBeInTheDocument();
   },
   args: {
     isOpen: true,

--- a/packages/arte-odyssey/src/components/overlays/drawer/drawer.tsx
+++ b/packages/arte-odyssey/src/components/overlays/drawer/drawer.tsx
@@ -36,18 +36,20 @@ export const Drawer: FC<
     >
       <section
         aria-describedby={`${rootId}-content`}
-        aria-labelledby={`${rootId}-header`}
+        aria-labelledby={`${rootId}-title`}
         className="vertical:flex-row flex h-full flex-col"
         id={rootId}
       >
-        <div
-          className="flex shrink-0 items-center justify-center p-4 pb-2"
-          id={`${rootId}-header`}
-        >
+        <div className="flex shrink-0 items-center justify-center p-4 pb-2">
           {typeof title === 'string' ? (
-            <Heading type="h3">{title}</Heading>
+            <Heading id={`${rootId}-title`} type="h3">
+              {title}
+            </Heading>
           ) : (
-            title
+            // labelledby の参照先 id を持たせつつ flex レイアウトに影響させないための contents ラッパー
+            <div className="contents" id={`${rootId}-title`}>
+              {title}
+            </div>
           )}
           <div
             className={cn(

--- a/packages/arte-odyssey/src/components/overlays/dropdown-menu/dropdown-menu.tsx
+++ b/packages/arte-odyssey/src/components/overlays/dropdown-menu/dropdown-menu.tsx
@@ -55,7 +55,7 @@ const Content: FC<PropsWithChildren> = ({ children }) => {
         <div
           {...props}
           {...contentProps}
-          className="bg-bg-raised vertical:min-w-0 vertical:min-h-40 flex min-w-40 flex-col rounded-lg py-2 shadow-md"
+          className="bg-bg-raised border-border-subtle vertical:min-w-0 vertical:min-h-40 flex min-w-40 flex-col rounded-lg border py-2 shadow-md"
         >
           {Children.toArray(children).map((child, index) =>
             isValidElement(child)

--- a/packages/arte-odyssey/src/components/overlays/list-box/list-box.tsx
+++ b/packages/arte-odyssey/src/components/overlays/list-box/list-box.tsx
@@ -85,7 +85,7 @@ const Content: FC<{
         <div
           {...props}
           {...contentProps}
-          className="bg-bg-raised vertical:max-h-none vertical:min-w-0 vertical:max-w-48 vertical:min-h-40 vertical:overflow-x-auto vertical:overflow-y-visible flex max-h-48 min-w-40 flex-col overflow-y-auto rounded-lg py-2 shadow-md"
+          className="bg-bg-raised border-border-subtle vertical:max-h-none vertical:min-w-0 vertical:max-w-48 vertical:min-h-40 vertical:overflow-x-auto vertical:overflow-y-visible flex max-h-48 min-w-40 flex-col overflow-y-auto rounded-lg border py-2 shadow-md"
         >
           {helpContent}
           {options.map(({ key, label }, idx) => (

--- a/packages/arte-odyssey/src/components/overlays/popover/popover.stories.tsx
+++ b/packages/arte-odyssey/src/components/overlays/popover/popover.stories.tsx
@@ -41,6 +41,55 @@ export const Default: Story = {
   },
 };
 
+// APG menu button パターン: メニュー項目から Tab で抜けたらメニューを閉じ、
+// trigger の aria-expanded を false に戻し、フォーカスは次のタブ順要素へ進む。
+export const CloseOnTabOut: Story = {
+  render: () => (
+    <div className="flex flex-col items-start gap-4">
+      <Popover.Root>
+        <Popover.Trigger
+          renderItem={(props) => (
+            <Button {...props} size="md" type="button">
+              メニュー
+            </Button>
+          )}
+        />
+        <Popover.Content
+          renderItem={(props) => (
+            <div className="bg-bg-raised rounded-lg p-4 shadow-md" {...props}>
+              <button role="menuitem" type="button">
+                項目1
+              </button>
+            </div>
+          )}
+        />
+      </Popover.Root>
+      <Button size="md" type="button">
+        次のフォーカス先
+      </Button>
+    </div>
+  ),
+  play: async ({ canvas, userEvent }) => {
+    const trigger = canvas.getByRole('button', { name: 'メニュー' });
+    await userEvent.click(trigger);
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    const item = canvas.getByRole('menuitem', { name: '項目1' });
+    await waitFor(() => {
+      expect(item).toHaveFocus();
+    });
+
+    await userEvent.tab();
+
+    await waitFor(() => {
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      expect(item).not.toBeVisible();
+    });
+    expect(
+      canvas.getByRole('button', { name: '次のフォーカス先' }),
+    ).toHaveFocus();
+  },
+};
+
 // 画面の四隅・上下左右の端・中央にトリガーを並べ、各 Popover をクリックで開いて
 // 配置と flip（端で入りきらないと反対側へ反転）を目視確認するためのストーリー。
 const PLACEMENT_POSITIONS = [

--- a/packages/arte-odyssey/src/components/overlays/popover/popover.tsx
+++ b/packages/arte-odyssey/src/components/overlays/popover/popover.tsx
@@ -2,6 +2,7 @@
 
 import {
   type FC,
+  type FocusEvent,
   type PropsWithChildren,
   type ReactElement,
   useCallback,
@@ -106,7 +107,7 @@ const Content: FC<{
 }> = ({ renderItem, animation = 'scale' }) => {
   const { isOpen, trapFocus, anchorName, placement, flipDisabled, itemProps } =
     usePopoverContent();
-  const { triggerRef } = usePopoverContext();
+  const { triggerRef, onClose } = usePopoverContext();
 
   // content は popover で top-layer に出すためインライン描画になり、trigger 側の
   // writing-mode を継承する。`vertical:` variant は `.writing-v` 祖先を要求するので、
@@ -135,6 +136,24 @@ const Content: FC<{
   // floating-ui の FloatingFocusManager(modal=false) 相当を自前フックで代替。
   useFocusTrap(contentWrapperRef, triggerRef, isOpen && trapFocus);
 
+  // FloatingFocusManager の closeOnFocusOut 相当（Tab でメニュー外へ抜けたら閉じる）。
+  // trapFocus で絞るのは、focus 管理を使わない Tooltip の hover 挙動に干渉しないため。
+  // relatedTarget が null のケース（外側クリックや hidePopover で焦点が body へ落ちる）
+  // は Tab 移動と区別できないので閉じず、外側クリックは useClickAway に任せる。
+  const handleFocusOut = (event: FocusEvent<HTMLDivElement>) => {
+    const next = event.relatedTarget;
+    if (
+      !isOpen ||
+      !trapFocus ||
+      next === null ||
+      event.currentTarget.contains(next) ||
+      triggerRef.current?.contains(next) === true
+    ) {
+      return;
+    }
+    onClose();
+  };
+
   return (
     // outline-hidden: フォーカス管理で当てる tabindex=-1 の管理用フォーカスでは
     // ブラウザ既定の outline を出さない（中の項目・ボタンは各自の focus リングを持つ）。
@@ -144,6 +163,7 @@ const Content: FC<{
         animation === 'fade' ? 'ao-anim-fade' : 'ao-anim-scale',
         writingClass,
       )}
+      onBlur={handleFocusOut}
       popover="manual"
       ref={contentWrapperRef}
       style={getContentAnchorStyle(anchorName, placement, flipDisabled)}

--- a/packages/arte-odyssey/src/integrations/_shared/schemas.ts
+++ b/packages/arte-odyssey/src/integrations/_shared/schemas.ts
@@ -188,7 +188,16 @@ type HeadingIntegrationProps = {
 export const headingProps = z.object({
   text: z.string(),
   level: z.enum(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']).optional(),
-  lineClamp: z.number().optional(),
+  lineClamp: z
+    .union([
+      z.literal(1),
+      z.literal(2),
+      z.literal(3),
+      z.literal(4),
+      z.literal(5),
+      z.literal(6),
+    ])
+    .optional(),
 }) satisfies z.ZodType<HeadingIntegrationProps>;
 
 type AvatarIntegrationProps = {

--- a/packages/arte-odyssey/src/styles/tokens.css
+++ b/packages/arte-odyssey/src/styles/tokens.css
@@ -139,7 +139,7 @@
   --orange-950: oklch(0.18 0.09 55);
 
   --fg-base: var(--gray-900);
-  --fg-subtle: var(--gray-400);
+  --fg-subtle: var(--gray-600);
   --fg-mute: var(--gray-700);
   --fg-inverse: var(--gray-50);
   --fg-info: var(--blue-800);
@@ -198,7 +198,7 @@
 
 .dark {
   --fg-base: var(--gray-50);
-  --fg-subtle: var(--gray-500);
+  --fg-subtle: var(--gray-400);
   --fg-mute: var(--gray-300);
   --fg-inverse: var(--gray-900);
   --fg-info: var(--blue-200);

--- a/packages/arte-odyssey/src/styles/tokens.generated.ts
+++ b/packages/arte-odyssey/src/styles/tokens.generated.ts
@@ -35,8 +35,8 @@ export const tokens = {
         dark: 'oklch(0.975 0.001 235)',
       },
       'fg-subtle': {
-        light: 'oklch(0.75 0.005 235)',
-        dark: 'oklch(0.66 0.006 235)',
+        light: 'oklch(0.52 0.006 235)',
+        dark: 'oklch(0.75 0.005 235)',
       },
       'fg-mute': {
         light: 'oklch(0.42 0.003 235)',
@@ -463,8 +463,8 @@ export const tokens = {
       dark: 'oklch(0.975 0.001 235)',
     },
     'fg-subtle': {
-      light: 'oklch(0.75 0.005 235)',
-      dark: 'oklch(0.66 0.006 235)',
+      light: 'oklch(0.52 0.006 235)',
+      dark: 'oklch(0.75 0.005 235)',
     },
     'fg-mute': {
       light: 'oklch(0.42 0.003 235)',
@@ -636,8 +636,8 @@ export const tokens = {
       dark: 'gray-50',
     },
     'fg-subtle': {
-      light: 'gray-400',
-      dark: 'gray-500',
+      light: 'gray-600',
+      dark: 'gray-400',
     },
     'fg-mute': {
       light: 'gray-700',


### PR DESCRIPTION
## 概要

ライブラリ監査で見つかった「型が約束するのに動かない」「支援技術に伝わらない」類のバグ級問題を一括修正する。全修正に Red→Green の play テストを追加済み。

## 動機

利用者から見ると裏切りになる問題が複数残っていた。特に Autocomplete は aria-activedescendant 欠如と Escape 非対応でスクリーンリーダー利用者にはほぼ操作不能だった。

## 詳細

**Autocomplete（キーボード・SR 対応の立て直し）**
- 絞り込み後の矢印キー clamp バグ（全 options 基準 → filteredOptions 基準）
- Escape で閉じる / aria-activedescendant 接続 / aria-multiselectable
- 候補リストの overflow-y-auto + アクティブ行 scrollIntoView
- placeholder / onBlur / onClick / onKeyDown の無言上書きを chain 連結に
- document click リスナーを開いている間だけ登録

**デッドプロップ・計算バグ**
- Progress: 読み上げが「0.5%」になる ×100 忘れ（minProgress も考慮）
- Heading: lineClamp が CSS 未生成で無効 → 静的マップ + 1〜6 リテラル型
- FileField: 未実装の defaultValue を実装
- FormControl: legend 分岐の id 欠落（radiogroup の名前欠落）
- NumberField: 利用者ハンドラの無言破棄

**アクセシビリティ**
- 全アイコン svg に aria-hidden / focusable=false（自前 SVG 11 個も IconRenderProps の spread で伝播）
- Dialog / Drawer のアクセシブルネームから「閉じる」を除外
- Breadcrumb: セパレータ除外・aria-current 付与・「パンクズ」誤記修正
- Pagination: カウンタへの aria-current 誤用削除
- Popover: Tab でフォーカスが外れたら閉じる（APG menu button 準拠、trapFocus でゲートし Tooltip 非影響）

**トークン（視覚変更 → VRT / Chromatic に差分が出ます）**
- fg-subtle: light 2.22:1 → 5.50:1、dark 4.39:1 → 6.13:1（WCAG AA、oklch から実測）
- メニュー / リストボックス面に border-border-subtle（ダークで境界が消える対策。bg-raised の色は過去の意図的決定を尊重し不変更）

## 気をつけるポイント

- **Heading の lineClamp 型が number → 1〜6 リテラルに**。従来はどの値でも無効（CSS 未生成）だったため実害はないが、型エラーになる利用コードはありえる
- Progress は minProgress を分母に織り込む挙動変更を含む（バグ修正として妥当、WithMinProgress テストで担保）
- VRT / Chromatic の差分は fg-subtle と輪郭線によるもので想定内

## テスト

- 85 ファイル / 373 テスト全パス（Playwright 実ブラウザ）
- 各修正に Red→Green の play テストを追加（FilteredKeyboardSelection / EscapeCloses / ActiveDescendant / CloseOnTabOut / アイコン網羅検証ほか）
- typecheck / check / check:tokens / check:package すべて通過