### PR TITLE
feat: 監査 Tier 3 — ref と HTML 属性の受け口を広げる

### DIFF
--- a/.changeset/tier3-ref-and-attrs.md
+++ b/.changeset/tier3-ref-and-attrs.md
@@ -1,0 +1,12 @@
+---
+'@k8o/arte-odyssey': minor
+---
+
+v12 監査の非破壊項目（Tier 3）を対応しました。すべて受け入れ範囲の拡張です。
+
+- **`Modal` の `ref` がコールバック ref も受け取れるようになりました**（`RefObject` 固定 → `Ref<HTMLDialogElement>`）。内部の開閉制御は内部 ref に一本化し、外部 ref は要素で合成します。
+- **`Table` の各サブコンポーネントが要素固有の HTML 属性を受け取れるようになりました**（`id` / `data-*` / aria 属性など。`className` / `style` は従来どおり不可）。`Cell` の `colSpan` は `TdHTMLAttributes` 経由になり、`HeaderCell` の `scope` が上書き可能になりました（既定 `col`）。
+- **`FormControl` / `Pagination` が `ref` と HTML 属性を受け取れるようになりました。**
+- **`PromptInput.Textarea` が `ref` を受け取れるようになりました**（内部の autosize 用 ref と合成）。
+- **`Dialog.Header` の `title` が `ReactNode` になりました**（`Drawer.title` と同型に）。
+- 内部整理: `React.` グローバル名前空間への依存 3 件を明示 import に置き換えました（公開 API への影響なし）。

--- a/packages/arte-odyssey/docs/props.generated.json
+++ b/packages/arte-odyssey/docs/props.generated.json
@@ -1335,12 +1335,6 @@
           "required": true
         },
         {
-          "name": "children",
-          "types": ["ReactNode"],
-          "defaultValue": null,
-          "required": false
-        },
-        {
           "name": "disabled",
           "types": ["boolean"],
           "defaultValue": "false",
@@ -2011,12 +2005,6 @@
         {
           "name": "aria-label",
           "types": ["string"],
-          "defaultValue": null,
-          "required": false
-        },
-        {
-          "name": "children",
-          "types": ["ReactNode"],
           "defaultValue": null,
           "required": false
         },
@@ -2832,6 +2820,12 @@
           "name": "children",
           "types": ["ReactNode"],
           "defaultValue": null,
+          "required": false
+        },
+        {
+          "name": "scope",
+          "types": ["'col'", "'row'", "'colgroup'", "'rowgroup'"],
+          "defaultValue": "'col'",
           "required": false
         }
       ],

--- a/packages/arte-odyssey/docs/props.generated.json
+++ b/packages/arte-odyssey/docs/props.generated.json
@@ -922,7 +922,7 @@
         },
         {
           "name": "title",
-          "types": ["string"],
+          "types": ["ReactNode"],
           "defaultValue": null,
           "required": true
         }
@@ -1335,6 +1335,12 @@
           "required": true
         },
         {
+          "name": "children",
+          "types": ["ReactNode"],
+          "defaultValue": null,
+          "required": false
+        },
+        {
           "name": "disabled",
           "types": ["boolean"],
           "defaultValue": "false",
@@ -1365,13 +1371,19 @@
           "required": false
         },
         {
+          "name": "ref",
+          "types": ["Ref<HTMLElement>"],
+          "defaultValue": null,
+          "required": false
+        },
+        {
           "name": "required",
           "types": ["boolean"],
           "defaultValue": "false",
           "required": false
         }
       ],
-      "inherits": null
+      "inherits": "HTMLAttributes<HTMLElement>"
     },
     {
       "name": "FormIcon",
@@ -1866,7 +1878,7 @@
         },
         {
           "name": "ref",
-          "types": ["RefObject<HTMLDialogElement | null>"],
+          "types": ["Ref<HTMLDialogElement>"],
           "defaultValue": null,
           "required": false
         },
@@ -2003,6 +2015,12 @@
           "required": false
         },
         {
+          "name": "children",
+          "types": ["ReactNode"],
+          "defaultValue": null,
+          "required": false
+        },
+        {
           "name": "disabled",
           "types": ["boolean"],
           "defaultValue": "false",
@@ -2019,9 +2037,15 @@
           "types": ["string"],
           "defaultValue": null,
           "required": false
+        },
+        {
+          "name": "ref",
+          "types": ["Ref<HTMLElement>"],
+          "defaultValue": null,
+          "required": false
         }
       ],
-      "inherits": null
+      "inherits": "HTMLAttributes<HTMLElement>"
     },
     {
       "name": "PaletteIcon",
@@ -2727,7 +2751,7 @@
           "required": false
         }
       ],
-      "inherits": null
+      "inherits": "HTMLAttributes<HTMLTableSectionElement>"
     },
     {
       "name": "Table.Caption",
@@ -2739,7 +2763,7 @@
           "required": false
         }
       ],
-      "inherits": null
+      "inherits": "HTMLAttributes<HTMLTableCaptionElement>"
     },
     {
       "name": "Table.Cell",
@@ -2761,15 +2785,9 @@
           "types": ["'base'", "'mute'"],
           "defaultValue": "'base'",
           "required": false
-        },
-        {
-          "name": "colSpan",
-          "types": ["number"],
-          "defaultValue": null,
-          "required": false
         }
       ],
-      "inherits": null
+      "inherits": "TdHTMLAttributes<HTMLTableCellElement>"
     },
     {
       "name": "Table.EmptyState",
@@ -2799,7 +2817,7 @@
           "required": false
         }
       ],
-      "inherits": null
+      "inherits": "HTMLAttributes<HTMLTableSectionElement>"
     },
     {
       "name": "Table.HeaderCell",
@@ -2817,7 +2835,7 @@
           "required": false
         }
       ],
-      "inherits": null
+      "inherits": "ThHTMLAttributes<HTMLTableCellElement>"
     },
     {
       "name": "Table.Root",
@@ -2829,7 +2847,7 @@
           "required": false
         }
       ],
-      "inherits": null
+      "inherits": "TableHTMLAttributes<HTMLTableElement>"
     },
     {
       "name": "Table.Row",
@@ -2847,7 +2865,7 @@
           "required": false
         }
       ],
-      "inherits": null
+      "inherits": "HTMLAttributes<HTMLTableRowElement>"
     },
     {
       "name": "TableIcon",

--- a/packages/arte-odyssey/docs/references/components.md
+++ b/packages/arte-odyssey/docs/references/components.md
@@ -225,9 +225,11 @@ Props:
 - `onChange`: `(page: number) => void`（必須）
 - `totalPages`: `number`（必須）
 - `aria-label`: `string`
+- `children`: `ReactNode`
 - `disabled`: `boolean`（既定: `false`）
 - `nextLabel`: `string`
 - `prevLabel`: `string`
+- `ref`: `Ref<HTMLElement>`
 
 ### Tabs
 
@@ -431,11 +433,13 @@ Props:
 
 - `label`: `string`（必須）
 - `renderInput`: `(props: { id: string; 'aria-describedby': string | undefined; 'aria-labelledby': string; disabled: boolean; invalid: boolean; required: boolean; }) => ReactElement`（必須）
+- `children`: `ReactNode`
 - `disabled`: `boolean`（既定: `false`）
 - `errorText`: `string`
 - `helpText`: `string`
 - `invalid`: `boolean`（既定: `false`）
 - `labelAs`: `'label'` | `'legend'`（既定: `'label'`）
+- `ref`: `Ref<HTMLElement>`
 - `required`: `boolean`（既定: `false`）
 
 `renderInput` は `{ id, 'aria-describedby', 'aria-labelledby', disabled, invalid, required }` を受け取る。
@@ -979,7 +983,6 @@ Props (Table.Cell):
 - `align`: `CellAlign`（既定: `'left'`）
 - `children`: `ReactNode`
 - `color`: `'base'` | `'mute'`（既定: `'base'`）
-- `colSpan`: `number`
 
 Props (Table.EmptyState):
 
@@ -1132,7 +1135,7 @@ Props:
 - `defaultOpen`: `boolean`
 - `isOpen`: `boolean`
 - `onClose`: `() => void`
-- `ref`: `RefObject<HTMLDialogElement | null>`
+- `ref`: `Ref<HTMLDialogElement>`
 - `side`: `ModalSide`（既定: `'center'`）
 
 名前の解決順は `aria-label` / `aria-labelledby` > 中の `Dialog.Root` が登録した見出し。どちらも無ければ無名の dialog になるため、`Dialog` を入れずに直接コンテンツを置くときは `aria-label` を渡す。
@@ -1165,7 +1168,7 @@ Props (Dialog.Content):
 Props (Dialog.Header):
 
 - `onClose`: `() => void`（必須）
-- `title`: `string`（必須）
+- `title`: `ReactNode`（必須）
 
 Props (Dialog.Root):
 

--- a/packages/arte-odyssey/docs/references/components.md
+++ b/packages/arte-odyssey/docs/references/components.md
@@ -225,7 +225,6 @@ Props:
 - `onChange`: `(page: number) => void`（必須）
 - `totalPages`: `number`（必須）
 - `aria-label`: `string`
-- `children`: `ReactNode`
 - `disabled`: `boolean`（既定: `false`）
 - `nextLabel`: `string`
 - `prevLabel`: `string`
@@ -433,7 +432,6 @@ Props:
 
 - `label`: `string`（必須）
 - `renderInput`: `(props: { id: string; 'aria-describedby': string | undefined; 'aria-labelledby': string; disabled: boolean; invalid: boolean; required: boolean; }) => ReactElement`（必須）
-- `children`: `ReactNode`
 - `disabled`: `boolean`（既定: `false`）
 - `errorText`: `string`
 - `helpText`: `string`
@@ -997,6 +995,7 @@ Props (Table.HeaderCell):
 
 - `align`: `CellAlign`（既定: `'left'`）
 - `children`: `ReactNode`
+- `scope`: `'col'` | `'row'` | `'colgroup'` | `'rowgroup'`（既定: `'col'`）
 
 Props (Table.Root):
 

--- a/packages/arte-odyssey/src/components/ai/conversation/conversation.tsx
+++ b/packages/arte-odyssey/src/components/ai/conversation/conversation.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { FC, ReactNode } from 'react';
+import type { FC, ReactNode, RefObject } from 'react';
 
 import { cn } from '../../../helpers/cn';
 import { createSafeContext } from '../../../helpers/create-safe-context';
@@ -18,8 +18,8 @@ const [ConversationProvider, useConversationContext] = createSafeContext<{
   isAtBottom: boolean;
   scrollToBottom: (behavior?: ScrollBehavior) => void;
   setViewport: (el: HTMLDivElement | null) => void;
-  sentinelRef: React.RefObject<HTMLDivElement | null>;
-  contentRef: React.RefObject<HTMLDivElement | null>;
+  sentinelRef: RefObject<HTMLDivElement | null>;
+  contentRef: RefObject<HTMLDivElement | null>;
 }>('Conversation.* must be used within <Conversation.Root>');
 
 const Root: FC<{ children: ReactNode }> = ({ children }) => {

--- a/packages/arte-odyssey/src/components/ai/prompt-input/prompt-input.tsx
+++ b/packages/arte-odyssey/src/components/ai/prompt-input/prompt-input.tsx
@@ -5,11 +5,13 @@ import type {
   FC,
   KeyboardEvent,
   ReactNode,
+  Ref,
   TextareaHTMLAttributes,
 } from 'react';
 
 import { cn } from '../../../helpers/cn';
 import { createSafeContext } from '../../../helpers/create-safe-context';
+import { mergeRefs } from '../../../helpers/merge-refs';
 import { useControllableState } from '../../../hooks/controllable-state';
 import { useMessages } from '../../../i18n/context';
 import { FOCUS_RING, FOCUS_RING_WITHIN } from '../../_internal/focus-ring';
@@ -96,18 +98,25 @@ const Root: FC<RootProps> = ({
 
 type TextareaProps = {
   placeholder?: string;
+  ref?: Ref<HTMLTextAreaElement>;
 } & Omit<
   TextareaHTMLAttributes<HTMLTextAreaElement>,
   'value' | 'defaultValue' | 'onChange' | 'className' | 'style' | 'rows'
 >;
 
-const Textarea: FC<TextareaProps> = ({ placeholder, onKeyDown, ...rest }) => {
+const Textarea: FC<TextareaProps> = ({
+  placeholder,
+  onKeyDown,
+  ref,
+  ...rest
+}) => {
   const { value, setValue, status } = usePromptInputContext();
-  const ref = useRef<HTMLTextAreaElement>(null);
+  const innerRef = useRef<HTMLTextAreaElement>(null);
+  const mergedRef = useMemo(() => mergeRefs(innerRef, ref), [ref]);
 
   useEffect(() => {
-    if (ref.current) {
-      resizeToContent(ref.current);
+    if (innerRef.current) {
+      resizeToContent(innerRef.current);
     }
   }, [value]);
 
@@ -142,7 +151,7 @@ const Textarea: FC<TextareaProps> = ({ placeholder, onKeyDown, ...rest }) => {
       }}
       onKeyDown={handleKeyDown}
       placeholder={placeholder}
-      ref={ref}
+      ref={mergedRef}
       rows={1}
       value={value}
     />

--- a/packages/arte-odyssey/src/components/data-display/code/code.tsx
+++ b/packages/arte-odyssey/src/components/data-display/code/code.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Fragment } from 'react';
-import type { FC, HTMLAttributes } from 'react';
+import type { FC, HTMLAttributes, ReactNode } from 'react';
 
 import { useMessages } from '../../../i18n/context';
 import { findAllColors } from './find-all-colors';
@@ -22,7 +22,7 @@ export const Code: FC<Props> = ({ children, ...rest }) => {
     );
   }
 
-  const parts: React.ReactNode[] = [];
+  const parts: ReactNode[] = [];
   let lastIndex = 0;
 
   for (const [index, colorInfo] of colors.entries()) {

--- a/packages/arte-odyssey/src/components/data-display/table/table.tsx
+++ b/packages/arte-odyssey/src/components/data-display/table/table.tsx
@@ -25,9 +25,10 @@ export type CellAlign = 'left' | 'center' | 'right';
 type HeaderCellProps = PropsWithChildren<
   {
     align?: CellAlign;
+    scope?: 'col' | 'row' | 'colgroup' | 'rowgroup';
   } & Omit<
     ThHTMLAttributes<HTMLTableCellElement>,
-    'className' | 'style' | 'align'
+    'className' | 'style' | 'align' | 'scope'
   >
 >;
 

--- a/packages/arte-odyssey/src/components/data-display/table/table.tsx
+++ b/packages/arte-odyssey/src/components/data-display/table/table.tsx
@@ -1,54 +1,85 @@
-import type { FC, PropsWithChildren, ReactNode } from 'react';
+import type {
+  FC,
+  HTMLAttributes,
+  PropsWithChildren,
+  ReactNode,
+  TableHTMLAttributes,
+  TdHTMLAttributes,
+  ThHTMLAttributes,
+} from 'react';
 
 import { cn } from '../../../helpers/cn';
 
-type RootProps = PropsWithChildren;
+type RootProps = PropsWithChildren<
+  Omit<TableHTMLAttributes<HTMLTableElement>, 'className' | 'style'>
+>;
 
-type RowProps = PropsWithChildren<{
-  interactive?: boolean;
-}>;
+type RowProps = PropsWithChildren<
+  {
+    interactive?: boolean;
+  } & Omit<HTMLAttributes<HTMLTableRowElement>, 'className' | 'style'>
+>;
 
 export type CellAlign = 'left' | 'center' | 'right';
 
-type HeaderCellProps = PropsWithChildren<{
-  align?: CellAlign;
-}>;
+type HeaderCellProps = PropsWithChildren<
+  {
+    align?: CellAlign;
+  } & Omit<
+    ThHTMLAttributes<HTMLTableCellElement>,
+    'className' | 'style' | 'align'
+  >
+>;
 
-type CellProps = PropsWithChildren<{
-  align?: CellAlign;
-  colSpan?: number;
-  color?: 'base' | 'mute';
-}>;
+type CellProps = PropsWithChildren<
+  {
+    align?: CellAlign;
+    color?: 'base' | 'mute';
+  } & Omit<
+    TdHTMLAttributes<HTMLTableCellElement>,
+    'className' | 'style' | 'align'
+  >
+>;
 
-type SectionProps = PropsWithChildren;
+type SectionProps = PropsWithChildren<
+  Omit<HTMLAttributes<HTMLTableSectionElement>, 'className' | 'style'>
+>;
 
-type CaptionProps = PropsWithChildren;
+type CaptionProps = PropsWithChildren<
+  Omit<HTMLAttributes<HTMLTableCaptionElement>, 'className' | 'style'>
+>;
 
 type EmptyStateProps = {
   colSpan: number;
   children: ReactNode;
 };
 
-const Root: FC<RootProps> = ({ children }) => (
+const Root: FC<RootProps> = ({ children, ...rest }) => (
   <div className="border-border-mute bg-bg-base vertical:writing-sideways-rl vertical:size-fit w-full overflow-x-auto rounded-lg border">
-    <table className="min-w-full border-collapse text-left text-sm">
+    <table {...rest} className="min-w-full border-collapse text-left text-sm">
       {children}
     </table>
   </div>
 );
 
-const Head: FC<SectionProps> = ({ children }) => (
-  <thead className="bg-bg-subtle">{children}</thead>
+const Head: FC<SectionProps> = ({ children, ...rest }) => (
+  <thead {...rest} className="bg-bg-subtle">
+    {children}
+  </thead>
 );
 
-const Body: FC<SectionProps> = ({ children }) => (
-  <tbody className="vertical:[&_tr:last-child]:border-l-0 [&_tr:last-child]:border-b-0">
+const Body: FC<SectionProps> = ({ children, ...rest }) => (
+  <tbody
+    {...rest}
+    className="vertical:[&_tr:last-child]:border-l-0 [&_tr:last-child]:border-b-0"
+  >
     {children}
   </tbody>
 );
 
-const Row: FC<RowProps> = ({ children, interactive = false }) => (
+const Row: FC<RowProps> = ({ children, interactive = false, ...rest }) => (
   <tr
+    {...rest}
     className={cn(
       'border-border-mute border-b transition-colors vertical:border-b-0 vertical:border-l',
       interactive && 'hover:bg-bg-mute',
@@ -58,14 +89,20 @@ const Row: FC<RowProps> = ({ children, interactive = false }) => (
   </tr>
 );
 
-const HeaderCell: FC<HeaderCellProps> = ({ align = 'left', children }) => (
+const HeaderCell: FC<HeaderCellProps> = ({
+  align = 'left',
+  children,
+  scope = 'col',
+  ...rest
+}) => (
   <th
+    {...rest}
     className={cn(
       'px-4 py-3 font-medium text-fg-base',
       align === 'center' && 'text-center',
       align === 'right' && 'text-right',
     )}
-    scope="col"
+    scope={scope}
   >
     {children}
   </th>
@@ -74,24 +111,24 @@ const HeaderCell: FC<HeaderCellProps> = ({ align = 'left', children }) => (
 const Cell: FC<CellProps> = ({
   align = 'left',
   children,
-  colSpan,
   color = 'base',
+  ...rest
 }) => (
   <td
+    {...rest}
     className={cn(
       'px-4 py-3 align-middle',
       color === 'mute' ? 'text-fg-mute' : 'text-fg-base',
       align === 'center' && 'text-center',
       align === 'right' && 'text-right',
     )}
-    colSpan={colSpan}
   >
     {children}
   </td>
 );
 
-const Caption: FC<CaptionProps> = ({ children }) => (
-  <caption className="text-fg-mute caption-bottom px-4 py-3 text-sm">
+const Caption: FC<CaptionProps> = ({ children, ...rest }) => (
+  <caption {...rest} className="text-fg-mute caption-bottom px-4 py-3 text-sm">
     {children}
   </caption>
 );

--- a/packages/arte-odyssey/src/components/form/form-control/form-control.tsx
+++ b/packages/arte-odyssey/src/components/form/form-control/form-control.tsx
@@ -22,7 +22,7 @@ type FormControlProps = {
     required: boolean;
   }) => ReactElement;
   ref?: Ref<HTMLElement>;
-} & Omit<HTMLAttributes<HTMLElement>, 'className' | 'style'>;
+} & Omit<HTMLAttributes<HTMLElement>, 'className' | 'style' | 'children'>;
 
 const LABEL_CLASS = 'text-fg-base text-md mb-1 flex gap-2 pl-0.5 font-bold';
 

--- a/packages/arte-odyssey/src/components/form/form-control/form-control.tsx
+++ b/packages/arte-odyssey/src/components/form/form-control/form-control.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useId } from 'react';
-import type { FC, ReactElement } from 'react';
+import type { FC, HTMLAttributes, ReactElement, Ref } from 'react';
 
 import { useMessages } from '../../../i18n/context';
 
@@ -21,7 +21,8 @@ type FormControlProps = {
     invalid: boolean;
     required: boolean;
   }) => ReactElement;
-};
+  ref?: Ref<HTMLElement>;
+} & Omit<HTMLAttributes<HTMLElement>, 'className' | 'style'>;
 
 const LABEL_CLASS = 'text-fg-base text-md mb-1 flex gap-2 pl-0.5 font-bold';
 
@@ -34,6 +35,8 @@ export const FormControl: FC<FormControlProps> = ({
   helpText,
   errorText,
   renderInput,
+  ref,
+  ...rest
 }) => {
   const messages = useMessages();
   const id = useId();
@@ -91,9 +94,23 @@ export const FormControl: FC<FormControlProps> = ({
 
   // 単一フィールドまで fieldset で包むと、名前の無いグループが全フィールドに増える。
   // legend を置けるのは fieldset の中だけなので、legend のときだけ fieldset にする。
+  // ラッパー要素が labelAs で div / fieldset に分かれるため、ref は共通の
+  // HTMLElement で受けて要素側でキャストする
   return labelAs === 'legend' ? (
-    <fieldset className="flex w-full min-w-0 flex-col">{content}</fieldset>
+    <fieldset
+      {...rest}
+      className="flex w-full min-w-0 flex-col"
+      ref={ref as Ref<HTMLFieldSetElement>}
+    >
+      {content}
+    </fieldset>
   ) : (
-    <div className="flex w-full min-w-0 flex-col">{content}</div>
+    <div
+      {...rest}
+      className="flex w-full min-w-0 flex-col"
+      ref={ref as Ref<HTMLDivElement>}
+    >
+      {content}
+    </div>
   );
 };

--- a/packages/arte-odyssey/src/components/form/slider/slider.tsx
+++ b/packages/arte-odyssey/src/components/form/slider/slider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { FC, InputHTMLAttributes, Ref } from 'react';
+import type { CSSProperties, FC, InputHTMLAttributes, Ref } from 'react';
 import { useFormStatus } from 'react-dom';
 
 import { cn } from '../../../helpers/cn';
@@ -74,7 +74,7 @@ export const Slider: FC<Props> = ({
         'block-8 inline-full vertical:inline-48',
         disabledResolved && 'opacity-50',
       )}
-      style={{ '--slider-progress': clampedProgress } as React.CSSProperties}
+      style={{ '--slider-progress': clampedProgress } as CSSProperties}
     >
       <span
         aria-hidden

--- a/packages/arte-odyssey/src/components/navigation/pagination/pagination.tsx
+++ b/packages/arte-odyssey/src/components/navigation/pagination/pagination.tsx
@@ -15,7 +15,10 @@ type Props = {
   nextLabel?: string;
   'aria-label'?: string;
   ref?: Ref<HTMLElement>;
-} & Omit<HTMLAttributes<HTMLElement>, 'className' | 'style' | 'onChange'>;
+} & Omit<
+  HTMLAttributes<HTMLElement>,
+  'className' | 'style' | 'onChange' | 'children'
+>;
 
 export const Pagination: FC<Props> = ({
   totalPages,

--- a/packages/arte-odyssey/src/components/navigation/pagination/pagination.tsx
+++ b/packages/arte-odyssey/src/components/navigation/pagination/pagination.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { FC } from 'react';
+import type { FC, HTMLAttributes, Ref } from 'react';
 
 import { useMessages } from '../../../i18n/context';
 import { Button } from '../../buttons/button';
@@ -14,7 +14,8 @@ type Props = {
   prevLabel?: string;
   nextLabel?: string;
   'aria-label'?: string;
-};
+  ref?: Ref<HTMLElement>;
+} & Omit<HTMLAttributes<HTMLElement>, 'className' | 'style' | 'onChange'>;
 
 export const Pagination: FC<Props> = ({
   totalPages,
@@ -24,6 +25,8 @@ export const Pagination: FC<Props> = ({
   prevLabel,
   nextLabel,
   'aria-label': ariaLabel,
+  ref,
+  ...rest
 }) => {
   const messages = useMessages();
   const safeTotal = Math.max(1, totalPages);
@@ -32,7 +35,7 @@ export const Pagination: FC<Props> = ({
   const isLast = safeCurrent >= safeTotal;
 
   return (
-    <nav aria-label={ariaLabel ?? messages.paginationLabel}>
+    <nav {...rest} aria-label={ariaLabel ?? messages.paginationLabel} ref={ref}>
       <div className="flex items-center justify-center gap-2">
         <Button
           color="base"

--- a/packages/arte-odyssey/src/components/overlays/dialog/dialog.tsx
+++ b/packages/arte-odyssey/src/components/overlays/dialog/dialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useId, useMemo } from 'react';
-import type { FC, PropsWithChildren, Ref } from 'react';
+import type { FC, PropsWithChildren, Ref, ReactNode } from 'react';
 
 import { useMessages } from '../../../i18n/context';
 import { IconButton } from '../../buttons/icon-button';
@@ -66,7 +66,7 @@ const Root: FC<
 };
 
 const Header: FC<{
-  title: string;
+  title: ReactNode;
   onClose: () => void;
 }> = ({ title, onClose }) => {
   const messages = useMessages();

--- a/packages/arte-odyssey/src/components/overlays/modal/modal.tsx
+++ b/packages/arte-odyssey/src/components/overlays/modal/modal.tsx
@@ -1,17 +1,18 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { FC, PropsWithChildren, RefObject } from 'react';
+import type { FC, PropsWithChildren, Ref } from 'react';
 
 import type { ModalSide } from '../../../types/variables';
 import { ToastProvider } from '../../feedback/toast';
 import { PortalRootProvider } from '../../providers';
 import { ModalDialogProvider } from '../_internal/modal-dialog-context';
 import { cn } from './../../../helpers/cn';
+import { mergeRefs } from './../../../helpers/merge-refs';
 
 export const Modal: FC<
   PropsWithChildren<{
-    ref?: RefObject<HTMLDialogElement | null>;
+    ref?: Ref<HTMLDialogElement>;
     side?: ModalSide;
     defaultOpen?: boolean;
     isOpen?: boolean;
@@ -32,6 +33,7 @@ export const Modal: FC<
   children,
 }) => {
   const dialogRef = useRef<HTMLDialogElement>(null);
+  const mergedRef = useMemo(() => mergeRefs(dialogRef, ref), [ref]);
   const [dialogOpen, setDialogOpen] = useState(defaultOpen ?? false);
   const [registeredLabelledBy, setRegisteredLabelledBy] = useState<
     string | undefined
@@ -49,8 +51,6 @@ export const Modal: FC<
     }
     setDialogOpen(false);
   }, [isOpen, onClose]);
-  const realRef = ref ?? dialogRef;
-
   const modalDialogContext = useMemo(
     () => ({
       registerLabelledBy: setRegisteredLabelledBy,
@@ -65,7 +65,7 @@ export const Modal: FC<
   const describedBy = ariaDescribedBy ?? registeredDescribedBy;
 
   useEffect(() => {
-    const dialog = realRef.current;
+    const dialog = dialogRef.current;
     if (!dialog || realDialogOpen === dialog.open) {
       return;
     }
@@ -74,10 +74,10 @@ export const Modal: FC<
     } else {
       dialog.close();
     }
-  }, [realDialogOpen, realRef]);
+  }, [realDialogOpen]);
 
   useEffect(() => {
-    const dialog = realRef.current;
+    const dialog = dialogRef.current;
     if (!dialog || isOpen !== undefined) return undefined;
 
     const observer = new MutationObserver(() => {
@@ -87,7 +87,7 @@ export const Modal: FC<
     return () => {
       observer.disconnect();
     };
-  }, [isOpen, realRef]);
+  }, [isOpen]);
 
   return (
     // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions -- onClick は枠外(backdrop)クリックで閉じるためのもの。キーボード等価操作はネイティブ modal dialog の Escape が担う
@@ -108,15 +108,15 @@ export const Modal: FC<
       )}
       onClick={(e) => {
         if (e.target === e.currentTarget) {
-          realRef.current?.close();
+          dialogRef.current?.close();
         }
       }}
       onClose={realOnClose}
-      ref={realRef}
+      ref={mergedRef}
     >
       <ModalDialogProvider value={modalDialogContext}>
-        <PortalRootProvider value={realRef}>
-          <ToastProvider portalRef={realRef} position="absolute">
+        <PortalRootProvider value={dialogRef}>
+          <ToastProvider portalRef={dialogRef} position="absolute">
             {children}
           </ToastProvider>
         </PortalRootProvider>


### PR DESCRIPTION
## 概要

v12 監査で「非破壊なので v12 に入れる必要はない」と仕分けた Tier 3 を実装する。すべて受け入れ範囲の拡張（minor）。#617 の続き。

## 詳細

- **Modal**: `ref` を `RefObject` 固定から `Ref<HTMLDialogElement>` に拡張（コールバック ref 対応）。開閉制御の読み取りは内部 ref に一本化し、外部 ref は `mergeRefs` で合成
- **Table**: 全サブコンポーネントが要素固有の HTML 属性（`id` / `data-*` / aria）を受け取る。`Cell.colSpan` は `TdHTMLAttributes` 経由に、`HeaderCell.scope` は上書き可能に（先頭列の行見出しで `scope="row"` が使える）
- **FormControl / Pagination**: `ref` と HTML 属性を受け取る
- **PromptInput.Textarea**: 外部 `ref` を内部の autosize 用 ref と合成
- **Dialog.Header**: `title` を `ReactNode` に拡張（`Drawer.title` と同型）
- 内部整理: `React.` グローバル名前空間依存 3 件を明示 import に

## 気をつけるポイント

- `Pagination` は `onChange(page)` が `HTMLAttributes` の `onChange` と交差して不成立型になるため、HTML 側の `onChange` を Omit している
- `FormControl` のラッパーは `labelAs` で div / fieldset に分かれるため、`ref` は `Ref<HTMLElement>` で受けて要素側でキャストしている

## 影響範囲

`@k8o/arte-odyssey` の公開 API（minor、追加のみ）。視覚変化なし。

## テスト

`generate:props` / `build` / `typecheck` / `check` / `test` / `publint` + `attw` / TS 7.0.2 tsc による examples 型検査、すべてローカル green。