### PR TITLE
fix: Tailwind lint のカスタムユーティリティ誤検知 12 件を解消する

### DIFF
--- a/apps/docs/src/pages/theming.tsx
+++ b/apps/docs/src/pages/theming.tsx
@@ -349,7 +349,7 @@ export function Theming() {
                   {space.step}
                 </code>
                 <div
-                  className="bg-primary-bg h-4 rounded"
+                  className="bg-primary-bg h-4 rounded-sm"
                   style={{ width: space.px }}
                 />
                 <span className="text-fg-subtle text-xs">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,19 @@ import { defineConfig } from 'vite-plus';
 const cssEntry = (path: string) =>
   fileURLToPath(new URL(path, import.meta.url));
 
+// oxlint-tailwindcss 1.6.0 は `--value(integer)` の関数型 @utility
+// (grid-cols-auto-fit-* 等) をクラス一覧に列挙できず、no-unknown-classes が
+// 実際にはコンパイルされるクラスを誤検知する。1.7.1 で修正済みのため
+// (sergioazoc/oxlint-tailwindcss#104)、更新を取り込んだらこの除外を消す。
+const noUnknownClassesOptions = {
+  ignorePrefixes: [
+    'grid-cols-auto-fill-',
+    'grid-cols-auto-fit-',
+    'grid-rows-auto-fill-',
+    'grid-rows-auto-fit-',
+  ],
+};
+
 export default defineConfig({
   fmt: {
     ...fmt,
@@ -57,6 +70,7 @@ export default defineConfig({
       // ErrorBoundary の fallbackRender などレンダープロップを許容する
       // (コンポーネント定義ではなく描画関数。実コンポーネントの入れ子定義は引き続き検出)。
       'react/no-unstable-nested-components': ['error', { allowAsProps: true }],
+      'tailwindcss/no-unknown-classes': ['warn', noUnknownClassesOptions],
     },
     settings: {
       react: { version: '19.2.5' },
@@ -81,6 +95,25 @@ export default defineConfig({
       },
     },
     overrides: [
+      {
+        // 上の settings.tailwindcss.entryPoint のグロブは oxlint の実行 CWD
+        // からの相対パスにマッチするため、`vp run -r check` (CWD=各パッケージ)
+        // では docs のファイルが `src/...` となりマッピングに一致せず、
+        // fallback の arte-odyssey index.css で検証されて docs 固有の
+        // ユーティリティ (font-palt / break-phrase / bg-preview-bg) が誤検知
+        // される。ルールオプションの entryPoint は settings より優先されるので
+        // ここで明示する (vp の overrides グロブはルート相対で解決される)。
+        files: ['apps/docs/**'],
+        rules: {
+          'tailwindcss/no-unknown-classes': [
+            'warn',
+            {
+              entryPoint: cssEntry('./apps/docs/src/styles/globals.css'),
+              ...noUnknownClassesOptions,
+            },
+          ],
+        },
+      },
       {
         files: ['**/*.test.ts', '**/*.test.tsx'],
         plugins: [...(test.plugins ?? [])],


### PR DESCRIPTION
## 概要

vp 0.2.7 への更新で有効になった `tailwindcss(no-unknown-classes)` がカスタムユーティリティに出していた 12 件の警告を解消する。#612 で「別途対応する」と残置された分。

## 動機

CI は落ちないが `pnpm check` のたびに 12 件の警告が出続け、本物の問題が埋もれるノイズになっていた。調べると誤検知 11 件と実バグ 1 件の混在だった。

## 詳細

**docs の 9 件（font-palt / break-phrase / bg-preview-bg）— entryPoint マッピングが CLI で効いていなかった**

`settings.tailwindcss.entryPoint` のグロブは oxlint 実行時 CWD からの相対パスにマッチするため、`vp run -r check`（CWD=各パッケージ）では docs のファイルが `src/...` となり `**/apps/docs/**` に一致せず、fallback の arte-odyssey index.css で検証されていた（プラグインのデバッグモードで実証）。vp の `lint.overrides` はグロブをルート相対で解決するので、docs には settings より優先されるルールオプションの `entryPoint` を明示した。

**grid-cols-auto-fit-36 / -28 の 2 件 — プラグインのバグ（上流で修正済み）**

Tailwind エンジン自体は `grid-cols-auto-fit-36` を正しくコンパイルするが、`--value(integer)` の関数型 `@utility` はクラス一覧に列挙されず、プラグインの列挙ベース判定で未知と扱われる。`oxlint-tailwindcss` 1.7.1（`sergioazoc/oxlint-tailwindcss#104`）で修正済みだが、公開 8/7 で minimumReleaseAge（7 日）を満たすのは 8/14 以降。それまでの暫定として `ignorePrefixes` で `grid-{cols,rows}-auto-{fill,fit}-` を除外し、削除条件をコメントに明記した。

**theming ページの `rounded` 1 件 — 誤検知ではなく実バグ**

Tailwind v4 に bare の `rounded` は存在せず（v3 の `rounded` → v4 `rounded-sm`）、spacing バーの角丸は効いていなかった。`rounded-sm` に修正し、dev サーバーで computed `border-radius: 6px` が当たることを確認した。

## 気をつけるポイント

- `ignorePrefixes` の除外中は `grid-cols-auto-fit-abc` のような本当に無効な値の typo も検出されない。プラグイン 1.7.1 取り込み時に除外を外せば元に戻る
- docs 以外の DS 依存ルール（enforce-canonical 等）は CLI 実行時は引き続き fallback の index.css で検証される（docs の DS はその上位互換なので実害はなく、現状の診断は 0 件）
- このブランチの `pnpm check` は #612 スコープの別エラー（consistent-type-specifier-style 等）で引き続き exit 1 になる。tailwindcss 診断に限れば全パッケージ 0 件
- パッケージに 1 件残る `tailwindcss(enforce-shorthand)` は #612 の diff が修正済みのため触っていない

## テスト

- `pnpm build` 後、arte-odyssey / docs / examples×3 の `vp lint` で tailwindcss 診断 0 件を確認
- ルート CWD 実行（エディタ相当）でも docs → globals.css / パッケージ → index.css へ正しくマップされることをデバッグログで確認
- `pnpm typecheck` 全パッケージ通過
- theming ページの spacing バーに角丸が実際に適用されることをブラウザで確認

## 関連

#612