### PR TITLE
feat(toast): Toast を刷新し motion 依存を Provider から切り離す

### DIFF
--- a/.changeset/toast-overhaul.md
+++ b/.changeset/toast-overhaul.md
@@ -1,0 +1,21 @@
+---
+'@k8o/arte-odyssey': minor
+---
+
+Toast を刷新し、ライブラリの motion 依存を Provider から切り離しました。
+
+**Toast の新機能**
+
+- `onOpen(tone, message, options)` に第3引数 `options` を追加
+  - `duration`: 自動クローズまでのミリ秒。`Number.POSITIVE_INFINITY` で自動クローズなし（既定 5000ms）
+  - `action`: Alert と同じ `{ label, renderItem }` 形式のインラインアクション
+- すべてのトーストに閉じるボタンが付き、手動で閉じられるようになりました
+- ホバー中・フォーカス中は自動クローズのタイマーが一時停止します（WCAG 2.2.1 Timing Adjustable 対応）。再開時は残り時間から数えます
+- 上限（5件）を超えたときは最古のトーストが閉じ演出つきで退避します
+
+**motion 依存の縮小（バンドルサイズ）**
+
+- トーストの出入りを CSS アニメーションに置き換え、`ToastProvider` から motion 依存を除去
+- `ArteOdysseyProvider` から `MotionConfig` を外し、motion を使う各コンポーネント（Modal / Tabs / ScrollLinked）がローカルに `reducedMotion="user"` を設定するように変更
+
+これにより、Modal / Tabs / ScrollLinked を使わないアプリのバンドルから motion のランタイム（数十KB gzip）が丸ごと外れます。既存の `onOpen(tone, message)` 呼び出しはそのまま動きます。

--- a/packages/arte-odyssey/src/components/feedback/alert/alert.tsx
+++ b/packages/arte-odyssey/src/components/feedback/alert/alert.tsx
@@ -5,7 +5,7 @@ import { AlertIcon, CloseIcon } from '../../icons';
 import { cn } from './../../../helpers/cn';
 import type { Status } from './../../../types/variables';
 
-type AlertAction = {
+export type AlertAction = {
   label: string;
   renderItem: (props: { children: ReactNode }) => ReactNode;
 };

--- a/packages/arte-odyssey/src/components/feedback/alert/index.ts
+++ b/packages/arte-odyssey/src/components/feedback/alert/index.ts
@@ -1,1 +1,1 @@
-export { Alert } from './alert';
+export { Alert, type AlertAction } from './alert';

--- a/packages/arte-odyssey/src/components/feedback/toast/context.ts
+++ b/packages/arte-odyssey/src/components/feedback/toast/context.ts
@@ -1,49 +1,44 @@
 'use client';
 
-import { type Dispatch, type SetStateAction, useCallback } from 'react';
-
+import type { AlertAction } from '../alert';
 import { createSafeContext } from './../../../helpers/create-safe-context';
 import type { Status } from './../../../types/variables';
 
-const MAX_TOAST_COUNT = 5;
+export type ToastAction = AlertAction;
+
+export type ToastOptions = {
+  /**
+   * 自動で閉じるまでのミリ秒。`Number.POSITIVE_INFINITY` で自動クローズなし
+   * （閉じるボタンでのみ閉じる）。既定は 5000ms。
+   */
+  duration?: number;
+  action?: ToastAction;
+};
 
 export type ToastType = {
   id: string;
   tone: Status;
   message: string;
+  duration: number;
+  action?: ToastAction;
 };
 
-export const [SetToastContext, useSetToast] = createSafeContext<
-  Dispatch<SetStateAction<ToastType[]>>
->('useToast must be used within a ToastProvider');
+export type ToastStore = {
+  open: (tone: Status, message: string, options?: ToastOptions) => void;
+  close: (id: string) => void;
+  closeAll: () => void;
+};
+
+export const [ToastStoreContext, useToastStore] = createSafeContext<ToastStore>(
+  'useToast must be used within a ToastProvider',
+);
 
 export const useToast = () => {
-  const setToasts = useSetToast();
-
-  const onOpen = useCallback(
-    (tone: Status, message: string) => {
-      setToasts((prev) => {
-        const next = [...prev, { id: crypto.randomUUID(), tone, message }];
-        return next.slice(-MAX_TOAST_COUNT);
-      });
-    },
-    [setToasts],
-  );
-
-  const onClose = useCallback(
-    (id: string) => {
-      setToasts((prev) => prev.filter((toast) => toast.id !== id));
-    },
-    [setToasts],
-  );
-
-  const onCloseAll = useCallback(() => {
-    setToasts([]);
-  }, [setToasts]);
+  const store = useToastStore();
 
   return {
-    onOpen,
-    onClose,
-    onCloseAll,
+    onOpen: store.open,
+    onClose: store.close,
+    onCloseAll: store.closeAll,
   };
 };

--- a/packages/arte-odyssey/src/components/feedback/toast/provider.tsx
+++ b/packages/arte-odyssey/src/components/feedback/toast/provider.tsx
@@ -1,44 +1,35 @@
 'use client';
 
-import { AnimatePresence, type Variants } from 'motion/react';
-import * as motion from 'motion/react-client';
 import {
   type FC,
   type PropsWithChildren,
   type RefObject,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
 import { createPortal } from 'react-dom';
 
 import { cn } from './../../../helpers/cn';
-import { SetToastContext, type ToastType } from './context';
+import type { Status } from './../../../types/variables';
+import {
+  type ToastOptions,
+  ToastStoreContext,
+  type ToastType,
+} from './context';
 import { Toast } from './toast';
 
-const toastMotionVariants: Variants = {
-  initial: {
-    opacity: 0,
-    y: 24,
-  },
-  animate: {
-    opacity: 1,
-    y: 0,
-    x: 0,
-    scale: 1,
-    transition: {
-      duration: 0.4,
-      ease: [0.4, 0, 0.2, 1],
-    },
-  },
-  exit: {
-    opacity: 0,
-    scale: 0.85,
-    transition: {
-      duration: 0.2,
-      ease: [0.4, 0, 1, 1],
-    },
-  },
+const MAX_TOAST_COUNT = 5;
+const DEFAULT_DURATION_MS = 5000;
+// base.css の .ao-toast-item の transition と同じ長さ。transitionend には
+// 依存しない(reduced motion で transition が無効でも確実に取り除くため)
+const EXIT_MS = 200;
+
+type ToastState = {
+  toasts: ToastType[];
+  // 閉じ演出中(高さ 0 へ畳む transition 中)のトースト。EXIT_MS 後に除去する
+  closingIds: string[];
 };
 
 export const ToastProvider: FC<
@@ -47,58 +38,167 @@ export const ToastProvider: FC<
     position?: 'fixed' | 'absolute';
   }>
 > = ({ children, portalRef = null, position = 'fixed' }) => {
-  const [toasts, setToasts] = useState<ToastType[]>([]);
-  const ref = useRef<HTMLElement | null>(null);
+  const [state, setState] = useState<ToastState>({
+    toasts: [],
+    closingIds: [],
+  });
+  const [isHovered, setIsHovered] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
+  // ライブリージョン(section)はトーストが増える前から DOM に存在している必要が
+  // あるため、ref ではなく state で持ちマウント直後の再レンダーで描画する
+  const [defaultContainer, setDefaultContainer] = useState<HTMLElement | null>(
+    null,
+  );
 
   useEffect(() => {
-    ref.current = document.body;
+    setDefaultContainer(document.body);
   }, []);
 
-  const container = portalRef?.current ?? ref.current;
+  // 閉じ演出を終えたエントリを id ごとの独立したタイマーで取り除く。
+  // 全体で 1 本のタイマーだと、EXIT_MS 未満の間隔で閉じ始めが続いたとき
+  // 先行エントリの除去が際限なく先送りされてしまう
+  const exitTimersRef = useRef(new Map<string, number>());
+  useEffect(() => {
+    for (const id of state.closingIds) {
+      if (exitTimersRef.current.has(id)) {
+        continue;
+      }
+      const timerId = window.setTimeout(() => {
+        exitTimersRef.current.delete(id);
+        setState((prev) => ({
+          toasts: prev.toasts.filter((toast) => toast.id !== id),
+          closingIds: prev.closingIds.filter((closingId) => closingId !== id),
+        }));
+      }, EXIT_MS);
+      exitTimersRef.current.set(id, timerId);
+    }
+  }, [state.closingIds]);
+  useEffect(() => {
+    const timers = exitTimersRef.current;
+    return () => {
+      for (const timerId of timers.values()) {
+        window.clearTimeout(timerId);
+      }
+      timers.clear();
+    };
+  }, []);
+
+  const store = useMemo(
+    () => ({
+      open: (tone: Status, message: string, options?: ToastOptions) => {
+        // updater は StrictMode で二重実行されうるので、非決定的な ID 生成は外で行う
+        const id = crypto.randomUUID();
+        setState((prev) => {
+          const toasts: ToastType[] = [
+            ...prev.toasts,
+            {
+              id,
+              tone,
+              message,
+              duration: options?.duration ?? DEFAULT_DURATION_MS,
+              action: options?.action,
+            },
+          ];
+          const active = toasts.filter(
+            (toast) => !prev.closingIds.includes(toast.id),
+          );
+          const overflow = active.length - MAX_TOAST_COUNT;
+          if (overflow <= 0) {
+            return { toasts, closingIds: prev.closingIds };
+          }
+          // 上限を超えた分は最古のものから閉じ演出つきで退避させる
+          return {
+            toasts,
+            closingIds: [
+              ...prev.closingIds,
+              ...active.slice(0, overflow).map((toast) => toast.id),
+            ],
+          };
+        });
+      },
+      close: (id: string) => {
+        setState((prev) =>
+          prev.closingIds.includes(id)
+            ? prev
+            : { toasts: prev.toasts, closingIds: [...prev.closingIds, id] },
+        );
+      },
+      closeAll: () => {
+        setState((prev) => ({
+          toasts: prev.toasts,
+          closingIds: prev.toasts.map((toast) => toast.id),
+        }));
+      },
+    }),
+    [],
+  );
+
+  const container = portalRef?.current ?? defaultContainer;
+  const isPaused = isHovered || isFocused;
 
   return (
-    <SetToastContext value={setToasts}>
+    <ToastStoreContext value={store}>
       {children}
       {container
         ? createPortal(
             <section
-              aria-label="通知"
+              // 空の間は名前を付けず region ランドマークにしない（複数 Provider の
+              // 共存時に同名ランドマークが重複して axe の landmark-unique に反するため）。
+              // aria-live 自体は最初から存在し、初回トーストも読み上げ対象になる
+              aria-label={state.toasts.length > 0 ? '通知' : undefined}
               aria-live="polite"
               className={cn(
-                'absolute bottom-3 z-toast flex w-full flex-col items-center justify-center gap-4',
+                'bottom-3 z-toast flex w-full flex-col items-center justify-center',
                 position === 'fixed' && 'fixed',
                 position === 'absolute' && 'absolute',
               )}
+              onBlur={(event) => {
+                if (!event.currentTarget.contains(event.relatedTarget)) {
+                  setIsFocused(false);
+                }
+              }}
+              onFocus={() => {
+                setIsFocused(true);
+              }}
+              onPointerEnter={() => {
+                setIsHovered(true);
+              }}
+              onPointerLeave={() => {
+                setIsHovered(false);
+              }}
             >
-              <AnimatePresence initial={false}>
-                {toasts.map((toast) => (
-                  <motion.div
-                    animate="animate"
-                    custom={{ position: 'bottom' }}
-                    exit="exit"
-                    initial="initial"
+              {state.toasts.map((toast) => {
+                const isClosing = state.closingIds.includes(toast.id);
+                return (
+                  <div
+                    className="ao-toast-item w-full justify-items-center"
+                    data-closing={isClosing || undefined}
+                    // 閉じ演出中は不可視のままフォーカス可能な要素が残らないようにする
+                    inert={isClosing || undefined}
                     key={toast.id}
-                    layout
-                    variants={toastMotionVariants}
                   >
-                    <div
-                      aria-atomic
-                      className="shadow-lg"
-                      role={
-                        toast.tone === 'error' || toast.tone === 'warning'
-                          ? 'alert'
-                          : 'status'
-                      }
-                    >
-                      <Toast {...toast} />
+                    <div className="min-h-0">
+                      {/* role は Alert 自身が tone に応じて持つ(status / alert) */}
+                      <div className="ao-toast-enter shadow-lg">
+                        <Toast
+                          action={toast.action}
+                          duration={toast.duration}
+                          isPaused={isPaused}
+                          message={toast.message}
+                          onClose={() => {
+                            store.close(toast.id);
+                          }}
+                          tone={toast.tone}
+                        />
+                      </div>
                     </div>
-                  </motion.div>
-                ))}
-              </AnimatePresence>
+                  </div>
+                );
+              })}
             </section>,
             container,
           )
         : null}
-    </SetToastContext>
+    </ToastStoreContext>
   );
 };

--- a/packages/arte-odyssey/src/components/feedback/toast/toast.stories.tsx
+++ b/packages/arte-odyssey/src/components/feedback/toast/toast.stories.tsx
@@ -1,19 +1,31 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 
 import { Button } from '../../buttons/button';
-import { useToast } from './context';
+import { Anchor } from '../../navigation/anchor';
+import type { Status } from './../../../types/variables';
+import { type ToastOptions, useToast } from './context';
 import { ToastProvider } from './provider';
-import { Toast } from './toast';
 
-const ToastTrigger = () => {
+const ToastTrigger = ({
+  label = 'トーストを呼ぶ',
+  message = 'トーストを呼びました',
+  options,
+  tone = 'success',
+}: {
+  label?: string;
+  message?: string;
+  options?: ToastOptions;
+  tone?: Status;
+}) => {
   const { onOpen } = useToast();
   return (
     <Button
       onClick={() => {
-        onOpen('success', 'トーストを呼びました');
+        onOpen(tone, message, options);
       }}
     >
-      トーストを呼ぶ
+      {label}
     </Button>
   );
 };
@@ -34,20 +46,228 @@ const meta: Meta<typeof ToastProvider> = {
 export default meta;
 type Story = StoryObj<typeof ToastProvider>;
 
-export const Primary: Story = {};
-
-export const ToastSuccess: Story = {
-  render: () => <Toast id="1" message="成功しました" tone="success" />,
+export const Primary: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole('button', { name: 'トーストを呼ぶ' }),
+    );
+    const body = within(canvasElement.ownerDocument.body);
+    const toast = await body.findByRole('status');
+    await expect(toast).toHaveTextContent('トーストを呼びました');
+    // 手動で閉じられる（閉じるボタンが必ず付く）。出現アニメーション完了を待つ
+    await waitFor(() => {
+      expect(
+        within(toast).getByRole('button', { name: '閉じる' }),
+      ).toBeVisible();
+    });
+  },
 };
 
-export const ToasInfo: Story = {
-  render: () => <Toast id="1" message="情報です" tone="info" />,
+export const Tones: Story = {
+  render: () => (
+    <div className="flex gap-2">
+      <ToastTrigger label="success" message="成功しました" tone="success" />
+      <ToastTrigger label="info" message="情報です" tone="info" />
+      <ToastTrigger label="warning" message="警告です" tone="warning" />
+      <ToastTrigger label="error" message="失敗しました" tone="error" />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(canvas.getByRole('button', { name: 'success' }));
+    await expect(await body.findByRole('status')).toHaveTextContent(
+      '成功しました',
+    );
+    // error / warning は割り込み読み上げの alert ロールになる
+    await userEvent.click(canvas.getByRole('button', { name: 'error' }));
+    await expect(await body.findByRole('alert')).toHaveTextContent(
+      '失敗しました',
+    );
+  },
 };
 
-export const ToastError: Story = {
-  render: () => <Toast id="1" message="失敗しました" tone="error" />,
+export const CloseButton: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole('button', { name: 'トーストを呼ぶ' }),
+    );
+    const body = within(canvasElement.ownerDocument.body);
+    const toast = await body.findByRole('status');
+    await userEvent.click(
+      within(toast).getByRole('button', { name: '閉じる' }),
+    );
+    await waitFor(() => {
+      expect(body.queryByRole('status')).not.toBeInTheDocument();
+    });
+  },
 };
 
-export const ToastWarning: Story = {
-  render: () => <Toast id="1" message="警告です" tone="warning" />,
+export const AutoDismiss: Story = {
+  render: () => (
+    <ToastTrigger message="500ms で消えます" options={{ duration: 500 }} />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole('button', { name: 'トーストを呼ぶ' }),
+    );
+    const body = within(canvasElement.ownerDocument.body);
+    await expect(await body.findByRole('status')).toBeInTheDocument();
+    await waitFor(
+      () => {
+        expect(body.queryByRole('status')).not.toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+  },
+};
+
+export const Persistent: Story = {
+  render: () => (
+    <ToastTrigger
+      message="自動では消えません"
+      options={{ duration: Number.POSITIVE_INFINITY }}
+      tone="error"
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole('button', { name: 'トーストを呼ぶ' }),
+    );
+    const body = within(canvasElement.ownerDocument.body);
+    const toast = await body.findByRole('alert');
+    // AutoDismiss(500ms) より十分長く待っても残っていることを確認する
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1200);
+    });
+    await expect(toast).toBeVisible();
+    // 閉じるボタンでだけ閉じられる
+    await userEvent.click(
+      within(toast).getByRole('button', { name: '閉じる' }),
+    );
+    await waitFor(() => {
+      expect(body.queryByRole('alert')).not.toBeInTheDocument();
+    });
+  },
+};
+
+export const PauseOnHover: Story = {
+  render: () => (
+    <ToastTrigger message="ホバー中は消えません" options={{ duration: 1000 }} />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole('button', { name: 'トーストを呼ぶ' }),
+    );
+    const body = within(canvasElement.ownerDocument.body);
+    const toast = await body.findByRole('status');
+    // すぐにホバーしてタイマーを止める
+    await userEvent.hover(toast);
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1500);
+    });
+    await expect(body.getByRole('status')).toBeVisible();
+    // ホバーを外すと残り時間で自動クローズが再開する
+    await userEvent.unhover(toast);
+    await waitFor(
+      () => {
+        expect(body.queryByRole('status')).not.toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+  },
+};
+
+export const PauseOnFocus: Story = {
+  render: () => (
+    <ToastTrigger
+      message="フォーカス中は消えません"
+      options={{ duration: 1000 }}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole('button', { name: 'トーストを呼ぶ' }),
+    );
+    const body = within(canvasElement.ownerDocument.body);
+    const toast = await body.findByRole('status');
+    // Tab で閉じるボタンにフォーカスを移すとタイマーが止まる (WCAG 2.2.1)
+    await userEvent.tab();
+    await expect(
+      within(toast).getByRole('button', { name: '閉じる' }),
+    ).toHaveFocus();
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1500);
+    });
+    await expect(body.getByRole('status')).toBeVisible();
+    // フォーカスが外れると残り時間で自動クローズが再開する
+    await userEvent.tab();
+    await waitFor(
+      () => {
+        expect(body.queryByRole('status')).not.toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+  },
+};
+
+export const WithAction: Story = {
+  render: () => (
+    <ToastTrigger
+      message="下書きを削除しました"
+      options={{
+        action: {
+          label: '元に戻す',
+          renderItem: ({ children }) => (
+            <Anchor href="#undo">{children}</Anchor>
+          ),
+        },
+        duration: Number.POSITIVE_INFINITY,
+      }}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole('button', { name: 'トーストを呼ぶ' }),
+    );
+    const body = within(canvasElement.ownerDocument.body);
+    const toast = await body.findByRole('status');
+    await waitFor(() => {
+      expect(
+        within(toast).getByRole('link', { name: '元に戻す' }),
+      ).toBeVisible();
+    });
+  },
+};
+
+export const MaxCount: Story = {
+  render: () => (
+    <ToastTrigger
+      message="上限テスト"
+      options={{ duration: Number.POSITIVE_INFINITY }}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'トーストを呼ぶ' });
+    await userEvent.click(trigger);
+    await userEvent.click(trigger);
+    await userEvent.click(trigger);
+    await userEvent.click(trigger);
+    await userEvent.click(trigger);
+    await userEvent.click(trigger);
+    await userEvent.click(trigger);
+    const body = within(canvasElement.ownerDocument.body);
+    // 6 個目以降を開くと最古が閉じ演出に入り、表示は常に最大 5 個
+    await waitFor(() => {
+      expect(body.getAllByRole('status')).toHaveLength(5);
+    });
+  },
 };

--- a/packages/arte-odyssey/src/components/feedback/toast/toast.tsx
+++ b/packages/arte-odyssey/src/components/feedback/toast/toast.tsx
@@ -1,29 +1,59 @@
 'use client';
 
-import { type FC, useCallback } from 'react';
+import { type FC, useEffect, useRef } from 'react';
 
 import { Alert } from '../alert';
-import { useTimeout } from './../../../hooks/timeout';
 import type { Status } from './../../../types/variables';
-import { useToast } from './context';
+import type { ToastAction } from './context';
 
 type ToastProps = {
-  id: string;
   tone: Status;
   message: string;
+  duration: number;
+  action?: ToastAction;
+  isPaused?: boolean;
+  onClose: () => void;
 };
 
-const DELAY_MS = 5000;
+export const Toast: FC<ToastProps> = ({
+  tone,
+  message,
+  duration,
+  action,
+  isPaused = false,
+  onClose,
+}) => {
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  });
 
-export const Toast: FC<ToastProps> = ({ id, tone, message }) => {
-  const { onClose } = useToast();
+  // 一時停止をまたいで残り時間を持ち越すため、経過分を都度差し引く
+  const remainingRef = useRef(duration);
 
-  useTimeout(
-    useCallback(() => {
-      onClose(id);
-    }, [id, onClose]),
-    DELAY_MS,
+  useEffect(() => {
+    if (isPaused || !Number.isFinite(remainingRef.current)) {
+      return undefined;
+    }
+    // Storybook が Date をモックするため、経過時間は monotonic な performance.now で測る
+    const startedAt = performance.now();
+    const timeoutId = window.setTimeout(() => {
+      onCloseRef.current();
+    }, remainingRef.current);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+      remainingRef.current -= performance.now() - startedAt;
+    };
+  }, [isPaused]);
+
+  return (
+    <Alert
+      action={action}
+      aria-atomic
+      message={message}
+      onClose={onClose}
+      tone={tone}
+    />
   );
-
-  return <Alert message={message} tone={tone} />;
 };

--- a/packages/arte-odyssey/src/components/layout/scroll-linked/scroll-linked.tsx
+++ b/packages/arte-odyssey/src/components/layout/scroll-linked/scroll-linked.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { motion, useScroll, useSpring } from 'motion/react';
+import { motion, MotionConfig, useScroll, useSpring } from 'motion/react';
 import type { FC, RefObject } from 'react';
 
 export const ScrollLinked: FC<{
@@ -14,9 +14,11 @@ export const ScrollLinked: FC<{
   });
 
   return (
-    <motion.div
-      className="bg-primary-bg fixed top-0 right-0 left-0 h-2 origin-left"
-      style={{ scaleX }}
-    />
+    <MotionConfig reducedMotion="user">
+      <motion.div
+        className="bg-primary-bg fixed top-0 right-0 left-0 h-2 origin-left"
+        style={{ scaleX }}
+      />
+    </MotionConfig>
   );
 };

--- a/packages/arte-odyssey/src/components/navigation/tabs/tabs.tsx
+++ b/packages/arte-odyssey/src/components/navigation/tabs/tabs.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { MotionConfig } from 'motion/react';
 import * as motion from 'motion/react-client';
 import {
   type FC,
@@ -158,10 +159,12 @@ const Tab: FC<PropsWithChildren<{ id: string }>> = ({ id, children }) => {
       tabIndex={activeIndex === index ? 0 : -1}
     >
       {selectedId === id && (
-        <motion.div
-          className="bg-primary-border absolute inset-s-0 inset-e-0 -inset-be-0.5 block-1"
-          layoutId={`${rootId}-underline`}
-        />
+        <MotionConfig reducedMotion="user">
+          <motion.div
+            className="bg-primary-border absolute inset-s-0 inset-e-0 -inset-be-0.5 block-1"
+            layoutId={`${rootId}-underline`}
+          />
+        </MotionConfig>
       )}
       {children}
     </div>

--- a/packages/arte-odyssey/src/components/overlays/modal/modal.tsx
+++ b/packages/arte-odyssey/src/components/overlays/modal/modal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { Variants } from 'motion/react';
+import { MotionConfig, type Variants } from 'motion/react';
 import * as motion from 'motion/react-client';
 import {
   type FC,
@@ -140,42 +140,44 @@ export const Modal: FC<
   }, [isOpen, realRef]);
 
   return (
-    <motion.dialog
-      animate={realDialogOpen ? 'open' : 'closed'}
-      className={cn(
-        'bg-bg-raised text-fg-base z-modal shadow-md backdrop:bg-back-drop',
-        type === 'center' &&
-          'm-auto max-h-lg w-5/6 max-w-2xl rounded-lg vertical:h-5/6 vertical:max-h-2xl vertical:w-auto vertical:max-w-lg',
-        type === 'bottom' && 'mt-auto w-screen max-w-screen rounded-t-lg',
-        type === 'right' &&
-          'ml-auto h-svh max-h-none w-screen max-w-sm rounded-l-lg',
-        type === 'left' &&
-          'mr-auto h-svh max-h-none w-screen max-w-sm rounded-r-lg',
-      )}
-      exit="closed"
-      initial="closed"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) {
-          realRef.current?.close();
+    <MotionConfig reducedMotion="user">
+      <motion.dialog
+        animate={realDialogOpen ? 'open' : 'closed'}
+        className={cn(
+          'bg-bg-raised text-fg-base z-modal shadow-md backdrop:bg-back-drop',
+          type === 'center' &&
+            'm-auto max-h-lg w-5/6 max-w-2xl rounded-lg vertical:h-5/6 vertical:max-h-2xl vertical:w-auto vertical:max-w-lg',
+          type === 'bottom' && 'mt-auto w-screen max-w-screen rounded-t-lg',
+          type === 'right' &&
+            'ml-auto h-svh max-h-none w-screen max-w-sm rounded-l-lg',
+          type === 'left' &&
+            'mr-auto h-svh max-h-none w-screen max-w-sm rounded-r-lg',
+        )}
+        exit="closed"
+        initial="closed"
+        onClick={(e) => {
+          if (e.target === e.currentTarget) {
+            realRef.current?.close();
+          }
+        }}
+        onClose={realOnClose}
+        ref={realRef}
+        variants={
+          type === 'center'
+            ? centerVariants
+            : type === 'bottom'
+              ? bottomVariants
+              : type === 'left'
+                ? leftVariants
+                : rightVariants
         }
-      }}
-      onClose={realOnClose}
-      ref={realRef}
-      variants={
-        type === 'center'
-          ? centerVariants
-          : type === 'bottom'
-            ? bottomVariants
-            : type === 'left'
-              ? leftVariants
-              : rightVariants
-      }
-    >
-      <PortalRootProvider value={realRef}>
-        <ToastProvider portalRef={realRef} position="absolute">
-          {children}
-        </ToastProvider>
-      </PortalRootProvider>
-    </motion.dialog>
+      >
+        <PortalRootProvider value={realRef}>
+          <ToastProvider portalRef={realRef} position="absolute">
+            {children}
+          </ToastProvider>
+        </PortalRootProvider>
+      </motion.dialog>
+    </MotionConfig>
   );
 };

--- a/packages/arte-odyssey/src/components/providers/arte-odyssey-provider.tsx
+++ b/packages/arte-odyssey/src/components/providers/arte-odyssey-provider.tsx
@@ -1,12 +1,11 @@
 'use client';
 
-import { MotionConfig } from 'motion/react';
 import type { FC, PropsWithChildren } from 'react';
 
 import { ToastProvider } from '../feedback/toast';
 
+// MotionConfig をここに置くと motion のランタイムが全利用者のバンドルに載るため、
+// reduced motion の指定は motion を使う各コンポーネント側でローカルに行う
 export const ArteOdysseyProvider: FC<PropsWithChildren> = ({ children }) => (
-  <MotionConfig reducedMotion="user">
-    <ToastProvider>{children}</ToastProvider>
-  </MotionConfig>
+  <ToastProvider>{children}</ToastProvider>
 );

--- a/packages/arte-odyssey/src/styles/base.css
+++ b/packages/arte-odyssey/src/styles/base.css
@@ -105,9 +105,52 @@
   }
 }
 
+/*
+ * Toast の出入り。出現は下からのスライドイン、退出は data-closing で
+ * 高さ(0fr)・間隔(padding)・不透明度を同時に畳み、後続トーストの詰めも
+ * 1 つの transition で表現する（JS 側は EXIT_MS 経過後に DOM から除去）。
+ */
+.ao-toast-item {
+  display: grid;
+  grid-template-rows: 1fr;
+  padding-block-start: 1rem;
+  transition:
+    grid-template-rows 0.2s ease,
+    opacity 0.2s ease,
+    padding-block-start 0.2s ease;
+}
+.ao-toast-item > * {
+  min-block-size: 0;
+}
+.ao-toast-item[data-closing] {
+  grid-template-rows: 0fr;
+  opacity: 0;
+  padding-block-start: 0;
+}
+/* 安静時は影(shadow-lg)を切り抜かないよう、畳む間だけ overflow を隠す */
+.ao-toast-item[data-closing] > * {
+  overflow: hidden;
+}
+.ao-toast-enter {
+  animation: ao-toast-in 0.2s ease;
+}
+
+@keyframes ao-toast-in {
+  from {
+    opacity: 0;
+    translate: 0 1.5rem;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .ao-anim-scale:popover-open,
   .ao-anim-fade:popover-open {
     animation: none;
+  }
+  .ao-toast-enter {
+    animation: none;
+  }
+  .ao-toast-item {
+    transition: none;
   }
 }


### PR DESCRIPTION
## 概要

Toast に duration / action / 手動クローズ / ホバー・フォーカスでの一時停止を追加し、出入りのアニメーションを motion から CSS に置き換える。あわせて `ArteOdysseyProvider` から `MotionConfig` を外し、motion を使う 3 コンポーネント（Modal / Tabs / ScrollLinked）にローカル配置する。

**これにより、Modal / Tabs / ScrollLinked を使わないアプリのバンドルから motion のランタイム（数十KB gzip）が丸ごと外れます**（motion 段階的全面削除の第一歩）。

## 動機

監査で Toast は a11y・UX・パフォーマンスの 3 観点すべてが最重要級と判定した唯一のコンポーネントだった:

- 5 秒固定で自動消滅し、手動で閉じる・一時停止する手段が一切ない（WCAG 2.2.1 Timing Adjustable 違反）
- トーストを使わないアプリにも Provider 経由で motion のフルランタイムが同梱される

## 詳細

**新 API（後方互換）**
- `onOpen(tone, message, options?)`: `duration`（`Infinity` で自動クローズなし・既定 5000ms）と `action`（Alert と同じ `{ label, renderItem }`）
- 全トーストに閉じるボタン。ホバー / フォーカス中はタイマー停止、残り時間から再開（Storybook の Date モックに影響されない `performance.now` 計測）
- 上限 5 件超過時は最古から閉じ演出つきで退避

**CSS アニメーション化**
- 出現: `ao-toast-in`（下からスライド + フェード 0.2s）
- 退出: `grid-template-rows 1fr→0fr` + padding + opacity の transition で、高さごと畳んで後続トーストの詰めも 1 つの transition で表現
- DOM 除去は id ごとの EXIT_MS タイマー（`transitionend` 非依存なので reduced motion でも確実に除去）。閉じ演出中は `inert`
- `prefers-reduced-motion` では enter/exit とも無効化

**a11y の整理**
- role をラッパーとの二重付与から Alert 自身の `status` / `alert` に一本化
- ライブリージョンの section をマウント直後から DOM に存在させ（初回トーストの読み上げ取りこぼし対策）、空の間は aria-label を外して region ランドマーク化しない（複数 Provider 共存時の axe landmark-unique 違反を回避）

## 気をつけるポイント

- **既知の制約**: 閉じるボタンにフォーカスがある状態でトーストが消えるとフォーカスが body に落ちる。フォーカス返還のロジックは次メジャー設計（Phase 5）で扱う
- toast stories はトリガーボタン方式に書き換えたため VRT のベースラインが変わる
- docs（references/components.md の useToast 節）の更新は #584 と競合するためマージ後のフォローアップで行う
- レビューエージェントの指摘 5 件（削除タイマーの際限ない先送り・updater 内の randomUUID・フォーカス一時停止のテスト欠如・ライブリージョンの初期不在・閉じ演出中のゴーストフォーカス）はすべて修正済み

## テスト

- 85 ファイル / 369 テスト全パス（Playwright 実ブラウザ）
- 新規 play テスト 9 本: 手動クローズ / 自動クローズ / `Infinity` / ホバー一時停止 / **フォーカス一時停止（Tab 操作）** / action / 上限退避 / tone 別 role / 閉じるボタン常設