### PR TITLE
fix: Breadcrumb を server コンポーネントから使えるようにする

### DIFF
--- a/.changeset/breadcrumb-rsc-compound.md
+++ b/.changeset/breadcrumb-rsc-compound.md
@@ -1,0 +1,7 @@
+---
+'@k8o/arte-odyssey': patch
+---
+
+RSC の server 環境で `Breadcrumb.List` などが undefined になり、server コンポーネントから使うと「Element type is invalid」で落ちるのを修正しました。v12 で nav ラベルを辞書化するために `useMessages()` を使い、`breadcrumb.tsx` が client モジュールになった結果、その中で合成していた `Breadcrumb` オブジェクトが参照プロキシになりプロパティを引けなくなっていました。`CheckboxGroup` と同じく、パーツを個別に export して client でない `index.ts` 側で合成します。公開 API は変わりません。
+
+あわせて、`'use client'` モジュール内で合成された複合コンポーネントが増えないことを検証するテストを追加しました。v12 以前から同じ形の 11 件（`Dialog` / `Tabs` / `Tooltip` など）は、個別に検証しながら順次移すため既知として許容リストに載せています。

--- a/packages/arte-odyssey/src/components/compound-rsc.test.ts
+++ b/packages/arte-odyssey/src/components/compound-rsc.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+// 複合コンポーネント（`X.Root` の形）を `'use client'` モジュールの中で
+// オブジェクトとして組み立てて export すると、RSC の server 環境では
+// export が参照プロキシになり `X.Root` が undefined になる。
+// 合成は client でない index.ts 側で行い、パーツは個別に export する。
+const CLIENT_DIRECTIVE = /^['"]use client['"];/u;
+const COMPOUND_EXPORT = /^export const ([A-Z]\w*) = \{/gmu;
+
+// v12 以前から client モジュール内で合成しており、server コンポーネントから
+// 使うと同じ理由で落ちる。個別に検証しながら順次 index.ts 合成へ移す。
+const PENDING_MIGRATION = new Set([
+  'Conversation',
+  'Dialog',
+  'DropdownMenu',
+  'FileField',
+  'ListBox',
+  'Message',
+  'Popover',
+  'PromptInput',
+  'Suggestion',
+  'Tabs',
+  'Tooltip',
+]);
+
+const COMPONENTS_DIR = join(import.meta.dirname, '.');
+
+const walk = (dir: string): string[] =>
+  readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return walk(path);
+    }
+    return entry.name.endsWith('.tsx') && !entry.name.includes('.stories.')
+      ? [path]
+      : [];
+  });
+
+const clientComposedCompounds = (): string[] => {
+  const found: string[] = [];
+  for (const path of walk(COMPONENTS_DIR)) {
+    const source = readFileSync(path, 'utf8');
+    if (!CLIENT_DIRECTIVE.test(source)) {
+      continue;
+    }
+    for (const [, name] of source.matchAll(COMPOUND_EXPORT)) {
+      if (name !== undefined) {
+        found.push(name);
+      }
+    }
+  }
+  return found.toSorted();
+};
+
+describe('複合コンポーネントの合成位置', () => {
+  describe('正常系', () => {
+    it("'use client' モジュール内で合成された複合コンポーネントを増やさない", () => {
+      expect(clientComposedCompounds()).toStrictEqual(
+        [...PENDING_MIGRATION].toSorted(),
+      );
+    });
+  });
+});

--- a/packages/arte-odyssey/src/components/navigation/breadcrumb/breadcrumb.stories.tsx
+++ b/packages/arte-odyssey/src/components/navigation/breadcrumb/breadcrumb.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect } from 'storybook/test';
 
-import { Breadcrumb } from './breadcrumb';
+import { Breadcrumb } from '.';
 
 const meta: Meta<typeof Breadcrumb.List> = {
   title: 'components/navigation/breadcrumb',

--- a/packages/arte-odyssey/src/components/navigation/breadcrumb/breadcrumb.tsx
+++ b/packages/arte-odyssey/src/components/navigation/breadcrumb/breadcrumb.tsx
@@ -6,7 +6,7 @@ import { useMessages } from '../../../i18n/context';
 import { ChevronIcon } from '../../icons';
 import { cn } from './../../../helpers/cn';
 
-const List: FC<
+export const List: FC<
   PropsWithChildren<{
     size?: 'sm' | 'md' | 'lg';
   }>
@@ -29,11 +29,11 @@ const List: FC<
   );
 };
 
-const Item: FC<PropsWithChildren> = ({ children }) => (
+export const Item: FC<PropsWithChildren> = ({ children }) => (
   <li className="inline-flex items-center">{children}</li>
 );
 
-const Separator: FC = () => (
+export const Separator: FC = () => (
   <li aria-hidden="true" className="text-fg-mute vertical:rotate-90">
     <ChevronIcon direction="right" size="sm" />
   </li>
@@ -52,7 +52,7 @@ const defaultRenderBreadcrumbAnchor = ({
   <a {...rest}>{children}</a>
 );
 
-const Link = <T extends string>({
+export const Link = <T extends string>({
   href,
   current = false,
   children,
@@ -74,10 +74,3 @@ const Link = <T extends string>({
       children,
     })
   );
-
-export const Breadcrumb = {
-  List,
-  Item,
-  Separator,
-  Link,
-} as const;

--- a/packages/arte-odyssey/src/components/navigation/breadcrumb/index.ts
+++ b/packages/arte-odyssey/src/components/navigation/breadcrumb/index.ts
@@ -1,1 +1,10 @@
-export { Breadcrumb } from './breadcrumb';
+import { Item, Link, List, Separator } from './breadcrumb';
+
+// RSC の server 環境では client モジュールの export は参照プロキシになり、
+// オブジェクトごと export するとプロパティを引けないため、直接参照で合成する。
+export const Breadcrumb = {
+  List,
+  Item,
+  Separator,
+  Link,
+} as const;


### PR DESCRIPTION
## 概要

RSC の server 環境で `Breadcrumb.List` などが `undefined` になり、server コンポーネントから使うと `Element type is invalid` で落ちる問題を直す。12.0.0 で入った退行。

## 動機

v12 で nav ラベルを辞書化するため `useMessages()` を導入した結果、`breadcrumb.tsx` が client モジュールになった。合成した `Breadcrumb` オブジェクトをその中で export していたため、server 側では export が参照プロキシになりプロパティを引けなくなっていた。

```js
// before: 'use client' モジュールの中で合成していた
const Breadcrumb = { List, Item, Separator, Link };
export { Breadcrumb };
```

v11 では `breadcrumb.tsx` に `'use client'` が付いておらず server でも動いていたため、辞書化がそのまま退行になった。

これは 12.0.0 で `CheckboxGroup.Root` に対して直したのとまったく同じ問題で、Breadcrumb が取りこぼされていた形。

## 詳細

- `breadcrumb.tsx` から `List` / `Item` / `Separator` / `Link` を個別に export し、`Breadcrumb` オブジェクトの合成を client でない `index.ts` へ移した（`CheckboxGroup` / `Accordion` と同じ形）
- Story は合成後の `Breadcrumb` を使うよう import 元を `.` に変更
- `'use client'` モジュール内で合成された複合コンポーネントが増えないことを検証するテストを追加

## 気をつけるポイント

**このバグは通常のユニットテストでは検出できない。** テスト環境では client/server の境界が無いのでオブジェクトは普通に引ける。同じ形の取りこぼしが 12.0.0 の `CheckboxGroup.Root` に続いて2件目なので、ソース構造を検査するテストで再発を止めている。

**許容リストの11件について。** `Dialog` / `DropdownMenu` / `Tabs` / `Tooltip` / `Popover` / `ListBox` / `FileField` と AI 系4件は、同じく client モジュール内で合成しているため server コンポーネントから使うと同じ理由で落ちる。ただしこれらは v11 以前から `'use client'` で、今回の退行ではない。パッチリリースの範囲を絞るため、既知として許容リストに載せて別途対応したい（リストは移行のたびに縮む）。

## 影響範囲

`Breadcrumb` のみ。公開 API は変わらないため、利用側の変更は不要。

## テスト

- `pnpm test` 460件すべて green（Breadcrumb の Story テスト含む）
- `packages/arte-odyssey` の `tsc --noEmit` / `pnpm check` ともに green
- 追加したテストは、修正を戻すと `Breadcrumb` を検出して落ちることを確認済み
- ビルド成果物を利用側（Next.js App Router の admin アプリ）へ流し込み、修正前は `/reading-list/articles/[id]` のプリレンダーで落ちること、修正後はフルビルドが通ることを確認した