### PR TITLE
fix: CheckboxGroup の compound 化に残っていた単体参照と RSC での Root 消失を正す

### DIFF
--- a/.changeset/checkbox-group-rsc-root.md
+++ b/.changeset/checkbox-group-rsc-root.md
@@ -1,0 +1,5 @@
+---
+'@k8o/arte-odyssey': patch
+---
+
+RSC の server 環境で `CheckboxGroup.Root` が undefined になり、server コンポーネントから使うと「Element type is invalid」で落ちるのを修正しました。合成モジュールが client モジュールの export（参照プロキシ）をスプレッドしており、`Root` がコピーされずに消えていたためで、`Accordion` などと同じ直接参照での合成に揃えています。公開 API は変わりません。

--- a/apps/docs/src/pages/components/checkbox-group-page.tsx
+++ b/apps/docs/src/pages/components/checkbox-group-page.tsx
@@ -11,7 +11,7 @@ import { ComponentPreview } from '../../components/component-preview';
 import { PropsTable } from '../../components/props-table';
 import { T } from '../../components/t';
 import { STORYBOOK_URL } from '../../constants';
-import { inheritsOf, propsOf } from '../../data/component-props';
+import { propsOf } from '../../data/component-props';
 import { CheckboxGroupControlledPreview } from './_previews/checkbox-group-previews';
 
 export function CheckboxGroupPage() {
@@ -148,10 +148,10 @@ export function CheckboxGroupPage() {
         <Heading level="h2">
           <T k="components.common.propsTitle" />
         </Heading>
-        <PropsTable
-          inherits={inheritsOf('CheckboxGroup')}
-          items={propsOf('CheckboxGroup')}
-        />
+        <Heading level="h3">CheckboxGroup.Root</Heading>
+        <PropsTable items={propsOf('CheckboxGroup.Root')} />
+        <Heading level="h3">CheckboxGroup.Item</Heading>
+        <PropsTable items={propsOf('CheckboxGroup.Item')} />
       </section>
     </div>
   );

--- a/apps/docs/src/pages/components/checkbox-page.tsx
+++ b/apps/docs/src/pages/components/checkbox-page.tsx
@@ -143,10 +143,10 @@ export function CheckboxPage() {
       <Separator color="mute" />
 
       <section className="flex flex-col gap-4">
-        <Heading level="h2">CheckboxGroup Props</Heading>
+        <Heading level="h2">CheckboxGroup.Root Props</Heading>
         <PropsTable
-          inherits={inheritsOf('CheckboxGroup')}
-          items={propsOf('CheckboxGroup')}
+          inherits={inheritsOf('CheckboxGroup.Root')}
+          items={propsOf('CheckboxGroup.Root')}
         />
       </section>
     </div>

--- a/packages/arte-odyssey/docs/references/components.md
+++ b/packages/arte-odyssey/docs/references/components.md
@@ -1299,6 +1299,13 @@ Props (DropdownMenu.Item):
 - `label`: `string`（必須）
 - `onAction`: `() => void`（必須）
 
+`DropdownMenu.SubMenu` は入れ子メニュー。`label` の行をホバーまたはキーボードで開くと、子要素のメニューが右側に開く。
+
+Props (DropdownMenu.SubMenu):
+
+- `label`: `string`（必須）
+- `children`: `ReactNode`
+
 Props (DropdownMenu.Trigger):
 
 - `label`: `string`（必須）

--- a/packages/arte-odyssey/docs/references/components.md
+++ b/packages/arte-odyssey/docs/references/components.md
@@ -647,17 +647,6 @@ import { CheckboxGroup } from '@k8o/arte-odyssey';
 </CheckboxGroup.Root>;
 ```
 
-Props:
-
-- `aria-labelledby`: `string`（必須）
-- `name`: `string`（必須）
-- `children`: `ReactNode`
-- `defaultValue`: `never`
-- `invalid`: `boolean`
-- `onChange`: `(value: string[]) => void`
-- `ref`: `Ref<HTMLFieldSetElement>`
-- `value`: `string[]`
-
 Props (CheckboxGroup.Item):
 
 - `label`: `string`（必須）

--- a/packages/arte-odyssey/src/components/form/checkbox-group/checkbox-group.tsx
+++ b/packages/arte-odyssey/src/components/form/checkbox-group/checkbox-group.tsx
@@ -105,4 +105,4 @@ const Root: FC<RootProps> = ({
   );
 };
 
-export const CheckboxGroup = { Root } as const;
+export { Root as CheckboxGroupRoot };

--- a/packages/arte-odyssey/src/components/form/checkbox-group/index.ts
+++ b/packages/arte-odyssey/src/components/form/checkbox-group/index.ts
@@ -1,7 +1,9 @@
 import { Checkbox } from '../checkbox';
-import { CheckboxGroup as BaseCheckboxGroup } from './checkbox-group';
+import { CheckboxGroupRoot } from './checkbox-group';
 
+// RSC の server 環境では client モジュールの export は参照プロキシになり、
+// スプレッドでプロパティをコピーできないため、直接参照で合成する。
 export const CheckboxGroup = {
-  ...BaseCheckboxGroup,
+  Root: CheckboxGroupRoot,
   Item: Checkbox,
 } as const;


### PR DESCRIPTION
## 概要

apps/docs のビルド中に RSC prerender が `No generated props for "CheckboxGroup"` エラーを複数回ログに出していた（exit は 0）のを解消する。調査の過程で見つかった、RSC の server 環境で `CheckboxGroup.Root` が undefined になる既存バグもあわせて修正する。

## 動機

compound 化（aac07a41 前後）で生成 props のエントリが `CheckboxGroup.Root` / `CheckboxGroup.Item` に分かれた一方、ドキュメント側に単体名 `CheckboxGroup` の参照が残っていた。`propsOf` は未知の名前で throw する設計なので、SSG のたびにエラーがログに出ていた。

## 詳細

- **docs サイト**: `propsOf('CheckboxGroup')` を参照していた 2 ページを更新。CheckboxGroup ページは Accordion などと同じ Root / Item の 2 テーブル構成に、Checkbox ページのグループ節は `CheckboxGroup.Root` 参照に変更。全 `propsOf` / `inheritsOf` 呼び出しを props.generated.json のキーと突き合わせ、不一致はこの 2 ファイルだけであることを確認済み
- **パッケージ（RSC バグ修正・patch changeset あり）**: `checkbox-group/index.ts` が client モジュールの export（参照プロキシ）をスプレッドして合成していたため、server 環境では `Root` がコピーされず消えていた。`CheckboxGroupRoot` を直接 export し、`Accordion` と同じ直接参照の合成に変更。公開 API は不変
- **components.md**: CheckboxGroup 節に残っていた宛先不明の素の `Props:` ブロックを削除（generate:props が警告していたもの）。あわせて、警告が出ていた `DropdownMenu.SubMenu` の Props ブロックと説明を追加

## 気をつけるポイント

- docs ページ側の修正だけでは dev サーバーの CheckboxGroup ページが「Element type is invalid」で落ちる（propsOf の throw に隠れていた既存バグ）。パッケージ側の修正とセットで初めてページが描画される
- `checkbox-group.tsx` の export が合成オブジェクトから `CheckboxGroupRoot` 単体に変わったが、外部からの入口は `index.ts` の `CheckboxGroup` のみで変化なし

## 影響範囲

- npm パッケージ: `CheckboxGroup` の内部合成のみ（API 不変）。RSC から `CheckboxGroup.Root` を使うケースが新たに動くようになる
- docs サイト: Checkbox / CheckboxGroup ページの props 表示

## テスト

- 修正前の docs ビルドでエラー 2 回の再現を確認 → 修正後はフルログで 0 件
- dev サーバーで checkbox / checkbox-group 両ページの描画とハイドレーション（チェック操作）を確認
- コンポーネントテスト 446 件パス、`pnpm typecheck` / `pnpm check` パス、extract-props / generate-components-md の `--check` も in sync