### PR TITLE
chore(deps): @oxc-project/types を単一バージョンに固定する

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ catalogs:
       specifier: 4.1.10
       version: 4.1.10
 
+overrides:
+  '@oxc-project/types': 0.143.0
+
 importers:
 
   .:
@@ -1384,11 +1387,8 @@ packages:
     resolution: {integrity: sha512-Dv3jRrcXFdvUBUEljUu9kusrEo9G0iiqZFZNg3yCg+mkET4DD4S2Ow6Q6shFWDJwPidSa980d6YVXBlErUGADw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@oxc-project/types@0.127.0':
-    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
-
-  '@oxc-project/types@0.142.0':
-    resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
+  '@oxc-project/types@0.143.0':
+    resolution: {integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==}
 
   '@oxc-resolver/binding-android-arm-eabi@11.19.1':
     resolution: {integrity: sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg==}
@@ -5613,9 +5613,7 @@ snapshots:
 
   '@oxc-project/runtime@0.142.0': {}
 
-  '@oxc-project/types@0.127.0': {}
-
-  '@oxc-project/types@0.142.0': {}
+  '@oxc-project/types@0.143.0': {}
 
   '@oxc-resolver/binding-android-arm-eabi@11.19.1':
     optional: true
@@ -6719,7 +6717,7 @@ snapshots:
   '@voidzero-dev/vite-plus-core@0.2.8(@arethetypeswrong/core@0.18.5)(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.23)(typescript@7.0.2)':
     dependencies:
       '@oxc-project/runtime': 0.142.0
-      '@oxc-project/types': 0.142.0
+      '@oxc-project/types': 0.143.0
       lightningcss: 1.33.0
       postcss: 8.5.25
       yuku-codegen: 0.5.48
@@ -6744,7 +6742,7 @@ snapshots:
   '@voidzero-dev/vite-plus-core@0.2.8(@arethetypeswrong/core@0.18.5)(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.23)(typescript@7.0.2)':
     dependencies:
       '@oxc-project/runtime': 0.142.0
-      '@oxc-project/types': 0.142.0
+      '@oxc-project/types': 0.143.0
       lightningcss: 1.33.0
       postcss: 8.5.25
       yuku-codegen: 0.5.48
@@ -8180,7 +8178,7 @@ snapshots:
 
   oxc-parser@0.127.0:
     dependencies:
-      '@oxc-project/types': 0.127.0
+      '@oxc-project/types': 0.143.0
     optionalDependencies:
       '@oxc-parser/binding-android-arm-eabi': 0.127.0
       '@oxc-parser/binding-android-arm64': 0.127.0
@@ -8623,7 +8621,7 @@ snapshots:
 
   rolldown@1.2.1:
     dependencies:
-      '@oxc-project/types': 0.142.0
+      '@oxc-project/types': 0.143.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
       '@rolldown/binding-android-arm64': 1.2.1
@@ -9099,7 +9097,7 @@ snapshots:
 
   vite-plus@0.2.8(@arethetypeswrong/core@0.18.5)(@opentelemetry/api@1.9.0)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.23)(typescript@7.0.2)(vite@8.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)):
     dependencies:
-      '@oxc-project/types': 0.142.0
+      '@oxc-project/types': 0.143.0
       '@oxlint/plugins': 1.73.0
       '@vitest/browser': 4.1.10(vite@8.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0))(vitest@4.1.10)
       '@vitest/browser-preview': 4.1.10(vite@8.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0))(vitest@4.1.10)
@@ -9158,7 +9156,7 @@ snapshots:
 
   vite-plus@0.2.8(@arethetypeswrong/core@0.18.5)(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0))(vitest@4.1.10))(@vitest/coverage-v8@4.1.10(@vitest/browser@4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0))(vitest@4.1.10))(vitest@4.1.10))(@vitest/ui@4.1.10(vitest@4.1.10))(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.23)(typescript@7.0.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)):
     dependencies:
-      '@oxc-project/types': 0.142.0
+      '@oxc-project/types': 0.143.0
       '@oxlint/plugins': 1.73.0
       '@vitest/browser': 4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0))(vitest@4.1.10)
       '@vitest/browser-preview': 4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0))(vitest@4.1.10)
@@ -9217,7 +9215,7 @@ snapshots:
 
   vite-plus@0.2.8(@arethetypeswrong/core@0.18.5)(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.23)(typescript@7.0.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)):
     dependencies:
-      '@oxc-project/types': 0.142.0
+      '@oxc-project/types': 0.143.0
       '@oxlint/plugins': 1.73.0
       '@vitest/browser': 4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0))(vitest@4.1.10)
       '@vitest/browser-preview': 4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0))(vitest@4.1.10)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,6 +31,13 @@ catalog:
 
 minimumReleaseAge: 10080
 
+# vite (rolldown 経由) と vite-plus はそれぞれ @oxc-project/types を exact pin しており、
+# 両者の pin がずれると同一内容の型が 2 コピーになり、vite の Plugin 型の比較で
+# tsc が "Excessive stack depth" を起こして typecheck が落ちる。単一バージョンに
+# 強制して型グラフのコピーを 1 つに保つ (types のみのパッケージでランタイム影響なし)。
+overrides:
+  '@oxc-project/types': 0.143.0
+
 minimumReleaseAgeExclude:
   - '@k8o/*'
   - 'storybook-addon-determinism'


### PR DESCRIPTION
## 概要

pnpm-workspace.yaml に override を追加し、`@oxc-project/types` をワークスペース全体で単一バージョン (0.143.0) に強制する。

## 動機

#622 / #623 の TypeScript ジョブが `vite.config.ts` の `Excessive stack depth comparing types` で落ちている。原因は `@oxc-project/types` の二重化:

- vite (8.2.1) は `rolldown: ~1.2.1` を範囲指定しており、lockfile 更新で rolldown 1.2.3 (`@oxc-project/types@=0.143.0` を pin) に進んだ
- vite-plus 0.2.8 は `@oxc-project/types@=0.142.0` を pin したまま

0.142.0 と 0.143.0 は中身が完全に同一 (バージョン文字列のみ差分) だが、tsc は別宣言として構造比較するため、vite の `Plugin` 型 (rolldown の型を参照) と `UserConfig` の比較が再帰爆発して typecheck が落ちる。両者は今後もそれぞれの都合で exact pin を進める (rolldown 1.2.4 は =0.144.0、vite-plus 0.2.9 は =0.143.0) ため、特定バージョンへの巻き戻しではなく「単一コピーの強制」で恒久対応する。

## 気をつけるポイント

- `@oxc-project/types` は `types.d.ts` 1 枚だけの型専用パッケージで、override してもランタイム影響はない
- oxc-parser (storybook の推移的依存、0.127.0 を pin) にも override が及ぶが、型の不整合は skipLibCheck で問題にならない
- renovate の lockfile を取り込んだ状態 (rolldown 1.2.3) で override を適用し、`pnpm typecheck` 全プロジェクト green を確認済み

## 影響範囲

依存解決のみ。マージ後に #622 / #623 を rebase すれば CI が通る想定。