### PR TITLE
feat: motion 依存を完全に削除し Modal / Tabs / ScrollLinked を CSS 実装に置き換える

### DIFF
--- a/.changeset/remove-motion.md
+++ b/.changeset/remove-motion.md
@@ -1,0 +1,12 @@
+---
+'@k8o/arte-odyssey': minor
+---
+
+motion（framer-motion）依存を完全に削除しました。Modal / Tabs / ScrollLinked のアニメーションを CSS に置き換え、どのコンポーネントを使ってもライブラリ由来で motion がバンドルされることはなくなりました。
+
+- **Modal**: `@starting-style` + `transition-behavior: allow-discrete` + `overlay` による CSS transition に移行。これまで実装されていながら再生されていなかった**退場アニメーションが実際に動くようになりました**（backdrop のフェード込み）。`overlay` 未対応ブラウザ（Safari / Firefox）は `@supports` で退場を即時に切り替え、位置ずれしたゴーストが残らないようにしています（入場アニメーションは全対応ブラウザで動作）
+- **Tabs**: 選択インジケータを CSS Anchor Positioning（`anchor-name` + `inset` の transition）によるスライドに移行。Popover と同じプラットフォーム依存で、未対応ブラウザでは選択タブの静的な下線に劣化します。`anchor-scope` で複数 React ルート間の名前衝突も防いでいます
+- **ScrollLinked**: CSS scroll-driven animations（`animation-timeline: scroll(root)`）に移行。未対応ブラウザ（Firefox）と `container` 指定時は scroll リスナー + ResizeObserver で同じ見た目を再現します。バーに `aria-hidden` を付与しました
+- `prefers-reduced-motion` は CSS メディアクエリで尊重します。従来の `MotionConfig reducedMotion="user"`（transform 系のみ無効化）より保守的に、Modal は退場含め遷移を完全に無効化します
+
+公開 API の変更はありません。

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -19,6 +19,21 @@
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["--filter", "@k8o/arte-odyssey", "storybook"],
       "port": 6006
+    },
+    {
+      "name": "storybook-wt",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": [
+        "--filter",
+        "@k8o/arte-odyssey",
+        "exec",
+        "storybook",
+        "dev",
+        "-p",
+        "6016",
+        "--no-open"
+      ],
+      "port": 6016
     }
   ]
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -17,7 +17,6 @@
     "@funstack/static": "1.2.0",
     "@k8o/arte-odyssey": "workspace:^",
     "@tailwindcss/vite": "catalog:",
-    "motion": "12.40.0",
     "react-error-boundary": "6.1.2",
     "shiki": "4.1.0",
     "tailwindcss": "catalog:"

--- a/apps/docs/src/pages/components/popover-page.tsx
+++ b/apps/docs/src/pages/components/popover-page.tsx
@@ -40,7 +40,6 @@ const popoverContentProps: PropItem[] = [
     types: ['(props: Record<string, unknown>) => ReactElement'],
     defaultValue: null,
   },
-  { name: 'motionVariants', types: ['Variants'], defaultValue: null },
 ];
 
 export function PopoverPage() {

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -16,7 +16,4 @@ export default defineConfig({
     tailwindcss(),
     react(),
   ],
-  optimizeDeps: {
-    include: ['motion/react-client', 'motion/react'],
-  },
 });

--- a/packages/arte-odyssey/package.json
+++ b/packages/arte-odyssey/package.json
@@ -95,7 +95,6 @@
   "dependencies": {
     "clsx": "2.1.1",
     "lucide-react": "1.17.0",
-    "motion": "12.40.0",
     "tailwind-merge": "3.6.0"
   },
   "devDependencies": {

--- a/packages/arte-odyssey/src/components/layout/scroll-linked/scroll-linked.stories.tsx
+++ b/packages/arte-odyssey/src/components/layout/scroll-linked/scroll-linked.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useRef } from 'react';
+import { expect, waitFor, within } from 'storybook/test';
 
 import { ScrollLinked } from './scroll-linked';
 
@@ -64,4 +65,29 @@ export const WithContainer: Story = {
       );
     },
   ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const scroller = canvas.getByLabelText('スクロールコンテナの例');
+    const bar = canvasElement.querySelector<HTMLElement>(
+      'div[aria-hidden="true"]',
+    );
+    if (!bar) {
+      throw new Error('progress bar not found');
+    }
+    // コンテナのスクロールに追従する
+    scroller.scrollTop = (scroller.scrollHeight - scroller.clientHeight) / 2;
+    await waitFor(() => {
+      expect(Number.parseFloat(bar.style.scale)).toBeCloseTo(0.5, 1);
+    });
+    // スクロールせずコンテンツの高さが変わっても ResizeObserver 経由で
+    // 進捗率が再計算される（コンテンツ倍増でおよそ半分の進捗率に下がる）
+    const content = scroller.querySelector<HTMLElement>('.h-\\[200vh\\]');
+    if (!content) {
+      throw new Error('content not found');
+    }
+    content.style.height = '400vh';
+    await waitFor(() => {
+      expect(Number.parseFloat(bar.style.scale)).toBeLessThan(0.35);
+    });
+  },
 };

--- a/packages/arte-odyssey/src/components/layout/scroll-linked/scroll-linked.stories.tsx
+++ b/packages/arte-odyssey/src/components/layout/scroll-linked/scroll-linked.stories.tsx
@@ -12,9 +12,7 @@ export default meta;
 type Story = StoryObj<typeof ScrollLinked>;
 
 export const NoScroll: Story = {
-  // The progress bar is driven by a motion spring (not CSS animation), so
-  // its resting state is not pixel-deterministic — and with no scroll the
-  // screenshot is a blank page anyway.
+  // With no scroll the screenshot is a blank page (the bar rests at scale 0).
   parameters: { vrt: { skip: true } },
 };
 

--- a/packages/arte-odyssey/src/components/layout/scroll-linked/scroll-linked.tsx
+++ b/packages/arte-odyssey/src/components/layout/scroll-linked/scroll-linked.tsx
@@ -55,8 +55,13 @@ export const ScrollLinked: FC<{
       // （native の ScrollTimeline はレイアウト変化に自動追従するため合わせる）
       const observer = new ResizeObserver(update);
       observer.observe(target ?? document.documentElement);
-      if (target?.firstElementChild) {
-        observer.observe(target.firstElementChild);
+      // コンテンツ高(scrollHeight)の変化は target 自身の box には現れないため
+      // 直下の子要素を監視する（バー自身が混ざっても無害）。attach 後に
+      // 追加された子までは追わず、次の scroll / resize で追従する
+      if (target) {
+        for (const child of target.children) {
+          observer.observe(child);
+        }
       }
       window.addEventListener('resize', update);
       cleanup = () => {

--- a/packages/arte-odyssey/src/components/layout/scroll-linked/scroll-linked.tsx
+++ b/packages/arte-odyssey/src/components/layout/scroll-linked/scroll-linked.tsx
@@ -1,24 +1,89 @@
 'use client';
 
-import { motion, MotionConfig, useScroll, useSpring } from 'motion/react';
-import type { FC, RefObject } from 'react';
+import { type FC, type RefObject, useEffect, useRef } from 'react';
 
+import { cn } from './../../../helpers/cn';
+
+/**
+ * ページ（または container）のスクロール進捗バー。
+ * CSS scroll-driven animations（animation-timeline: scroll()）で描画し、
+ * 未対応ブラウザ（Firefox）と container 指定時は同じ見た目を
+ * scroll リスナー + ResizeObserver で再現する（named timeline +
+ * timeline-scope を任意の外部要素へ配線するより単純で確実なため）。
+ */
 export const ScrollLinked: FC<{
   container?: RefObject<HTMLElement | null>;
 }> = ({ container }) => {
-  const { scrollYProgress } = useScroll({ container });
-  const scaleX = useSpring(scrollYProgress, {
-    stiffness: 100,
-    damping: 30,
-    restDelta: 0.01,
-  });
+  const barRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const bar = barRef.current;
+    if (!bar) {
+      return undefined;
+    }
+    if (
+      container === undefined &&
+      CSS.supports('animation-timeline', 'scroll()')
+    ) {
+      return undefined;
+    }
+
+    let cleanup: (() => void) | undefined;
+    let retryId: number | undefined;
+
+    const attach = () => {
+      // container の要素が後からマウントされるケースでは、window に
+      // フォールバックすると誤ったスクローラーを恒久的に追跡してしまう。
+      // ref が解決するまで接続を遅らせる
+      if (container?.current === null) {
+        retryId = window.setTimeout(attach, 50);
+        return;
+      }
+      const target = container?.current ?? null;
+      const scroller: HTMLElement | Window = target ?? window;
+      const update = () => {
+        const scrollTop = target ? target.scrollTop : window.scrollY;
+        const scrollable = target
+          ? target.scrollHeight - target.clientHeight
+          : document.documentElement.scrollHeight - window.innerHeight;
+        const progress = scrollable > 0 ? scrollTop / scrollable : 0;
+        bar.style.scale = `${Math.min(1, Math.max(0, progress)).toString()} 1`;
+      };
+      update();
+      scroller.addEventListener('scroll', update, { passive: true });
+      // リサイズやコンテンツ高さの変化でも進捗を再計算する
+      // （native の ScrollTimeline はレイアウト変化に自動追従するため合わせる）
+      const observer = new ResizeObserver(update);
+      observer.observe(target ?? document.documentElement);
+      if (target?.firstElementChild) {
+        observer.observe(target.firstElementChild);
+      }
+      window.addEventListener('resize', update);
+      cleanup = () => {
+        scroller.removeEventListener('scroll', update);
+        observer.disconnect();
+        window.removeEventListener('resize', update);
+      };
+    };
+    attach();
+
+    return () => {
+      if (retryId !== undefined) {
+        window.clearTimeout(retryId);
+      }
+      cleanup?.();
+    };
+  }, [container]);
 
   return (
-    <MotionConfig reducedMotion="user">
-      <motion.div
-        className="bg-primary-bg fixed top-0 right-0 left-0 h-2 origin-left"
-        style={{ scaleX }}
-      />
-    </MotionConfig>
+    <div
+      aria-hidden="true"
+      className={cn(
+        'bg-primary-bg fixed top-0 right-0 left-0 h-2 origin-left scale-[0_1]',
+        // CSS アニメーションが有効な間は inline の scale より優先される
+        container === undefined && 'ao-scroll-progress',
+      )}
+      ref={barRef}
+    />
   );
 };

--- a/packages/arte-odyssey/src/components/navigation/tabs/tabs.tsx
+++ b/packages/arte-odyssey/src/components/navigation/tabs/tabs.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { MotionConfig } from 'motion/react';
-import * as motion from 'motion/react-client';
 import {
+  type CSSProperties,
   type FC,
   type KeyboardEvent,
   type PropsWithChildren,
@@ -28,6 +27,17 @@ type TabsContext = {
   selectedId: string;
   setSelectedId: (id: string) => void;
 };
+
+// React の CSSProperties はまだ anchor positioning 系プロパティを型に持たない
+type AnchorCSSProperties = CSSProperties & {
+  anchorName?: string;
+  anchorScope?: string;
+  positionAnchor?: string;
+};
+
+// useId() の戻り値は CSS の dashed-ident として無効な文字を含むので無害化する
+const toAnchorName = (rootId: string): string =>
+  `--ao-tab-${rootId.replaceAll(/[^a-zA-Z0-9_-]/gu, '')}`;
 
 const [TabsProvider, useTabsState] = createSafeContext<TabsContext>(
   'useTabsState must be used within a TabsProvider',
@@ -92,12 +102,24 @@ const List: FC<
     <div
       aria-label={label}
       aria-orientation={writingMode === 'vertical' ? 'vertical' : 'horizontal'}
-      className="border-border-base vertical:border-b-0 vertical:border-l vertical:overflow-x-hidden vertical:overflow-y-auto flex overflow-x-auto overflow-y-hidden border-b p-0.5 wrap-normal"
+      className="border-border-base vertical:border-b-0 vertical:border-l vertical:overflow-x-hidden vertical:overflow-y-auto relative flex overflow-x-auto overflow-y-hidden border-b p-0.5 wrap-normal"
       id={`${rootId}-tablist`}
       ref={listRef}
       role="tablist"
+      style={
+        // useId は React ルートを跨ぐと衝突しうるので、anchor 名の解決を
+        // この tablist のサブツリーに限定する
+        { anchorScope: toAnchorName(rootId) } satisfies AnchorCSSProperties
+      }
     >
       <TabsListProvider value={listContextValue}>{children}</TabsListProvider>
+      <div
+        aria-hidden="true"
+        className="ao-tab-indicator bg-primary-border"
+        style={
+          { positionAnchor: toAnchorName(rootId) } satisfies AnchorCSSProperties
+        }
+      />
     </div>
   );
 };
@@ -134,7 +156,7 @@ const Tab: FC<PropsWithChildren<{ id: string }>> = ({ id, children }) => {
       aria-controls={selectedId === id ? `${rootId}-panel-${id}` : undefined}
       aria-selected={selectedId === id}
       className={cn(
-        'relative cursor-pointer rounded-lg p-2 transition-colors',
+        'ao-tab relative cursor-pointer rounded-lg p-2 transition-colors',
         selectedId !== id && 'hover:bg-primary-bg-subtle hover:text-primary-fg',
         FOCUS_RING,
       )}
@@ -156,16 +178,14 @@ const Tab: FC<PropsWithChildren<{ id: string }>> = ({ id, children }) => {
       }}
       ref={ref}
       role="tab"
+      style={
+        // 選択中のタブをインジケータ(ao-tab-indicator)のアンカーにする
+        (selectedId === id
+          ? { anchorName: toAnchorName(rootId) }
+          : undefined) satisfies AnchorCSSProperties | undefined
+      }
       tabIndex={activeIndex === index ? 0 : -1}
     >
-      {selectedId === id && (
-        <MotionConfig reducedMotion="user">
-          <motion.div
-            className="bg-primary-border absolute inset-s-0 inset-e-0 -inset-be-0.5 block-1"
-            layoutId={`${rootId}-underline`}
-          />
-        </MotionConfig>
-      )}
       {children}
     </div>
   );

--- a/packages/arte-odyssey/src/components/overlays/modal/modal.tsx
+++ b/packages/arte-odyssey/src/components/overlays/modal/modal.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { MotionConfig, type Variants } from 'motion/react';
-import * as motion from 'motion/react-client';
 import {
   type FC,
   type PropsWithChildren,
@@ -15,81 +13,6 @@ import {
 import { ToastProvider } from '../../feedback/toast';
 import { PortalRootProvider } from '../../providers';
 import { cn } from './../../../helpers/cn';
-
-const centerVariants: Variants = {
-  open: {
-    opacity: 1,
-    scale: 1,
-    transition: {
-      duration: 0.2,
-      ease: [0.4, 0, 0.2, 1],
-    },
-  },
-  closed: {
-    opacity: 0,
-    scale: 0.9,
-    transition: {
-      duration: 0.2,
-      ease: [0.4, 0, 0.2, 1],
-    },
-  },
-};
-
-const bottomVariants: Variants = {
-  open: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      duration: 0.2,
-      ease: [0.4, 0, 0.2, 1],
-    },
-  },
-  closed: {
-    opacity: 0,
-    y: '100%',
-    transition: {
-      duration: 0.2,
-      ease: [0.4, 0, 0.2, 1],
-    },
-  },
-};
-const rightVariants: Variants = {
-  open: {
-    opacity: 1,
-    x: 0,
-    transition: {
-      duration: 0.3,
-      ease: [0.4, 0, 0.2, 1],
-    },
-  },
-  closed: {
-    opacity: 0,
-    x: '100%',
-    transition: {
-      duration: 0.3,
-      ease: [0.4, 0, 0.2, 1],
-    },
-  },
-};
-
-const leftVariants: Variants = {
-  open: {
-    opacity: 1,
-    x: 0,
-    transition: {
-      duration: 0.3,
-      ease: [0.4, 0, 0.2, 1],
-    },
-  },
-  closed: {
-    opacity: 0,
-    x: '-100%',
-    transition: {
-      duration: 0.3,
-      ease: [0.4, 0, 0.2, 1],
-    },
-  },
-};
 
 export const Modal: FC<
   PropsWithChildren<{
@@ -140,44 +63,32 @@ export const Modal: FC<
   }, [isOpen, realRef]);
 
   return (
-    <MotionConfig reducedMotion="user">
-      <motion.dialog
-        animate={realDialogOpen ? 'open' : 'closed'}
-        className={cn(
-          'bg-bg-raised text-fg-base z-modal shadow-md backdrop:bg-back-drop',
-          type === 'center' &&
-            'm-auto max-h-lg w-5/6 max-w-2xl rounded-lg vertical:h-5/6 vertical:max-h-2xl vertical:w-auto vertical:max-w-lg',
-          type === 'bottom' && 'mt-auto w-screen max-w-screen rounded-t-lg',
-          type === 'right' &&
-            'ml-auto h-svh max-h-none w-screen max-w-sm rounded-l-lg',
-          type === 'left' &&
-            'mr-auto h-svh max-h-none w-screen max-w-sm rounded-r-lg',
-        )}
-        exit="closed"
-        initial="closed"
-        onClick={(e) => {
-          if (e.target === e.currentTarget) {
-            realRef.current?.close();
-          }
-        }}
-        onClose={realOnClose}
-        ref={realRef}
-        variants={
-          type === 'center'
-            ? centerVariants
-            : type === 'bottom'
-              ? bottomVariants
-              : type === 'left'
-                ? leftVariants
-                : rightVariants
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions -- onClick は枠外(backdrop)クリックで閉じるためのもの。キーボード等価操作はネイティブ modal dialog の Escape が担う
+    <dialog
+      className={cn(
+        'ao-modal bg-bg-raised text-fg-base z-modal shadow-md backdrop:bg-back-drop',
+        type === 'center' &&
+          'ao-modal-center m-auto max-h-lg w-5/6 max-w-2xl rounded-lg vertical:h-5/6 vertical:max-h-2xl vertical:w-auto vertical:max-w-lg',
+        type === 'bottom' &&
+          'ao-modal-bottom mt-auto w-screen max-w-screen rounded-t-lg',
+        type === 'right' &&
+          'ao-modal-right ml-auto h-svh max-h-none w-screen max-w-sm rounded-l-lg',
+        type === 'left' &&
+          'ao-modal-left mr-auto h-svh max-h-none w-screen max-w-sm rounded-r-lg',
+      )}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) {
+          realRef.current?.close();
         }
-      >
-        <PortalRootProvider value={realRef}>
-          <ToastProvider portalRef={realRef} position="absolute">
-            {children}
-          </ToastProvider>
-        </PortalRootProvider>
-      </motion.dialog>
-    </MotionConfig>
+      }}
+      onClose={realOnClose}
+      ref={realRef}
+    >
+      <PortalRootProvider value={realRef}>
+        <ToastProvider portalRef={realRef} position="absolute">
+          {children}
+        </ToastProvider>
+      </PortalRootProvider>
+    </dialog>
   );
 };

--- a/packages/arte-odyssey/src/components/providers/arte-odyssey-provider.tsx
+++ b/packages/arte-odyssey/src/components/providers/arte-odyssey-provider.tsx
@@ -4,8 +4,8 @@ import type { FC, PropsWithChildren } from 'react';
 
 import { ToastProvider } from '../feedback/toast';
 
-// MotionConfig をここに置くと motion のランタイムが全利用者のバンドルに載るため、
-// reduced motion の指定は motion を使う各コンポーネント側でローカルに行う
+// アニメーションは全て CSS で実装しており、reduced motion は base.css の
+// @media (prefers-reduced-motion) が一元処理するため、Provider の責務はトーストのみ
 export const ArteOdysseyProvider: FC<PropsWithChildren> = ({ children }) => (
   <ToastProvider>{children}</ToastProvider>
 );

--- a/packages/arte-odyssey/src/styles/base.css
+++ b/packages/arte-odyssey/src/styles/base.css
@@ -76,7 +76,7 @@
 /*
  * Popover（top-layer）の開く時のアニメーション。
  * :popover-open になった瞬間に keyframe を再生する。安静時の値は上書きしない
- * （natural=opacity:1）ため固着しない。閉じる時は display:none で即時（Modal/Drawer 同様）。
+ * （natural=opacity:1）ため固着しない。閉じる時は display:none で即時。
  * scale は transform ではなく `scale` プロパティを使い、CSS Anchor Positioning
  * （inset で配置）と干渉させない。
  */
@@ -142,6 +142,152 @@
   }
 }
 
+/*
+ * Modal（<dialog>）の出入り。入場は @starting-style からの transition、
+ * 退場は transition-behavior: allow-discrete による display の遅延で表現する。
+ * overlay を transition に含めることで、退場中も top layer に留まる
+ * （overlay 未対応ブラウザでは退場が即時になる、という段階的劣化）。
+ * scale / translate は transform ではなく個別プロパティを使う（Popover 同様）。
+ */
+/* allow-discrete は per-transition で指定する。ショートハンド後の別行
+   transition-behavior は lightningcss の宣言並べ替えでリセットされ、
+   本番ビルドだけ退場アニメーションが消える */
+.ao-modal {
+  opacity: 0;
+  transition:
+    opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+    scale 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+    translate 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+    display 0.2s allow-discrete,
+    overlay 0.2s allow-discrete;
+}
+.ao-modal[open] {
+  opacity: 1;
+}
+.ao-modal[open]::backdrop {
+  opacity: 1;
+}
+.ao-modal::backdrop {
+  opacity: 0;
+  transition:
+    opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+    display 0.2s allow-discrete,
+    overlay 0.2s allow-discrete;
+}
+/* overlay 未対応ブラウザ(Safari / Firefox)では close で top layer から即座に
+   外れるため、display の遅延だけが残ると位置がジャンプしたゴーストが
+   0.2s クリック可能なまま残る。退場を本当に即時にする(入場は影響なし) */
+@supports not (overlay: auto) {
+  .ao-modal:not([open]),
+  .ao-modal:not([open])::backdrop {
+    transition: none;
+  }
+}
+@starting-style {
+  .ao-modal[open],
+  .ao-modal[open]::backdrop {
+    opacity: 0;
+  }
+}
+
+.ao-modal-center {
+  scale: 0.9;
+}
+.ao-modal-center[open] {
+  scale: 1;
+}
+.ao-modal-bottom {
+  translate: 0 100%;
+}
+.ao-modal-right {
+  translate: 100% 0;
+}
+.ao-modal-left {
+  translate: -100% 0;
+}
+.ao-modal-bottom[open],
+.ao-modal-right[open],
+.ao-modal-left[open] {
+  translate: 0 0;
+}
+.ao-modal-right,
+.ao-modal-left {
+  transition-duration: 0.3s;
+}
+@starting-style {
+  .ao-modal-center[open] {
+    scale: 0.9;
+  }
+  .ao-modal-bottom[open] {
+    translate: 0 100%;
+  }
+  .ao-modal-right[open] {
+    translate: 100% 0;
+  }
+  .ao-modal-left[open] {
+    translate: -100% 0;
+  }
+}
+
+/*
+ * Tabs の選択インジケータ。選択中のタブを anchor にした単一要素を
+ * inset の transition でスライドさせる（旧 motion layoutId の置き換え）。
+ * position-area は transition できないため inset + anchor() を使う。
+ * self-* キーワードは論理プロパティと合わせて縦書きでも正しい辺に解決される。
+ */
+.ao-tab-indicator {
+  position: absolute;
+  inset-inline-start: anchor(self-start);
+  inset-inline-end: anchor(self-end);
+  inset-block-start: calc(anchor(self-end) - 0.125rem);
+  block-size: 0.25rem;
+  /* 純装飾。タブ下端やスライド通過中のクリックを横取りしない */
+  pointer-events: none;
+}
+@media (prefers-reduced-motion: no-preference) {
+  .ao-tab-indicator {
+    transition: inset 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+}
+/* anchor positioning 未対応ブラウザでは anchor() が無効になり迷子のバーが
+   残るため隠し、選択タブ側の静的な下線で選択表示を維持する（スライドなし）。
+   box-shadow だと utilities レイヤーの focus-visible リングを潰すため
+   擬似要素 + 論理プロパティで描く（.ao-tab は Tabs.Tab だけに付く） */
+@supports not (anchor-name: --a) {
+  .ao-tab-indicator {
+    display: none;
+  }
+  .ao-tab[aria-selected='true']::after {
+    content: '';
+    position: absolute;
+    inset-inline: 0;
+    inset-block-end: -0.125rem;
+    block-size: 0.25rem;
+    background: var(--primary-border);
+  }
+}
+
+/*
+ * スクロール進捗バー。ルートスクローラーの進捗を scale x に写像する。
+ * @supports 外（Firefox）と container 指定時はコンポーネント側の
+ * scroll リスナーが inline の scale を更新する。ユーザーのスクロールに
+ * 1:1 で追従する機能的表示のため prefers-reduced-motion では無効化しない。
+ */
+@supports (animation-timeline: scroll()) {
+  .ao-scroll-progress {
+    animation: ao-scroll-grow auto linear;
+    animation-timeline: scroll(root);
+  }
+  @keyframes ao-scroll-grow {
+    from {
+      scale: 0 1;
+    }
+    to {
+      scale: 1 1;
+    }
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .ao-anim-scale:popover-open,
   .ao-anim-fade:popover-open {
@@ -151,6 +297,10 @@
     animation: none;
   }
   .ao-toast-item {
+    transition: none;
+  }
+  .ao-modal,
+  .ao-modal::backdrop {
     transition: none;
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,9 +89,6 @@ importers:
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.3.0(vite@8.0.16(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0))
-      motion:
-        specifier: 12.40.0
-        version: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-error-boundary:
         specifier: 6.1.2
         version: 6.1.2(react@19.2.6)
@@ -215,9 +212,6 @@ importers:
       lucide-react:
         specifier: 1.17.0
         version: 1.17.0(react@19.2.6)
-      motion:
-        specifier: 12.40.0
-        version: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       tailwind-merge:
         specifier: 3.6.0
         version: 3.6.0
@@ -3074,20 +3068,6 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  framer-motion@12.40.0:
-    resolution: {integrity: sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==}
-    peerDependencies:
-      '@emotion/is-prop-valid': '*'
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/is-prop-valid':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3570,26 +3550,6 @@ packages:
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  motion-dom@12.40.0:
-    resolution: {integrity: sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==}
-
-  motion-utils@12.39.0:
-    resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
-
-  motion@12.40.0:
-    resolution: {integrity: sha512-yjrHUrBFW6kQvjJwRsoiPSAhC5tRwRqNGJWmiJ4CrGnbKp0V88AdzkhBmDoqIsIPfarOe0Uddd37Xq43/gIocA==}
-    peerDependencies:
-      '@emotion/is-prop-valid': '*'
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/is-prop-valid':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -6699,15 +6659,6 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  framer-motion@12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
-    dependencies:
-      motion-dom: 12.40.0
-      motion-utils: 12.39.0
-      tslib: 2.8.1
-    optionalDependencies:
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
   fsevents@2.3.2:
     optional: true
 
@@ -7416,20 +7367,6 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.3: {}
-
-  motion-dom@12.40.0:
-    dependencies:
-      motion-utils: 12.39.0
-
-  motion-utils@12.39.0: {}
-
-  motion@12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
-    dependencies:
-      framer-motion: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      tslib: 2.8.1
-    optionalDependencies:
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
 
   mri@1.2.0: {}
 


### PR DESCRIPTION
## 概要

motion（framer-motion）のランタイム依存をライブラリから完全に削除する。#588 の Toast CSS 化に続く最終段で、残っていた Modal / Tabs / ScrollLinked を CSS 実装に置き換え、dependencies から motion を外す。**公開 API の変更なし**。

## 動機

トースト・アニメーションを使うだけで motion のフルランタイム（数十KB gzip）が利用者のバンドルに載る問題の根本解消（承認済みの段階的削除方針の完了）。「控えめなアニメーション」のデザイン原則には CSS で十分。

## 詳細

- **Modal**: `@starting-style` + `transition-behavior: allow-discrete` + `overlay`。**従来 dead code だった退場アニメーションが実際に再生されるようになる**（backdrop フェード込み）
- **Tabs**: `layoutId` の下線 → CSS Anchor Positioning の単一インジケータ（`anchor-name` + `inset` transition）。Popover と同じプラットフォーム前提。`anchor-scope` でルート間衝突防止、`pointer-events: none` でクリック横取り防止、未対応ブラウザは静的下線に劣化
- **ScrollLinked**: `animation-timeline: scroll(root)`。Firefox / `container` 指定時は scroll リスナー + ResizeObserver で再現。`aria-hidden` 付与
- reduced motion は base.css の `@media (prefers-reduced-motion)` に一元化（modern-web-guidance のガイド 3 本に準拠）

## レビューで潰した問題（3視点の並列レビュー + 実ブラウザ検証済み）

- **[high] 本番ビルドで退場アニメが消えるバグ**: ショートハンド後の別行 `transition-behavior` は lightningcss の宣言並べ替えでリセットされる（dev では動くため VRT/Chromatic をすり抜ける）。per-transition の `allow-discrete` 指定に変更し、**docs の実ビルド出力（最小化後 CSS）で保持を確認済み**
- **[high] Safari/Firefox のゴースト dialog**: `overlay` 未対応環境では display 遅延だけが生き残り、top layer から外れた位置に 0.2s クリック可能なゴーストが残る → `@supports not (overlay: auto)` で退場を即時化
- **[medium]** タブフォールバックの `[role=tab]` グローバル汚染・focus-visible リング消失・縦書き破綻 → クラススコープ + 擬似要素 + 論理プロパティに変更 / インジケータの `pointer-events` / ScrollLinked のリサイズ非追従・container 遅延マウント

## 検証

- Chromium 実測: Modal enter/exit とも opacity/scale/display/overlay の CSSTransition 発火、Tabs はクリックで transition 発火し選択タブへ正確に着地、ScrollLinked は ScrollTimeline 駆動 + フォールバックが 0→0.5→1 追従（レビューエージェントは WebKit でも Modal/Tabs を確認）
- 85 ファイル / 377 テスト全パス、typecheck / lint / check:package / docs ビルド通過

## 気をつけるポイント

- Modal の退場が新たに再生されるため Chromatic に差分が出る（改善方向の差分）
- Firefox は anchor positioning / scroll-driven animations とも未対応: Tabs はスライドなしの静的下線、ScrollLinked は JS フォールバックで同じ見た目（Popover が既に同じ前提のため、サポート面の新規後退はなし）