### PR TITLE
docs: クリーンな worktree では check の前に build が必要な旨を Gotchas に追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ pnpm check              # lint/format check (pnpm check:write to auto-fix)
 
 ## Gotchas
 
+- Run `pnpm build` before `pnpm check` / `pnpm typecheck` on a fresh checkout or worktree: docs/examples resolve `@k8o/arte-odyssey` types from `dist/`, so without it type-aware lint reports bogus `no-unsafe-*` errors (and parallel checks can die with exit 137). CI builds in the install action.
 - Use `type`, not `interface`.
 - No `@ts-ignore` — use `@ts-expect-error` with an explanation.
 - No skipped tests (`test.skip`, `describe.skip`).


### PR DESCRIPTION
クリーンな checkout / worktree で `pnpm check` が失敗する（`typescript/no-unsafe-*` の誤検知 5 件と、並列実行時の exit 137）原因を調査したところ、コードのバグではなく `packages/arte-odyssey/dist/` が未ビルドで `@k8o/arte-odyssey` の型が解決できないことが原因でした。CI では install composite action が `pnpm build` を実行してから `pnpm check` を走らせるため顕在化しません。

同じ調査を繰り返さないよう、「`pnpm check` / `pnpm typecheck` の前に `pnpm build` が必要」という前提を CLAUDE.md の Gotchas に 1 行追記します。コード変更はありません（`pnpm build` 後に `pnpm check` が全パッケージ exit 0 で安定することを確認済み）。