### PR TITLE
fix(docs): Alert のアクション例による RSC ペイロード生成エラーを解消する

### DIFF
--- a/.changeset/docs-alert-rsc-payload.md
+++ b/.changeset/docs-alert-rsc-payload.md
@@ -1,0 +1,5 @@
+---
+'@k8o/arte-odyssey': none
+---
+
+ドキュメントサイトの SSG で、Alert のアクションボタン例が RSC ペイロード生成エラー（Event handlers cannot be passed to Client Component props）を起こし、フォールバックペイロードにエラーチャンクが埋め込まれていたのを修正しました。該当例を 'use client' のプレビューコンポーネントに切り出しています。npm パッケージの内容には影響しません。

--- a/apps/docs/src/pages/components/_previews/alert-previews.tsx
+++ b/apps/docs/src/pages/components/_previews/alert-previews.tsx
@@ -3,6 +3,27 @@
 import { Alert, Button } from '@k8o/arte-odyssey';
 import { useState } from 'react';
 
+export function AlertActionButtonPreview() {
+  return (
+    <Alert
+      action={{
+        label: 'Open settings',
+        renderItem: ({ children }) => (
+          <button
+            className="text-fg-info underline"
+            onClick={() => {}}
+            type="button"
+          >
+            {children}
+          </button>
+        ),
+      }}
+      message="Your profile setup is incomplete."
+      tone="warning"
+    />
+  );
+}
+
 export function AlertDismissiblePreview() {
   const [isVisible, setIsVisible] = useState(true);
   return isVisible ? (

--- a/apps/docs/src/pages/components/alert-page.tsx
+++ b/apps/docs/src/pages/components/alert-page.tsx
@@ -7,6 +7,7 @@ import { PropsTable } from '../../components/props-table';
 import { T } from '../../components/t';
 import { STORYBOOK_URL } from '../../constants';
 import {
+  AlertActionButtonPreview,
   AlertDismissiblePreview,
   AlertWithActionPreview,
 } from './_previews/alert-previews';
@@ -172,22 +173,7 @@ export function AlertPage() {
               message="A new version is available."
               tone="info"
             />
-            <Alert
-              action={{
-                label: 'Open settings',
-                renderItem: ({ children }) => (
-                  <button
-                    className="text-fg-info underline"
-                    onClick={() => {}}
-                    type="button"
-                  >
-                    {children}
-                  </button>
-                ),
-              }}
-              message="Your profile setup is incomplete."
-              tone="warning"
-            />
+            <AlertActionButtonPreview />
           </ComponentPreview>
         </div>
 


### PR DESCRIPTION
## 概要

docs の SSG ビルド中に「Event handlers cannot be passed to Client Component props」がログへ出力され、ビルドは exit 0 で成功するものの、生成される RSC ペイロードにエラーチャンク（`:E{"digest":""}`）が埋め込まれていた。原因を修正し、ペイロードがクリーンに生成されるようにする。

## 動機

サーバーコンポーネントの `AlertPage` が、アクション例の `action.renderItem` で `onClick` 付きの `<button>` を返していた。`Alert` は `'use client'` 境界を持たない共有コンポーネントのためサーバー側で実行され、イベントハンドラ付きの host 要素がそのまま RSC ペイロードへ直列化されようとして失敗していた。SSG は `/` のフォールバックペイロードに全ルートのツリーを含めるため、この 1 箇所の失敗が index の RSC ペイロードを壊していた。

## 詳細

- 該当の Alert を既存の docs パターンに合わせて `_previews/alert-previews.tsx`（`'use client'`）へ `AlertActionButtonPreview` として切り出し、ページからはそれを参照する
- 表示されるコードサンプル文字列は変更なし。同セクションの `Anchor` 版はクライアント参照として直列化できるため対象外

## テスト

- `pnpm --filter docs build` が exit 0 で、当該エラーがログに出ないことを確認
- 生成された RSC ペイロードのエラーチャンクが 1 → 0 になり、`AlertActionButtonPreview` がクライアント参照として含まれることを確認
- `typecheck` / `vp check` パス。ビルド成果物を静的配信して `/ja/components/alert` の表示とコンソールエラーがないことを確認